### PR TITLE
fix(audit): queue-based writes to prevent EBUSY on Windows

### DIFF
--- a/test/audit.race.test.ts
+++ b/test/audit.race.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { auditLog, configureAudit } from "../lib/audit.js";
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+
+describe("Audit Logger - Concurrency Tests", () => {
+    const testLogDir = path.join(os.tmpdir(), "oc-chatgpt-multi-auth-test-audit-2");
+    
+    beforeAll(() => {
+        if (fs.existsSync(testLogDir)) {
+            fs.rmSync(testLogDir, { recursive: true, force: true });
+        }
+        fs.mkdirSync(testLogDir, { recursive: true });
+        configureAudit({ enabled: true, logDir: testLogDir, maxFileSizeBytes: 10 * 1024 * 1024, maxFiles: 5 });
+    });
+
+    afterAll(() => {
+        if (fs.existsSync(testLogDir)) {
+            fs.rmSync(testLogDir, { recursive: true, force: true });
+        }
+    });
+
+    it("should handle 100 concurrent log writes without throwing EBUSY or dropping lines", async () => {
+        const concurrencyCount = 100;
+        const promises = [];
+
+        // Fire 100 concurrent audit logs
+        for (let i = 0; i < concurrencyCount; i++) {
+            promises.push(new Promise<void>((resolve) => {
+                setTimeout(() => {
+                    expect(() => {
+                        auditLog("concurrent_test" as any, "test_actor", "concurrent_test_resource", "success" as any, { iteration: i });
+                    }).not.toThrow();
+                    resolve();
+                }, 0);
+            }));
+        }
+
+        await Promise.all(promises);
+
+        // Give the async queue a tiny moment to flush to disk
+        await new Promise(r => setTimeout(r, 100));
+
+        const files = fs.readdirSync(testLogDir);
+        expect(files.length).toBeGreaterThan(0);
+        
+        const logContent = fs.readFileSync(path.join(testLogDir, files[0] as string), "utf-8");
+        const lines = logContent.split("\n").filter(line => line.trim().length > 0);
+        
+        expect(lines.length).toBe(concurrencyCount);
+    });
+});


### PR DESCRIPTION
## summary

noticed a race condition in `lib/audit.ts` where concurrent writes via `writeFileSync` with append flag can cause EBUSY errors on Windows when multiple processes or rapid calls hit the log file simultaneously.

## fix

implemented an in-memory queue that batches writes before flushing to disk. when `auditLog` is called, the entry is pushed to a queue and flushed synchronously. if the flush fails (e.g., file locked by antivirus), the items are re-queued for retry rather than dropped.

## testing

added `test/audit.race.test.ts` which fires 100 concurrent audit log writes and verifies all entries make it to disk without errors or data loss.