### PR TITLE
chore: deep audit hardening + codex alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ OAuth plugin for OpenCode that lets you use ChatGPT Plus/Pro rate limits with mo
 - **Click-to-switch** — Switch accounts directly from the OpenCode TUI
 - **Strict tool validation** — Automatically cleans schemas for compatibility with strict models
 - **Auto-update notifications** — Get notified when a new version is available
-- **21 template model presets** — Full variant system with reasoning levels (none/low/medium/high/xhigh)
+- **27 template model presets** — Full variant system with reasoning levels (none/low/medium/high/xhigh)
 - **Prompt caching** — Session-based caching for faster multi-turn conversations
 - **Usage-aware errors** — Friendly messages with rate limit reset timing
 - **Plugin compatible** — Works alongside other OpenCode plugins (oh-my-opencode, dcp, etc.)

--- a/config/README.md
+++ b/config/README.md
@@ -6,8 +6,8 @@ This directory contains the official OpenCode config templates for the ChatGPT C
 
 | File | OpenCode version | Description |
 |------|------------------|-------------|
-| [`opencode-modern.json`](./opencode-modern.json) | **v1.0.210+** | Variant-based config: 6 base models with 21 total presets |
-| [`opencode-legacy.json`](./opencode-legacy.json) | **v1.0.209 and below** | Legacy explicit entries: 21 individual model definitions |
+| [`opencode-modern.json`](./opencode-modern.json) | **v1.0.210+** | Variant-based config: 6 base models with 27 total presets |
+| [`opencode-legacy.json`](./opencode-legacy.json) | **v1.0.209 and below** | Legacy explicit entries: 22 individual model definitions |
 
 ## Quick pick
 
@@ -72,6 +72,7 @@ Current defaults are strict entitlement handling:
 - set `unsupportedCodexPolicy: "fallback"` (or `CODEX_AUTH_UNSUPPORTED_MODEL_POLICY=fallback`) to enable automatic fallback retries
 - `fallbackToGpt52OnUnsupportedGpt53: true` keeps the legacy `gpt-5.3-codex -> gpt-5.2-codex` edge inside fallback mode
 - `unsupportedCodexFallbackChain` lets you override fallback order per model
+- Spark entitlement failures (`gpt-5.3-codex-spark`) force fallback immediately, even with strict policy, to support non-entitled workspaces
 
 Default fallback chain (when policy is `fallback`):
 - `gpt-5.3-codex -> gpt-5-codex -> gpt-5.2-codex`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -44,7 +44,11 @@ controls how much thinking the model does.
 | `gpt-5.1-codex-mini` | medium, high |
 | `gpt-5.1` | none, low, medium, high |
 
-the shipped config templates include 21 presets and do not add Spark by default. add `gpt-5.3-codex-spark` manually only for entitled workspaces.
+the shipped config templates include:
+- modern template (variants): 27 presets
+- legacy template (explicit model ids): 22 presets
+
+Spark is not added by default. add `gpt-5.3-codex-spark` manually only for entitled workspaces.
 
 what they mean:
 - `none` - no reasoning phase (base models only, auto-converts to `low` for codex)
@@ -144,6 +148,8 @@ advanced settings go in `~/.opencode/openai-codex-auth-config.json`:
 ### unsupported-model behavior + fallback chain
 
 by default the plugin is strict (`unsupportedCodexPolicy: "strict"`). it returns entitlement errors directly for unsupported models.
+
+Spark exception: `gpt-5.3-codex-spark` entitlement failures auto-fallback to the default chain even in strict mode, because Spark access is commonly limited to Pro/Business workspaces. This avoids long account-rotation stalls for non-entitled users.
 
 set `unsupportedCodexPolicy: "fallback"` to enable model fallback after account/workspace attempts are exhausted.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -126,7 +126,7 @@ Use one of the provided config files:
 
 Copy the relevant config to your `~/.config/opencode/opencode.json`.
 
-The shipped templates include 21 presets and intentionally omit Spark IDs. Add `gpt-5.3-codex-spark` manually only when your workspace is entitled.
+The shipped templates include 27 presets in modern mode and 22 presets in legacy mode, and intentionally omit Spark IDs. Add `gpt-5.3-codex-spark` manually only when your workspace is entitled.
 
 <details>
 <summary><b>Why use the full config?</b></summary>
@@ -151,7 +151,7 @@ opencode run "write hello world to test.txt" --model=openai/gpt-5.2-medium
 opencode
 ```
 
-You'll see all 21 GPT-5.x variants in the model selector!
+You'll see all 27 GPT-5.x variants in the model selector!
 
 If `gpt-5-codex` or `gpt-5.3-codex-spark` returns an unsupported-model entitlement error, re-auth with `opencode auth login` or add another entitled account/workspace first. The plugin tries remaining accounts/workspaces before model fallback. See [Configuration](configuration.md) for strict vs fallback policy controls.
 
@@ -171,7 +171,7 @@ If you manually add Spark IDs and want to confirm effective upstream routing, ru
 | `gpt-5.1-codex-mini` | medium, high | Lightweight |
 | `gpt-5.1` | none, low, medium, high | Base model |
 
-**Total: 21 template presets** with 272k context / 128k output (+ optional Spark IDs when entitled).
+**Total: 27 template presets** with 272k context / 128k output (+ optional Spark IDs when entitled).
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "oc-chatgpt-multi-auth",
-  "version": "5.2.2",
+  "version": "5.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oc-chatgpt-multi-auth",
-      "version": "5.2.2",
+      "version": "5.2.1",
       "license": "MIT",
       "dependencies": {
         "@openauthjs/openauth": "^0.4.3",
-        "@opencode-ai/plugin": "^1.2.9",
+        "@opencode-ai/plugin": "^1.2.10",
         "hono": "^4.12.0",
         "zod": "^4.3.6"
       },
@@ -19,7 +19,7 @@
       },
       "devDependencies": {
         "@fast-check/vitest": "^0.2.4",
-        "@opencode-ai/sdk": "^1.2.9",
+        "@opencode-ai/sdk": "^1.2.10",
         "@types/node": "^25.3.0",
         "@typescript-eslint/eslint-plugin": "^8.56.0",
         "@typescript-eslint/parser": "^8.56.0",
@@ -754,12 +754,12 @@
       }
     },
     "node_modules/@opencode-ai/plugin": {
-      "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.2.9.tgz",
-      "integrity": "sha512-lmhF0QoLnA663NwX1gXfvcqPX7+CWeSSFFmjHzfkih0iWEnEw7aIJ8Nf1p4uwoHaNBkQ4O/aKW/5/mS5GrtElQ==",
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.2.10.tgz",
+      "integrity": "sha512-Z1BMqNHnD8AGAEb+kUz0b2SOuiODwdQLdCA4aVGTXqkGzhiD44OVxr85MeoJ5AMTnnea9SnJ3jp9GAQ5riXA5g==",
       "license": "MIT",
       "dependencies": {
-        "@opencode-ai/sdk": "1.2.9",
+        "@opencode-ai/sdk": "1.2.10",
         "zod": "4.1.8"
       }
     },
@@ -773,9 +773,9 @@
       }
     },
     "node_modules/@opencode-ai/sdk": {
-      "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.2.9.tgz",
-      "integrity": "sha512-/CYOxGN93q1B/Piog2nXB1GlAs5MZJ0PvY0lhpvSxdKmXtm5o9qX5poZZRTWCUhhuJfzHZ9Ute3ojwpen7s7Rw==",
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.2.10.tgz",
+      "integrity": "sha512-SyXcVqry2hitPVvQtvXOhqsWyFhSycG/+LTLYXrcq8AFmd9FR7dyBSDB3f5Ol6IPkYOegk8P2Eg2kKPNSNiKGw==",
       "license": "MIT"
     },
     "node_modules/@oslojs/asn1": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oc-chatgpt-multi-auth",
-  "version": "5.2.2",
+  "version": "5.2.1",
   "description": "Multi-account rotation plugin for ChatGPT Plus/Pro (OAuth / Codex backend)",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -40,6 +40,9 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:ui": "vitest --ui",
+    "test:model-matrix": "node scripts/test-model-matrix.js",
+    "test:model-matrix:smoke": "node scripts/test-model-matrix.js --smoke",
+    "test:model-matrix:report": "node scripts/test-model-matrix.js --smoke --report-json=.tmp/model-matrix-report.json",
     "test:coverage": "vitest run --coverage",
     "coverage": "vitest run --coverage",
     "audit:prod": "npm audit --omit=dev --audit-level=high",
@@ -76,7 +79,7 @@
   },
   "devDependencies": {
     "@fast-check/vitest": "^0.2.4",
-    "@opencode-ai/sdk": "^1.2.9",
+    "@opencode-ai/sdk": "^1.2.10",
     "@types/node": "^25.3.0",
     "@typescript-eslint/eslint-plugin": "^8.56.0",
     "@typescript-eslint/parser": "^8.56.0",
@@ -92,7 +95,7 @@
   },
   "dependencies": {
     "@openauthjs/openauth": "^0.4.3",
-    "@opencode-ai/plugin": "^1.2.9",
+    "@opencode-ai/plugin": "^1.2.10",
     "hono": "^4.12.0",
     "zod": "^4.3.6"
   },

--- a/scripts/test-model-matrix.js
+++ b/scripts/test-model-matrix.js
@@ -1,0 +1,423 @@
+#!/usr/bin/env node
+
+import { existsSync } from "node:fs";
+import { readFile, writeFile, rm, mkdir } from "node:fs/promises";
+import { spawnSync } from "node:child_process";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import process from "node:process";
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(scriptDir, "..");
+const localConfigPaths = [join(repoRoot, ".opencode.json"), join(repoRoot, "opencode.json")];
+const scenarioTemplates = {
+	legacy: join(repoRoot, "config", "opencode-legacy.json"),
+	modern: join(repoRoot, "config", "opencode-modern.json"),
+};
+
+const defaultPromptPrefix = "Reply exactly:";
+const modelProviderId = "openai";
+const pluginPackageName = "oc-chatgpt-multi-auth";
+
+function resolveOpencodeExecutable() {
+	const envOverride = process.env.OPENCODE_BIN;
+	if (envOverride && envOverride.trim().length > 0) {
+		const command = envOverride.trim();
+		return { command, shell: /\.cmd$/i.test(command) };
+	}
+
+	if (process.platform !== "win32") {
+		return { command: "opencode", shell: false };
+	}
+
+	const whereResult = spawnSync("where", ["opencode"], {
+		encoding: "utf8",
+		windowsHide: true,
+	});
+	const candidates = `${whereResult.stdout ?? ""}\n${whereResult.stderr ?? ""}`
+		.split(/\r?\n/)
+		.map((line) => line.trim())
+		.filter(Boolean);
+
+	if (candidates.length === 0) {
+		return { command: "opencode", shell: false };
+	}
+
+	const exactExe = candidates.find((candidate) =>
+		/npm\\opencode\.exe$/i.test(candidate),
+	);
+	if (exactExe) {
+		return { command: exactExe, shell: false };
+	}
+
+	const exactCmd = candidates.find((candidate) =>
+		/npm\\opencode\.cmd$/i.test(candidate),
+	);
+	if (exactCmd) {
+		return { command: exactCmd, shell: true };
+	}
+
+	const anyCmd = candidates.find((candidate) => /\.cmd$/i.test(candidate));
+	if (anyCmd) {
+		return { command: anyCmd, shell: true };
+	}
+
+	return { command: candidates[0], shell: false };
+}
+
+const opencodeExecutable = resolveOpencodeExecutable();
+
+function printUsage() {
+	console.log(
+		[
+			"Usage: node scripts/test-model-matrix.js [options]",
+			"",
+			"Options:",
+			"  --scenario=legacy|modern|all   Which template(s) to audit (default: all)",
+			"  --smoke                         Run reduced per-model checks",
+			"  --plugin=dist|package          Load plugin from local dist URI or package name (default: dist)",
+			"  --max-cases=N                  Hard cap number of cases per scenario",
+			"  --report-json=PATH             Write JSON report to PATH (relative to repo root)",
+			"  --no-restore                   Keep generated local config files after run",
+			"  -h, --help                     Show help",
+		].join("\n"),
+	);
+}
+
+function parseArgValue(args, name) {
+	const prefix = `${name}=`;
+	const hit = args.find((arg) => arg.startsWith(prefix));
+	if (!hit) return undefined;
+	return hit.slice(prefix.length);
+}
+
+function toFileUri(pathValue) {
+	const normalized = pathValue.replace(/\\/g, "/");
+	if (/^[A-Za-z]:\//.test(normalized)) {
+		return `file:///${normalized}`;
+	}
+	if (normalized.startsWith("/")) {
+		return `file://${normalized}`;
+	}
+	return `file:///${normalized}`;
+}
+
+function runQuiet(command, commandArgs) {
+	try {
+		spawnSync(command, commandArgs, {
+			stdio: "ignore",
+			windowsHide: true,
+		});
+	} catch {
+		// Ignore cleanup failures.
+	}
+}
+
+function stopOpencodeServers() {
+	if (process.platform === "win32") {
+		runQuiet("taskkill", ["/F", "/IM", "opencode.exe"]);
+	}
+	runQuiet("pkill", ["-f", "opencode"]);
+}
+
+function normalizePluginList(value, pluginRef) {
+	const entries = Array.isArray(value) ? value.filter(Boolean) : [];
+	const filtered = entries.filter((entry) => {
+		if (typeof entry !== "string") return true;
+		return !entry.startsWith(pluginPackageName);
+	});
+	return [...filtered, pluginRef];
+}
+
+function enumerateCases(models, smoke, maxCases) {
+	const modelEntries = Object.entries(models).sort(([left], [right]) =>
+		left.localeCompare(right),
+	);
+	const cases = [];
+
+	for (const [modelId, modelDef] of modelEntries) {
+		const variants =
+			modelDef && typeof modelDef === "object" && modelDef !== null
+				? modelDef.variants
+				: undefined;
+		const variantNames =
+			variants && typeof variants === "object"
+				? Object.keys(variants).sort()
+				: [];
+
+		cases.push({ model: modelId, variant: undefined });
+		for (const variant of variantNames) {
+			cases.push({ model: modelId, variant });
+		}
+	}
+
+	let selected = cases;
+	if (smoke) {
+		const reduced = [];
+		for (const [modelId, modelDef] of modelEntries) {
+			reduced.push({ model: modelId, variant: undefined });
+			const variants =
+				modelDef && typeof modelDef === "object" && modelDef !== null
+					? modelDef.variants
+					: undefined;
+			const variantNames =
+				variants && typeof variants === "object"
+					? Object.keys(variants).sort()
+					: [];
+			if (variantNames.length > 0) {
+				if (variantNames.includes("high")) {
+					reduced.push({ model: modelId, variant: "high" });
+				} else if (variantNames.includes("medium")) {
+					reduced.push({ model: modelId, variant: "medium" });
+				} else {
+					reduced.push({ model: modelId, variant: variantNames[0] });
+				}
+			}
+		}
+		selected = reduced;
+	}
+
+	if (maxCases > 0 && selected.length > maxCases) {
+		return selected.slice(0, maxCases);
+	}
+	return selected;
+}
+
+function executeModelCase(caseInfo, index, port) {
+	const token = `MODEL_MATRIX_OK_${index}`;
+	const message = `${defaultPromptPrefix} ${token}`;
+	const args = [
+		"run",
+		message,
+		"--model",
+		`${modelProviderId}/${caseInfo.model}`,
+		"--port",
+		String(port),
+	];
+	if (caseInfo.variant) {
+		args.push("--variant", caseInfo.variant);
+	}
+
+	const finalized = spawnSync(opencodeExecutable.command, args, {
+		cwd: repoRoot,
+		encoding: "utf8",
+		windowsHide: true,
+		shell: opencodeExecutable.shell,
+		env: {
+			...process.env,
+			ENABLE_PLUGIN_REQUEST_LOGGING: "0",
+			CODEX_PLUGIN_LOG_BODIES: "0",
+			DEBUG_CODEX_PLUGIN: "0",
+		},
+	});
+
+	const combinedOutput = `${finalized.stdout ?? ""}\n${finalized.stderr ?? ""}`.trim();
+	const hasToken = combinedOutput.includes(token);
+	const hasFatalError = /ProviderModelNotFoundError|Model not found/i.test(combinedOutput);
+	const exitCode = finalized.status ?? 1;
+	const ok = exitCode === 0 && hasToken && !hasFatalError;
+
+	return {
+		...caseInfo,
+		ok,
+		exitCode,
+		hasToken,
+		output: combinedOutput,
+	};
+}
+
+async function readJson(pathValue) {
+	return JSON.parse(await readFile(pathValue, "utf8"));
+}
+
+async function writeJson(pathValue, value) {
+	await writeFile(pathValue, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}
+
+async function backupLocalConfigs() {
+	const backups = new Map();
+	for (const configPath of localConfigPaths) {
+		if (existsSync(configPath)) {
+			backups.set(configPath, await readFile(configPath, "utf8"));
+		} else {
+			backups.set(configPath, null);
+		}
+	}
+	return backups;
+}
+
+async function restoreLocalConfigs(backups) {
+	for (const [configPath, content] of backups.entries()) {
+		if (content === null) {
+			if (existsSync(configPath)) {
+				await rm(configPath, { force: true });
+			}
+			continue;
+		}
+		await writeFile(configPath, content, "utf8");
+	}
+}
+
+function resolvePluginReference(mode) {
+	if (mode === "package") {
+		return pluginPackageName;
+	}
+	const distEntry = join(repoRoot, "dist", "index.js");
+	if (!existsSync(distEntry)) {
+		throw new Error(
+			`dist build missing at ${distEntry}. Run 'npm run build' before matrix audit.`,
+		);
+	}
+	return toFileUri(join(repoRoot, "dist"));
+}
+
+async function prepareScenarioConfig(templatePath, pluginRef) {
+	const config = await readJson(templatePath);
+	config.plugin = normalizePluginList(config.plugin, pluginRef);
+	for (const configPath of localConfigPaths) {
+		await writeJson(configPath, config);
+	}
+	return config;
+}
+
+async function runScenario(scenario, options) {
+	const templatePath = scenarioTemplates[scenario];
+	if (!templatePath || !existsSync(templatePath)) {
+		throw new Error(`Template not found for scenario '${scenario}': ${templatePath}`);
+	}
+
+	const config = await prepareScenarioConfig(templatePath, options.pluginRef);
+	const models = config?.provider?.openai?.models;
+	if (!models || typeof models !== "object") {
+		throw new Error(`Scenario '${scenario}' has no provider.openai.models object`);
+	}
+
+	const cases = enumerateCases(models, options.smoke, options.maxCases);
+	console.log(`\n=== ${scenario.toUpperCase()} (${cases.length} cases) ===`);
+
+	const results = [];
+	for (let i = 0; i < cases.length; i += 1) {
+		const caseInfo = cases[i];
+		const result = executeModelCase(
+			caseInfo,
+			i + 1,
+			options.portStart + i,
+		);
+		results.push(result);
+		const variantLabel = result.variant ? ` [variant=${result.variant}]` : "";
+		if (result.ok) {
+			console.log(`PASS  ${result.model}${variantLabel}`);
+		} else {
+			console.log(`FAIL  ${result.model}${variantLabel} (exit=${result.exitCode}, token=${result.hasToken})`);
+			const tail = result.output.split(/\r?\n/).slice(-12).join("\n");
+			if (tail.trim().length > 0) {
+				console.log(tail);
+			}
+		}
+	}
+
+	return results;
+}
+
+async function main() {
+	const args = process.argv.slice(2);
+	if (args.includes("--help") || args.includes("-h")) {
+		printUsage();
+		return;
+	}
+
+	const scenarioValue = parseArgValue(args, "--scenario") ?? "all";
+	const smoke = args.includes("--smoke");
+	const pluginMode = parseArgValue(args, "--plugin") ?? "dist";
+	const noRestore = args.includes("--no-restore");
+	const maxCasesRaw = parseArgValue(args, "--max-cases");
+	const maxCases = maxCasesRaw ? Number.parseInt(maxCasesRaw, 10) : 0;
+	const reportJsonPathRaw = parseArgValue(args, "--report-json");
+	const reportJsonPath = reportJsonPathRaw
+		? resolve(repoRoot, reportJsonPathRaw)
+		: undefined;
+
+	if (!["all", "legacy", "modern"].includes(scenarioValue)) {
+		throw new Error(`Invalid --scenario value '${scenarioValue}'. Use legacy, modern, or all.`);
+	}
+	if (!["dist", "package"].includes(pluginMode)) {
+		throw new Error(`Invalid --plugin value '${pluginMode}'. Use dist or package.`);
+	}
+	if (Number.isNaN(maxCases) || maxCases < 0) {
+		throw new Error(`Invalid --max-cases value '${maxCasesRaw}'. Use a non-negative integer.`);
+	}
+
+	const pluginRef = resolvePluginReference(pluginMode);
+	const scenarios =
+		scenarioValue === "all" ? ["legacy", "modern"] : [scenarioValue];
+
+	console.log("OpenCode Model Matrix Audit");
+	console.log(`Repo: ${repoRoot}`);
+	console.log(`Scenarios: ${scenarios.join(", ")}`);
+	console.log(`Mode: ${smoke ? "smoke" : "full"}`);
+	console.log(`Plugin: ${pluginRef}`);
+	console.log(`OpenCode command: ${opencodeExecutable.command}`);
+
+	const backups = await backupLocalConfigs();
+	const allResults = [];
+	try {
+		for (let i = 0; i < scenarios.length; i += 1) {
+			const scenario = scenarios[i];
+			stopOpencodeServers();
+			const scenarioResults = await runScenario(scenario, {
+				smoke,
+				maxCases,
+				pluginRef,
+				portStart: 47000 + i * 500,
+			});
+			allResults.push(...scenarioResults.map((item) => ({ ...item, scenario })));
+		}
+	} finally {
+		if (!noRestore) {
+			await restoreLocalConfigs(backups);
+		}
+	}
+
+	const failed = allResults.filter((result) => !result.ok);
+	const passed = allResults.length - failed.length;
+	console.log("\n=== SUMMARY ===");
+	console.log(`Total: ${allResults.length}`);
+	console.log(`Passed: ${passed}`);
+	console.log(`Failed: ${failed.length}`);
+
+	if (reportJsonPath) {
+		const report = {
+			generatedAt: new Date().toISOString(),
+			repoRoot,
+			scenarios,
+			mode: smoke ? "smoke" : "full",
+			plugin: pluginRef,
+			opencodeCommand: opencodeExecutable.command,
+			totals: {
+				total: allResults.length,
+				passed,
+				failed: failed.length,
+			},
+			results: allResults,
+		};
+		await mkdir(dirname(reportJsonPath), { recursive: true });
+		await writeFile(reportJsonPath, `${JSON.stringify(report, null, 2)}\n`, "utf8");
+		console.log(`Report written: ${reportJsonPath}`);
+	}
+
+	if (failed.length > 0) {
+		console.log("\nFailed cases:");
+		for (const result of failed) {
+			const variantLabel = result.variant ? ` [variant=${result.variant}]` : "";
+			console.log(`- ${result.scenario}: ${result.model}${variantLabel}`);
+		}
+		process.exitCode = 1;
+	}
+}
+
+main().catch((error) => {
+	console.error(
+		`Model matrix audit failed: ${error instanceof Error ? error.message : String(error)}`,
+	);
+	process.exit(1);
+});


### PR DESCRIPTION
## Summary
- upgrade OpenCode integration deps to latest patch (@opencode-ai/plugin and @opencode-ai/sdk 1.2.10)
- add robust model matrix audit runner (scripts/test-model-matrix.js) with legacy/modern coverage and JSON reporting
- harden dev-audit allowlist script for Windows/silent npm environments
- fix docs drift for modern template preset count (27, not 21)

## Verification
- 
pm run lint
- 
pm run typecheck
- 
pm test
- 
pm run audit:ci
- 
ode scripts/test-model-matrix.js --smoke --max-cases=2
- full matrix previously validated: 
ode scripts/test-model-matrix.js (49/49 pass)

## Notes
- scope intentionally limited to audit tooling, dependency alignment, and preset-count documentation consistency.
