### PR TITLE
fix(auth): prevent silent failure in background token rotation

### DIFF
--- a/lib/proactive-refresh.ts
+++ b/lib/proactive-refresh.ts
@@ -150,8 +150,19 @@ export async function refreshExpiringAccounts(
 
 	// Refresh in parallel for efficiency
 	const refreshPromises = accountsToRefresh.map(async (account) => {
-		const result = await proactiveRefreshAccount(account, bufferMs);
-		return { index: account.index, result };
+		try {
+			const result = await proactiveRefreshAccount(account, bufferMs);
+			return { index: account.index, result };
+		} catch (error) {
+			log.error("Unhandled exception during proactive refresh", {
+				accountId: account.accountId,
+				error: String(error)
+			});
+			return { 
+				index: account.index, 
+				result: { reason: "error", error: String(error) } as ProactiveRefreshResult 
+			};
+		}
 	});
 
 	const outcomes = await Promise.all(refreshPromises);


### PR DESCRIPTION
noticed a critical stability flaw in the background refresh daemon inside `lib/proactive-refresh.ts`.

the `map(async)` loop over `accountsToRefresh` was missing an inner error boundary. if `proactiveRefreshAccount` threw a synchronous exception (due to a bad token parse or unexpected network drop), the promise would reject *before* reaching `Promise.all`. in node 18+, this triggers an unhandled promise rejection, which silently kills the background rotation process entirely.

refactored the inner map function to include a `try/catch` block that logs the specific account failure but allows the `Promise.all` array to resolve safely so the rest of the accounts keep rotating.

tested locally and verified the flow. let me know if this needs adjustment.