### PR TITLE
fix(deps): deep audit remediation for npm advisory set on main

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1710,9 +1710,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "hono": "^4.12.3",
     "vite": "^7.3.1",
     "rollup": "^4.59.0",
+    "ajv": "^6.14.0",
     "minimatch": "^10.2.4",
     "@typescript-eslint/typescript-estree": {
       "minimatch": "^9.0.9"


### PR DESCRIPTION
## Summary
Deep audit pass from an isolated worktree on origin/main identified reproducible dependency vulnerabilities as the only failing gate (
pm audit --audit-level=high).

This PR fixes each root cause in atomic commits (one advisory family per commit), with full verification after each step and final full-matrix validation.

## Defect Ledger
| ID | Symptom | Root Cause | Minimal Fix | Commit |
|---|---|---|---|---|
| DEF-001 | 
pm audit reported high severity hono auth bypass advisory | Vulnerable hono floor persisted in both direct dependency and override | Raise to patched ^4.12.3 | 10a7ba |
| DEF-002 | 
pm audit reported high severity minimatch ReDoS advisories | Override floors allowed vulnerable 9.x and 10.x minimatch ranges | Pin patched minimatch paths: 10.2.4 and nested 9.0.9 |  927d97 |
| DEF-003 | 
pm audit reported high severity ollup path traversal advisory | Transitive ite/itest chain resolved vulnerable rollup (<4.59.0) | Add override ollup: ^4.59.0 | 8a8e870 |
| DEF-004 | 
pm audit reported moderate jv ReDoS advisory | slint transitive tree resolved vulnerable jv@6.12.6 | Add override jv: ^6.14.0 |  1ceec8 |

## Per-Defect RCA
### DEF-001 (hono)
- **Symptom:** 
pm run audit:all flagged GHSA-xh87-mx6m-69f3.
- **Root Cause:** vulnerable range was configured in project dependency/override declarations.
- **References:**
  - package.json:96
  - package.json:100
- **Reproduction:**
  1. Checkout origin/main at b970af.
  2. Run 
pm ci.
  3. Run 
pm run audit:all.
  4. Observe hono 4.12.0 - 4.12.1 advisory.
- **Fix:** bump both declarations to ^4.12.3.
- **Verification:** 
pm ls hono resolves 4.12.3; advisory disappears from audit output.

### DEF-002 (minimatch)
- **Symptom:** 
pm run audit:all flagged multiple ReDoS advisories for minimatch (9.x and 10.x ranges).
- **Root Cause:** override floors allowed vulnerable versions in two independent resolution paths.
- **References:**
  - package.json:104
  - package.json:106
- **Reproduction:**
  1. On origin/main, run 
pm ci.
  2. Run 
pm run audit:all.
  3. Observe minimatch advisories (GHSA-3ppc-4f35-3m26 / GHSA-7r86-cg39-jmmj / GHSA-23c5-xmqv-rm74).
- **Fix:** set top-level minimatch override to ^10.2.4 and @typescript-eslint/typescript-estree nested override to ^9.0.9.
- **Verification:** 
pm ls minimatch --all resolves 10.2.4 and 9.0.9; advisories disappear.

### DEF-003 (ollup)
- **Symptom:** 
pm run audit:all flagged GHSA-mw96-cpmx-2vgc against rollup.
- **Root Cause:** transitive vite/vitest path resolved vulnerable rollup floor.
- **Reference:** package.json:102
- **Reproduction:**
  1. On origin/main, run 
pm ci.
  2. Run 
pm run audit:all.
  3. Observe ollup 4.0.0 - 4.58.0 advisory.
- **Fix:** add explicit override ollup: ^4.59.0.
- **Verification:** 
pm ls rollup --all resolves 4.59.0; rollup advisory is removed.

### DEF-004 (jv)
- **Symptom:** 
pm run audit:all flagged GHSA-2g4f-4pwh-qvx6.
- **Root Cause:** eslint transitive resolution held jv@6.12.6 (<6.14.0).
- **Reference:** package.json:103
- **Reproduction:**
  1. On origin/main, run 
pm ci.
  2. Run 
pm run audit:all.
  3. Observe jv <6.14.0 advisory.
- **Fix:** add override jv: ^6.14.0.
- **Verification:** 
pm run audit:all reports zero vulnerabilities; installed ajv resolves to 6.14.0.

## Similar Pattern Sweep
Checked other resolver control points in package.json for vulnerable floors and validated all override entries are now on patched versions:
- hono, ollup, jv, minimatch, nested @typescript-eslint/typescript-estree > minimatch.

## Validation Evidence
Executed in isolated worktree branch after all commits:
- 
pm run typecheck ✅
- 
pm run lint ✅
- 
pm test ✅ (56 files, 1776 tests)
- 
pm run audit:all ✅ (0 vulnerabilities)
- 
pm run audit:ci ✅

## Security Handling
Per SECURITY.md, this was handled via PR workflow only; no public vulnerability issue was opened.
