### PR TITLE
fix: update remaining occurrences of old package name

### DIFF
--- a/lib/oauth-success.html
+++ b/lib/oauth-success.html
@@ -548,7 +548,7 @@
                 <div class="terminal-button red"></div>
                 <div class="terminal-button yellow"></div>
                 <div class="terminal-button green"></div>
-                <div class="terminal-title">opencode-openai-codex-auth-multi — OAuth Authentication</div>
+                <div class="terminal-title">oc-chatgpt-multi-auth — OAuth Authentication</div>
             </div>
 
             <div class="status-box">

--- a/scripts/install-opencode-codex-auth.js
+++ b/scripts/install-opencode-codex-auth.js
@@ -6,7 +6,7 @@ import { fileURLToPath } from "node:url";
 import { dirname, join, resolve } from "node:path";
 import { homedir } from "node:os";
 
-const PLUGIN_NAME = "opencode-openai-codex-auth-multi";
+const PLUGIN_NAME = "oc-chatgpt-multi-auth";
 
 const args = new Set(process.argv.slice(2));
 

--- a/scripts/test-all-models.sh
+++ b/scripts/test-all-models.sh
@@ -149,7 +149,7 @@ update_config() {
     esac
 
     # Replace npm package with local dist for testing
-    sed -i.bak -E 's|"opencode-openai-codex-auth-multi(@[^"]*)?"|"file://'"${REPO_DIR}"'/dist"|' "${OPENCODE_JSON}"
+    sed -i.bak -E 's|"oc-chatgpt-multi-auth(@[^"]*)?"|"file://'"${REPO_DIR}"'/dist"|' "${OPENCODE_JSON}"
 
     rm -f "${OPENCODE_JSON}.bak"
     echo "✓ Using local dist for plugin"


### PR DESCRIPTION
## Summary
- Updated `PLUGIN_NAME` in `scripts/install-opencode-codex-auth.js` to ensure `npx` installs correctly.
- Updated local testing script `scripts/test-all-models.sh` to use the new package name.
- Updated the terminal title in the OAuth success page.

These changes ensure that the renome from `opencode-openai-codex-auth-multi` to `oc-chatgpt-multi-auth` is complete and functional across all scripts and UI.