### PR TITLE
fix: align OpenCode tool mapping and harden codex prompt source fallback

### DIFF
--- a/docs/development/ARCHITECTURE.md
+++ b/docs/development/ARCHITECTURE.md
@@ -384,7 +384,7 @@ let include: Vec<String> = if reasoning.is_some() {
 **Solution**: Replace OpenCode prompts with Codex-specific instructions.
 
 **Benefits**:
-- ✅ Explains tool name differences (apply_patch → edit)
+- ✅ Explains tool name differences (apply_patch intent → patch/edit)
 - ✅ Documents available tools
 - ✅ Maintains OpenCode working style
 - ✅ Preserves Codex best practices

--- a/lib/prompts/codex-opencode-bridge.ts
+++ b/lib/prompts/codex-opencode-bridge.ts
@@ -15,11 +15,11 @@ You are running Codex through OpenCode, an open-source terminal coding assistant
 ## CRITICAL: Tool Usage
 
 <critical_rule priority="0">
-❌ APPLY_PATCH DOES NOT EXIST → ✅ USE "edit" INSTEAD
-- NEVER use: apply_patch, applyPatch, patch, diff
-- ALWAYS use: edit tool for ALL file modifications
-- For complex multi-line changes: use multiple sequential edit calls
-- If you attempt apply_patch, the tool call will fail and waste tokens
+apply_patch/applyPatch are Codex names. In OpenCode, use native tools:
+- For diff-style or multi-line structural edits: use \`patch\`
+- For precise in-place string replacements: use \`edit\`
+- Never call a tool literally named apply_patch/applyPatch
+- If an instruction says apply_patch, translate that intent to \`patch\` first
 </critical_rule>
 
 <critical_rule priority="0">
@@ -34,12 +34,13 @@ You are running Codex through OpenCode, an open-source terminal coding assistant
 **File Operations:**
 - \`write\`  - Create new files
   - Overwriting existing files requires a prior Read in this session; default to ASCII unless the file already uses Unicode.
-- \`edit\`   - Modify existing files (ONLY tool for modifications)
+- \`edit\`   - Modify existing files with string replacement
   - Requires a prior Read in this session; preserve exact indentation; ensure \`oldString\` uniquely matches or use \`replaceAll\`; edit fails if ambiguous or missing.
   - For complex multi-line changes: break into multiple sequential edit calls, each with unique oldString context.
+- \`patch\`  - Apply diff-style patches for multi-line updates
 - \`read\`   - Read file contents
 
-❌ FORBIDDEN: apply_patch, patch, diff tools DO NOT EXIST - use \`edit\` instead.
+Note: \`apply_patch\` is not an OpenCode tool name. Use \`patch\` or \`edit\`.
 
 **Search/Discovery:**
 - \`grep\`   - Search file contents (tool, not bash grep); use \`include\` to filter patterns; set \`path\` only when not searching workspace root; for cross-file match counts use bash with \`rg\`.
@@ -70,7 +71,7 @@ You are running Codex through OpenCode, an open-source terminal coding assistant
 ## Substitution Rules
 
 Base instruction says:    You MUST use instead:
-apply_patch           →   edit (CRITICAL - apply_patch does not exist)
+apply_patch           →   patch (preferred), or edit for targeted replacements
 update_plan           →   todowrite
 read_plan             →   todoread
 
@@ -83,7 +84,7 @@ read_plan             →   todoread
 ## Verification Checklist
 
 Before file/plan modifications:
-1. Am I using "edit" NOT "apply_patch"? (apply_patch DOES NOT EXIST)
+1. Am I using \`patch\` or \`edit\`, never a tool named \`apply_patch\`?
 2. Am I using "todowrite" NOT "update_plan"?
 3. Is this tool in the approved list above?
 4. Am I following each tool's path requirements?

--- a/lib/prompts/codex.ts
+++ b/lib/prompts/codex.ts
@@ -431,10 +431,11 @@ YOU ARE IN A DIFFERENT ENVIRONMENT. These instructions override ALL previous too
 
 <tool_replacements priority="0">
 <critical_rule priority="0">
-❌ APPLY_PATCH DOES NOT EXIST → ✅ USE "edit" INSTEAD
-- NEVER use: apply_patch, applyPatch
-- ALWAYS use: edit tool for ALL file modifications
-- Before modifying files: Verify you're using "edit", NOT "apply_patch"
+apply_patch/applyPatch are Codex names. In OpenCode, use native tools:
+- For diff-style or multi-line structural edits: use patch
+- For precise in-place string replacements: use edit
+- Never call a tool literally named apply_patch/applyPatch
+- If an instruction says apply_patch, translate that intent to patch first
 </critical_rule>
 
 <critical_rule priority="0">
@@ -449,7 +450,7 @@ YOU ARE IN A DIFFERENT ENVIRONMENT. These instructions override ALL previous too
 <available_tools priority="0">
 File Operations:
   • write  - Create new files
-  • edit   - Modify existing files (REPLACES apply_patch)
+  • edit   - Modify existing files with string replacement
   • patch  - Apply diff patches
   • read   - Read file contents
 
@@ -471,7 +472,7 @@ Task Management:
 
 <substitution_rules priority="0">
 Base instruction says:    You MUST use instead:
-apply_patch           →   edit
+apply_patch           →   patch (preferred), or edit for targeted replacements
 update_plan           →   todowrite
 read_plan             →   todoread
 absolute paths        →   relative paths
@@ -479,7 +480,7 @@ absolute paths        →   relative paths
 
 <verification_checklist priority="0">
 Before file/plan modifications:
-1. Am I using "edit" NOT "apply_patch"?
+1. Am I using patch or edit, never a tool named apply_patch?
 2. Am I using "todowrite" NOT "update_plan"?
 3. Is this tool in the approved list above?
 4. Am I using relative paths?

--- a/test/codex-prompts.test.ts
+++ b/test/codex-prompts.test.ts
@@ -50,7 +50,8 @@ describe("Codex Prompts Module", () => {
 
 	describe("TOOL_REMAP_MESSAGE constant", () => {
 		it("should contain apply_patch replacement instruction", () => {
-			expect(TOOL_REMAP_MESSAGE).toContain("APPLY_PATCH DOES NOT EXIST");
+			expect(TOOL_REMAP_MESSAGE).toContain("apply_patch/applyPatch are Codex names");
+			expect(TOOL_REMAP_MESSAGE).toContain("patch");
 			expect(TOOL_REMAP_MESSAGE).toContain("edit");
 		});
 

--- a/test/request-transformer.test.ts
+++ b/test/request-transformer.test.ts
@@ -406,6 +406,7 @@ describe('Request Transformer Module', () => {
 			expect(result![0].role).toBe('developer');
 			expect(result![0].type).toBe('message');
 			expect((result![0].content as any)[0].text).toContain('apply_patch');
+			expect((result![0].content as any)[0].text).toContain('patch (preferred)');
 		});
 
 		it('should not modify input when tools not present', async () => {
@@ -1817,6 +1818,7 @@ describe('Request Transformer Module', () => {
 				expect(result.input).toHaveLength(2);
 				expect(result.input![0].role).toBe('developer');
 				expect((result.input![0].content as any)[0].text).toContain('apply_patch');
+				expect((result.input![0].content as any)[0].text).toContain('patch (preferred)');
 			});
 
 			it('should not filter OpenCode prompts when codexMode=false', async () => {
@@ -1838,6 +1840,7 @@ describe('Request Transformer Module', () => {
 				expect(result.input).toHaveLength(3);
 				expect(result.input![0].role).toBe('developer');
 				expect((result.input![0].content as any)[0].text).toContain('apply_patch');
+				expect((result.input![0].content as any)[0].text).toContain('patch (preferred)');
 				expect(result.input![1].role).toBe('developer');
 				expect(result.input![2].role).toBe('user');
 			});


### PR DESCRIPTION
This fixes the behavior reported in #22.

What changed:
- Updated Codex/OpenCode bridge and tool remap prompts so `apply_patch` intent maps to `patch` (preferred) or `edit` for targeted replacements, and removed conflicting "patch is forbidden" guidance.
- Hardened OpenCode codex prompt fetching with multi-source fallback, source-aware ETag reuse, and `OPENCODE_CODEX_PROMPT_URL` override support.
- Added regression tests for source fallback/override behavior and updated prompt assertions to match the new `patch` + `edit` policy.
- Updated architecture docs to reflect the new tool-mapping behavior.

Validation:
- npm run build
- npm run typecheck
- npm run lint
- npm test

Closes #22
