### PR TITLE
fix(audit phase 2/3): oauth callback hardening

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -389,7 +389,7 @@ export const OpenAIOAuthPlugin: Plugin = async ({ client }: PluginInput) => {
                 validate: (input: string): string | undefined => {
                         const parsed = parseAuthorizationInput(input);
                         if (!parsed.code) {
-                                return "No authorization code found. Paste the full callback URL (e.g., http://localhost:1455/auth/callback?code=...)";
+                                return `No authorization code found. Paste the full callback URL (e.g., ${REDIRECT_URI}?code=...)`;
                         }
                         if (!parsed.state) {
                                 return "Missing OAuth state. Paste the full callback URL including both code and state parameters.";

--- a/lib/auth/auth.ts
+++ b/lib/auth/auth.ts
@@ -8,7 +8,7 @@ import { safeParseOAuthTokenResponse } from "../schemas.js";
 export const CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann";
 export const AUTHORIZE_URL = "https://auth.openai.com/oauth/authorize";
 export const TOKEN_URL = "https://auth.openai.com/oauth/token";
-export const REDIRECT_URI = "http://localhost:1455/auth/callback";
+export const REDIRECT_URI = "http://127.0.0.1:1455/auth/callback";
 export const SCOPE = "openid profile email offline_access";
 
 /**
@@ -44,6 +44,10 @@ export function parseAuthorizationInput(input: string): ParsedAuthInput {
 		if (code || state) {
 			return { code, state };
 		}
+
+		// Input is a valid URL but does not contain OAuth parameters.
+		// Do not reinterpret URL fragments as "code#state" fallback syntax.
+		return {};
 	} catch {
 		// Invalid URL, try other parsing methods
 	}

--- a/test/auth.test.ts
+++ b/test/auth.test.ts
@@ -115,13 +115,10 @@ describe('Auth Module', () => {
 			expect(result).toEqual({});
 		});
 
-	it('should fall through to # split when valid URL has hash with no code/state params (line 44 false branch)', () => {
-		// URL parses successfully but hash contains no code= or state= params
-		// Line 44's false branch is hit (code && state both undefined)
-		// Falls through to line 51 which splits on #
+	it('should return empty object for valid URL hash fragments without OAuth params', () => {
 		const input = 'http://localhost:1455/auth/callback#invalid';
 		const result = parseAuthorizationInput(input);
-		expect(result).toEqual({ code: 'http://localhost:1455/auth/callback', state: 'invalid' });
+		expect(result).toEqual({});
 	});
 	});
 
@@ -178,6 +175,10 @@ describe('Auth Module', () => {
 	});
 
 	describe('createAuthorizationFlow', () => {
+		it('uses explicit loopback redirect URI to avoid localhost IPv6 ambiguity', () => {
+			expect(REDIRECT_URI).toBe('http://127.0.0.1:1455/auth/callback');
+		});
+
 		it('should create authorization flow with PKCE', async () => {
 			const flow = await createAuthorizationFlow();
 


### PR DESCRIPTION
## Phase 2/3 - OAuth Callback Hardening

### Scope
- Harden manual OAuth callback handling behavior.
- Stack on Phase 1 branch to preserve security baseline.

### Changes
- Switched `REDIRECT_URI` to explicit loopback `http://127.0.0.1:1455/auth/callback` to avoid localhost IPv4/IPv6 ambiguity.
- Updated manual auth validation hint to use `REDIRECT_URI` constant directly.
- Tightened `parseAuthorizationInput` behavior so valid URLs lacking OAuth params return `{}` instead of being misparsed as `code#state`.
- Added/updated tests for new parser behavior and redirect URI invariant.

### Files
- `lib/auth/auth.ts`
- `index.ts`
- `test/auth.test.ts`

### Validation
- `npm run lint` ✅
- `npm run typecheck` ✅
- `npm test` ✅ (1777 tests)
- `npm run build` ✅
- `npm run audit:ci` ✅



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated OAuth authentication redirect URI handling to use explicit loopback address instead of localhost, preventing potential IPv6 compatibility issues
  * Refined authorization flow parameter parsing for improved validation of URLs without OAuth parameters

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---


<h3>Greptile Summary</h3>

tightens oauth callback parsing to prevent ambiguous localhost resolution and url misinterpretation.

**key changes:**
- switched `REDIRECT_URI` to explicit `http://127.0.0.1:1455/auth/callback` (prevents ipv6/ipv4 ambiguity)
- fixed `parseAuthorizationInput` to return `{}` for valid urls lacking oauth params instead of falling through to `code#state` split logic
- updated validation hint to reference `REDIRECT_URI` constant

**security posture:**
- no filesystem, token storage, or concurrency changes
- parser hardening prevents misinterpreting url fragments as auth codes
- comprehensive test coverage including edge case regression

**scope:**
stacks cleanly on phase 1 audit branch. focused changes with clear security rationale.

<h3>Confidence Score: 5/5</h3>

- safe to merge - focused oauth callback hardening with comprehensive test coverage and no risky side effects
- gave 5/5 because: (1) changes are scoped to oauth url parsing with clear security rationale, (2) comprehensive vitest coverage including edge case that was broken before, (3) no filesystem/token storage/concurrency touched, (4) follows project conventions (constant usage, explicit loopback address), (5) all validation checks pass
- no files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| lib/auth/auth.ts | hardened redirect uri to 127.0.0.1 (avoids ipv6 ambiguity) and fixed parser to not misinterpret valid urls without oauth params |
| index.ts | updated validation message to use REDIRECT_URI constant for consistency |
| test/auth.test.ts | updated test expectations to match new parser behavior and added redirect uri invariant test |

</details>



<sub>Last reviewed commit: 91af817</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->