### PR TITLE
fix(audit phase 3/3): correct retry-after unit parsing

### DIFF
--- a/lib/request/fetch-helpers.ts
+++ b/lib/request/fetch-helpers.ts
@@ -848,7 +848,7 @@ function parseRetryAfterMs(
         if (retryAfterMsHeader) {
                 const parsed = Number.parseInt(retryAfterMsHeader, 10);
                 if (!Number.isNaN(parsed) && parsed > 0) {
-                        return parsed;
+                        return normalizeRetryAfterMilliseconds(parsed);
                 }
         }
 
@@ -856,7 +856,7 @@ function parseRetryAfterMs(
         if (retryAfterHeader) {
                 const parsed = Number.parseInt(retryAfterHeader, 10);
                 if (!Number.isNaN(parsed) && parsed > 0) {
-                        return parsed * 1000;
+                        return normalizeRetryAfterSeconds(parsed);
                 }
         }
 

--- a/test/fetch-helpers.test.ts
+++ b/test/fetch-helpers.test.ts
@@ -709,6 +709,40 @@ describe('Fetch Helpers Module', () => {
 		expect(rateLimit?.retryAfterMs).toBe(250);
 	});
 
+	it('clamps retry_after_ms zero and negative values to minimum delay', async () => {
+		const zeroResponse = new Response(
+			JSON.stringify({ error: { message: 'rate limited', retry_after_ms: 0 } }),
+			{ status: 429 },
+		);
+		const negativeResponse = new Response(
+			JSON.stringify({ error: { message: 'rate limited', retry_after_ms: -5 } }),
+			{ status: 429 },
+		);
+
+		const zeroRateLimit = await handleErrorResponse(zeroResponse);
+		const negativeRateLimit = await handleErrorResponse(negativeResponse);
+
+		expect(zeroRateLimit.rateLimit?.retryAfterMs).toBe(1);
+		expect(negativeRateLimit.rateLimit?.retryAfterMs).toBe(1);
+	});
+
+	it('clamps retry_after zero and negative values to minimum delay', async () => {
+		const zeroResponse = new Response(
+			JSON.stringify({ error: { message: 'rate limited', retry_after: 0 } }),
+			{ status: 429 },
+		);
+		const negativeResponse = new Response(
+			JSON.stringify({ error: { message: 'rate limited', retry_after: -5 } }),
+			{ status: 429 },
+		);
+
+		const zeroRateLimit = await handleErrorResponse(zeroResponse);
+		const negativeRateLimit = await handleErrorResponse(negativeResponse);
+
+		expect(zeroRateLimit.rateLimit?.retryAfterMs).toBe(1);
+		expect(negativeRateLimit.rateLimit?.retryAfterMs).toBe(1);
+	});
+
 		it('handles millisecond unix timestamp in reset header', async () => {
 			const futureTimestampMs = Date.now() + 45000;
 			const headers = new Headers({ 'x-ratelimit-reset': String(futureTimestampMs) });


### PR DESCRIPTION
## Phase 3/3 - Rate-Limit Parsing Unit Correctness

### Scope
- Correct retry delay unit handling in error parsing path.
- Stack on Phase 2 branch to preserve prior fixes.

### Findings
- `retry_after_ms` payload values were normalized with second-based heuristics for small values, causing potential 1000x delay inflation.

### Changes
- Separated body parsing fields: `retry_after_ms` (milliseconds) vs `retry_after` (seconds).
- Added dedicated normalization paths for milliseconds and seconds.
- Added tests proving:
  - small `retry_after_ms` remains milliseconds,
  - `retry_after` is treated as seconds.

### Files
- `lib/request/fetch-helpers.ts`
- `test/fetch-helpers.test.ts`

### Validation
- `npm run lint` ✅
- `npm run typecheck` ✅
- `npm test` ✅ (1778 tests)
- `npm run build` ✅
- `npm run audit:ci` ✅



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rate-limit parsing: recognizes retry-after in seconds or milliseconds, preserves millisecond values, prefers millisecond over second values, enforces a 1 ms minimum and 5-minute maximum, and better incorporates reset-at values from headers and payloads.

* **Tests**
  * Added and updated tests validating second- and millisecond-based retry-after handling, clamping, capping, and prioritization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---


<h3>Greptile Summary</h3>

fixed critical unit-parsing bug where `retry_after_ms` values were incorrectly normalized using second-based heuristics, causing potential 1000x delay inflation.

- separated `retry_after_ms` (milliseconds) from `retry_after` (seconds) parsing paths in `parseRateLimitBody`
- split `normalizeRetryAfter` into `normalizeRetryAfterMilliseconds` and `normalizeRetryAfterSeconds` - removed broken heuristic that treated small values (< 1000) as seconds
- established precedence: `retry_after_ms` > `retry_after` > `retry-after-ms` header > `retry-after` header
- added boundary clamping [1ms, 300000ms] to prevent zero/negative delays and excessive waits
- comprehensive test coverage validates millisecond preservation, second conversion, precedence, and clamping

no windows filesystem, token safety, or concurrency concerns - pure parsing logic with no shared state.

<h3>Confidence Score: 5/5</h3>

- safe to merge - fixes critical rate-limit parsing bug with comprehensive test coverage
- clean separation of millisecond/second parsing paths, well-tested edge cases (zero, negative, precedence, clamping), no breaking changes, no security or concurrency concerns
- no files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| lib/request/fetch-helpers.ts | separated millisecond and second retry-after parsing paths, added min/max clamping, fixed 1000x inflation bug for small retry_after_ms values |
| test/fetch-helpers.test.ts | added tests validating millisecond preservation, second-to-millisecond conversion, precedence, and boundary clamping for retry delays |

</details>



<sub>Last reviewed commit: 4309694</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->