### PR TITLE
fix: harden tool-call failure handling for issue #22

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1451,6 +1451,12 @@ while (attempted.size < Math.max(1, accountCount)) {
 						streamStallTimeoutMs,
 					});
 
+					if (!successResponse.ok) {
+						runtimeMetrics.failedRequests++;
+						runtimeMetrics.lastError = `HTTP ${successResponse.status}`;
+						return successResponse;
+					}
+
 					if (!isStreaming && emptyResponseMaxRetries > 0) {
 						const clonedResponse = successResponse.clone();
 						try {

--- a/lib/prompts/codex.ts
+++ b/lib/prompts/codex.ts
@@ -443,7 +443,7 @@ File Operations:
 Search/Discovery:
   • grep   - Search file contents
   • glob   - Find files by pattern
-  • list   - List directories (use relative paths)
+  • list   - List directories
 
 Execution:
   • bash   - Run shell commands
@@ -456,12 +456,17 @@ Task Management:
   • todoread  - Read current plan
 </available_tools>
 
+<tool_call_guardrails priority="0">
+- Call only tool names listed in the active tool schema.
+- Do not invent wrapper namespaces (for example functions.task or multi_tool_use.parallel) unless explicitly listed.
+- Follow each tool's required path format instead of forcing absolute or relative paths globally.
+</tool_call_guardrails>
+
 <substitution_rules priority="0">
 Base instruction says:    You MUST use instead:
 apply_patch           →   patch (preferred), or edit for targeted replacements
 update_plan           →   todowrite
 read_plan             →   todoread
-absolute paths        →   relative paths
 </substitution_rules>
 
 <verification_checklist priority="0">
@@ -469,7 +474,7 @@ Before file/plan modifications:
 1. Am I using patch or edit, never a tool named apply_patch?
 2. Am I using "todowrite" NOT "update_plan"?
 3. Is this tool in the approved list above?
-4. Am I using relative paths?
+4. Am I following the active tool schema (including path format)?
 
 If ANY answer is NO → STOP and correct before proceeding.
 </verification_checklist>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oc-chatgpt-multi-auth",
-  "version": "5.2.1",
+  "version": "5.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oc-chatgpt-multi-auth",
-      "version": "5.2.1",
+      "version": "5.2.2",
       "license": "MIT",
       "dependencies": {
         "@openauthjs/openauth": "^0.4.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oc-chatgpt-multi-auth",
-  "version": "5.2.1",
+  "version": "5.2.2",
   "description": "Multi-account rotation plugin for ChatGPT Plus/Pro (OAuth / Codex backend)",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/test/chaos/fault-injection.test.ts
+++ b/test/chaos/fault-injection.test.ts
@@ -359,7 +359,31 @@ describe("SSE Parsing Edge Cases", () => {
 				'data: {"type":"error","error":{"message":"Something went wrong"}}\n\n';
 			const response = new Response(sseText, { status: 200 });
 			const result = await convertSseToJson(response, new Headers());
-			expect(result.status).toBe(200);
+			expect(result.status).toBe(502);
+			const body = await result.json();
+			expect(body).toEqual({
+				error: {
+					message: "Something went wrong",
+					type: "stream_error",
+					code: "stream_error",
+				},
+			});
+		});
+
+		it("handles response.failed terminal event type", async () => {
+			const sseText =
+				'data: {"type":"response.failed","response":{"id":"resp_fail","status":"failed","error":{"message":"Tool failed"}}}\n\n';
+			const response = new Response(sseText, { status: 200 });
+			const result = await convertSseToJson(response, new Headers());
+			expect(result.status).toBe(502);
+			const body = await result.json();
+			expect(body).toEqual({
+				error: {
+					message: "Tool failed",
+					type: "stream_error",
+					code: "stream_error",
+				},
+			});
 		});
 
 		it("handles multiple events, extracts last response.done", async () => {


### PR DESCRIPTION
This fixes the remaining behavior reported in #22.

What changed:
- Added stricter tool-call guardrails in OpenCode bridge/remap prompts so the model only calls tools that actually exist in the active schema.
- Removed cross-environment path/tool assumptions that could trigger invalid tool calls.
- Hardened SSE response handling to convert terminal stream errors into structured JSON errors (`error`, `response.error`, `response.failed`, `response.incomplete`, and `data:` line variants).
- Prevented transformed non-OK responses from being counted/treated as successful turns.
- Added regression tests covering terminal SSE error paths and parser edge cases.

Validation:
- npm run typecheck
- npm run lint
- npm test
- npm run build

Closes #22