### PR TITLE
fix(codex-limits): harden deduped usage refresh

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -4165,6 +4165,7 @@ while (attempted.size < Math.max(1, accountCount)) {
 				async execute() {
 					const ui = resolveUiRuntime();
 					const storage = await loadAccounts();
+					const usageFetchTimeoutMs = getFetchTimeoutMs(loadPluginConfig());
 					if (!storage || storage.accounts.length === 0) {
 						if (ui.v2Enabled) {
 							return [
@@ -4307,16 +4308,28 @@ while (attempted.size < Math.max(1, accountCount)) {
 							organizationId: params.organizationId,
 						});
 						headers.set("accept", "application/json");
+						const controller = new AbortController();
+						const timeout = setTimeout(() => controller.abort(), usageFetchTimeoutMs);
 
-						const response = await fetch(`${CODEX_BASE_URL}/wham/usage`, {
-							method: "GET",
-							headers,
-						});
-						if (!response.ok) {
-							const bodyText = await response.text().catch(() => "");
-							throw new Error(bodyText || `HTTP ${response.status}`);
+						try {
+							const response = await fetch(`${CODEX_BASE_URL}/wham/usage`, {
+								method: "GET",
+								headers,
+								signal: controller.signal,
+							});
+							if (!response.ok) {
+								const bodyText = await response.text().catch(() => "");
+								throw new Error(bodyText || `HTTP ${response.status}`);
+							}
+							return (await response.json()) as UsagePayload;
+						} catch (error) {
+							if (error instanceof Error && error.name === "AbortError") {
+								throw new Error(`Usage request timed out after ${usageFetchTimeoutMs}ms`);
+							}
+							throw error;
+						} finally {
+							clearTimeout(timeout);
 						}
-						return (await response.json()) as UsagePayload;
 					};
 
 					// Deduplicate accounts by refreshToken (same credential = same limits)
@@ -4325,8 +4338,9 @@ while (attempted.size < Math.max(1, accountCount)) {
 					for (let i = 0; i < storage.accounts.length; i++) {
 						const acct = storage.accounts[i];
 						if (!acct) continue;
-						if (seenTokens.has(acct.refreshToken)) continue;
-						seenTokens.add(acct.refreshToken);
+						const refreshToken = typeof acct.refreshToken === "string" ? acct.refreshToken : "";
+						if (refreshToken && seenTokens.has(refreshToken)) continue;
+						if (refreshToken) seenTokens.add(refreshToken);
 						uniqueIndices.push(i);
 					}
 
@@ -4334,13 +4348,18 @@ while (attempted.size < Math.max(1, accountCount)) {
 						? [...formatUiHeader(ui, "Codex limits"), ""]
 						: [`Codex limits (${uniqueIndices.length} account${uniqueIndices.length === 1 ? "" : "s"}):`, ""];
 					const activeIndex = resolveActiveIndex(storage, "codex");
+					const activeRefreshToken =
+						typeof activeIndex === "number" && activeIndex >= 0 && activeIndex < storage.accounts.length
+							? storage.accounts[activeIndex]?.refreshToken
+							: undefined;
 					let storageChanged = false;
 
 					for (const i of uniqueIndices) {
 						const account = storage.accounts[i];
 						if (!account) continue;
 						const label = formatCommandAccountLabel(account, i);
-						const activeSuffix = i === activeIndex ? (ui.v2Enabled ? ` ${formatUiBadge(ui, "active", "accent")}` : " [active]") : "";
+						const isActive = i === activeIndex || (!!activeRefreshToken && account.refreshToken === activeRefreshToken);
+						const activeSuffix = isActive ? (ui.v2Enabled ? ` ${formatUiBadge(ui, "active", "accent")}` : " [active]") : "";
 
 						try {
 							let accessToken = account.accessToken;
@@ -4350,13 +4369,34 @@ while (attempted.size < Math.max(1, accountCount)) {
 								typeof account.expiresAt !== "number" ||
 								account.expiresAt <= Date.now() + 30_000
 							) {
+								const previousRefreshToken = account.refreshToken;
 								const refreshResult = await queuedRefresh(account.refreshToken);
 								if (refreshResult.type !== "success") {
 									throw new Error(refreshResult.message ?? refreshResult.reason);
 								}
-								account.refreshToken = refreshResult.refresh;
-								account.accessToken = refreshResult.access;
-								account.expiresAt = refreshResult.expires;
+
+								const applyRefreshedCredentials = (
+									target: {
+										refreshToken: string;
+										accessToken?: string;
+										expiresAt?: number;
+									},
+								): void => {
+									target.refreshToken = refreshResult.refresh;
+									target.accessToken = refreshResult.access;
+									target.expiresAt = refreshResult.expires;
+								};
+
+								if (previousRefreshToken && refreshResult.refresh !== previousRefreshToken) {
+									for (const storedAccount of storage.accounts) {
+										if (storedAccount?.refreshToken === previousRefreshToken) {
+											applyRefreshedCredentials(storedAccount);
+										}
+									}
+								} else {
+									applyRefreshedCredentials(account);
+								}
+
 								accessToken = refreshResult.access;
 								storageChanged = true;
 							}
@@ -4379,7 +4419,7 @@ while (attempted.size < Math.max(1, accountCount)) {
 								payload.additional_rate_limits?.find((entry) => entry.limit_name === "code_review_rate_limit")?.rate_limit ??
 								null;
 							const codeReview = mapWindow(codeReviewRateLimit?.primary_window ?? null);
-						const credits = formatCredits(payload.credits ?? null);
+							const credits = formatCredits(payload.credits ?? null);
 							const additionalLimits = (payload.additional_rate_limits ?? []).filter(
 								(entry) => entry.limit_name !== "code_review_rate_limit",
 							);
@@ -4435,11 +4475,7 @@ while (attempted.size < Math.max(1, accountCount)) {
 
 					if (storageChanged) {
 						await saveAccounts(storage);
-						if (cachedAccountManager) {
-							const reloadedManager = await AccountManager.loadFromDisk();
-							cachedAccountManager = reloadedManager;
-							accountManagerPromise = Promise.resolve(reloadedManager);
-						}
+						invalidateAccountManagerCache();
 					}
 
 					while (lines.length > 0 && lines[lines.length - 1] === "") {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -763,7 +763,6 @@ describe("OpenAIOAuthPlugin", () => {
 		});
 
 		it("refreshes missing tokens before fetching usage", async () => {
-			const { saveAccounts } = await import("../lib/storage.js");
 			mockStorage.accounts = [
 				{ refreshToken: "r1", accountId: "acc-1", email: "user@example.com" },
 			];
@@ -783,53 +782,173 @@ describe("OpenAIOAuthPlugin", () => {
 
 			expect(result).toContain("100% left");
 			expect(mockStorage.accounts[0]?.accessToken).toBe("refreshed-access");
-			expect(saveAccounts).toHaveBeenCalled();
 		});
 
-	it("deduplicates accounts with same refreshToken", async () => {
-		mockStorage.accounts = [
-			{
-				refreshToken: "rt_same",
-				accountId: "acc-1",
-				email: "a@test.com",
-				accessToken: "access-1",
-				expiresAt: Date.now() + 3600_000,
-			},
-			{
-				refreshToken: "rt_same",
-				accountId: "acc-2",
-				email: "a@test.com",
-				accessToken: "access-2",
-				expiresAt: Date.now() + 3600_000,
-			},
-			{
-				refreshToken: "rt_other",
-				accountId: "acc-3",
-				email: "b@test.com",
-				accessToken: "access-3",
-				expiresAt: Date.now() + 3600_000,
-			},
-		];
-		globalThis.fetch = vi.fn().mockResolvedValue(
-			new Response(
-				JSON.stringify({
-					rate_limit: {
-						primary_window: { used_percent: 50, limit_window_seconds: 18000, reset_at: Math.floor(Date.now() / 1000) + 1800 },
-						secondary_window: { used_percent: 50, limit_window_seconds: 604800, reset_at: Math.floor(Date.now() / 1000) + 86400 },
-					},
-				}),
-				{ status: 200, headers: { "content-type": "application/json" } },
-			),
-		);
+		it("deduplicates accounts with same refreshToken and keeps the active marker", async () => {
+			mockStorage.accounts = [
+				{
+					refreshToken: "rt_same",
+					accountId: "acc-1",
+					email: "a@test.com",
+					accessToken: "access-1",
+					expiresAt: Date.now() + 3600_000,
+				},
+				{
+					refreshToken: "rt_same",
+					accountId: "acc-2",
+					email: "a@test.com",
+					accessToken: "access-2",
+					expiresAt: Date.now() + 3600_000,
+				},
+				{
+					refreshToken: "rt_other",
+					accountId: "acc-3",
+					email: "b@test.com",
+					accessToken: "access-3",
+					expiresAt: Date.now() + 3600_000,
+				},
+			];
+			mockStorage.activeIndex = 1;
+			mockStorage.activeIndexByFamily = { codex: 1 };
+			globalThis.fetch = vi.fn().mockImplementation(async () =>
+				new Response(
+					JSON.stringify({
+						rate_limit: {
+							primary_window: {
+								used_percent: 50,
+								limit_window_seconds: 18000,
+								reset_at: Math.floor(Date.now() / 1000) + 1800,
+							},
+							secondary_window: {
+								used_percent: 50,
+								limit_window_seconds: 604800,
+								reset_at: Math.floor(Date.now() / 1000) + 86400,
+							},
+						},
+					}),
+					{ status: 200, headers: { "content-type": "application/json" } },
+				),
+			);
 
-		const result = await plugin.tool["codex-limits"].execute();
+			const result = await plugin.tool["codex-limits"].execute();
 
-		expect(result).toBeDefined();
-		// Header should say "2 accounts" (not 3)
-		expect(result).toContain("2 account");
-		// fetch should be called exactly twice (once per unique refreshToken)
-		expect(globalThis.fetch).toHaveBeenCalledTimes(2);
-	});
+			expect(result).toContain("2 account");
+			expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+			expect(result).toContain("Account 1 (a@test.com, id:acc-1) [active]:");
+			expect(result.match(/Account 1 \(a@test\.com, id:acc-1\)/g)).toHaveLength(1);
+			expect(result).toContain("Account 3 (b@test.com, id:acc-3):");
+			expect(result).not.toContain("Account 2 (a@test.com, id:acc-2):");
+		});
+
+		it("does not deduplicate accounts that are missing refreshToken", async () => {
+			mockStorage.accounts = [
+				{
+					refreshToken: "",
+					accountId: "acc-1",
+					email: "missing-1@test.com",
+					accessToken: "access-1",
+					expiresAt: Date.now() + 3600_000,
+				},
+				{
+					refreshToken: "",
+					accountId: "acc-2",
+					email: "missing-2@test.com",
+					accessToken: "access-2",
+					expiresAt: Date.now() + 3600_000,
+				},
+				{
+					refreshToken: "rt_other",
+					accountId: "acc-3",
+					email: "other@test.com",
+					accessToken: "access-3",
+					expiresAt: Date.now() + 3600_000,
+				},
+			];
+			globalThis.fetch = vi.fn().mockImplementation(async () =>
+				new Response(
+					JSON.stringify({
+						rate_limit: {
+							primary_window: {
+								used_percent: 25,
+								limit_window_seconds: 18000,
+								reset_at: Math.floor(Date.now() / 1000) + 1800,
+							},
+							secondary_window: {
+								used_percent: 25,
+								limit_window_seconds: 604800,
+								reset_at: Math.floor(Date.now() / 1000) + 86400,
+							},
+						},
+					}),
+					{ status: 200, headers: { "content-type": "application/json" } },
+				),
+			);
+
+			const result = await plugin.tool["codex-limits"].execute();
+
+			expect(result).toContain("3 account");
+			expect(globalThis.fetch).toHaveBeenCalledTimes(3);
+			expect(result).toContain("Account 1 (missing-1@test.com, id:acc-1) [active]:");
+			expect(result).toContain("Account 2 (missing-2@test.com, id:acc-2):");
+			expect(result).toContain("Account 3 (other@test.com, id:acc-3):");
+		});
+
+		it("propagates rotated refresh tokens to duplicate stored accounts", async () => {
+			const { queuedRefresh } = await import("../lib/refresh-queue.js");
+			vi.mocked(queuedRefresh).mockResolvedValueOnce({
+				type: "success",
+				access: "rotated-access",
+				refresh: "rotated-refresh",
+				expires: Date.now() + 7200_000,
+			});
+			mockStorage.accounts = [
+				{
+					refreshToken: "stale-refresh",
+					accountId: "acc-1",
+					email: "a@test.com",
+					accessToken: "expired-access-1",
+					expiresAt: Date.now() - 1000,
+				},
+				{
+					refreshToken: "stale-refresh",
+					accountId: "acc-2",
+					email: "a@test.com",
+					accessToken: "expired-access-2",
+					expiresAt: Date.now() - 1000,
+				},
+			];
+			globalThis.fetch = vi.fn().mockImplementation(async () =>
+				new Response(
+					JSON.stringify({
+						rate_limit: {
+							primary_window: {
+								used_percent: 10,
+								limit_window_seconds: 18000,
+								reset_at: Math.floor(Date.now() / 1000) + 1800,
+							},
+							secondary_window: {
+								used_percent: 10,
+								limit_window_seconds: 604800,
+								reset_at: Math.floor(Date.now() / 1000) + 86400,
+							},
+						},
+					}),
+					{ status: 200, headers: { "content-type": "application/json" } },
+				),
+			);
+
+			await plugin.tool["codex-limits"].execute();
+
+			expect(vi.mocked(queuedRefresh)).toHaveBeenCalledTimes(1);
+			expect(mockStorage.accounts.map((account) => account.refreshToken)).toEqual([
+				"rotated-refresh",
+				"rotated-refresh",
+			]);
+			expect(mockStorage.accounts.map((account) => account.accessToken)).toEqual([
+				"rotated-access",
+				"rotated-access",
+			]);
+		});
 	});
 
 	describe("codex-metrics tool", () => {


### PR DESCRIPTION
## Summary
- harden `codex-limits` usage fetching with a timeout
- preserve active-account labeling across deduplicated refresh-token views
- keep duplicate stored credentials in sync when refresh-token rotation occurs
- add regression tests for deduplication, missing refresh tokens, and rotated token propagation

## Context
This PR supersedes #70.

I accidentally pushed the fix from #70 to `main`, reverted that accidental push in `6e18b35`, and reapplied the intended change on top of current `main` in `supersede/pr70-codex-limits` so it can be reviewed normally here.

## Validation
- `npm run lint`
- `npm run typecheck`
- `npm test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timeout handling for account operations, now throws clearer timeout errors when operations take too long.
  * Fixed account deduplication to properly track active accounts during token rotation.
  * Enhanced token refresh propagation across duplicate accounts for consistent state.

* **Refactor**
  * Optimized storage synchronization to reduce redundant data reloading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

this PR hardens the `codex-limits` tool with three targeted fixes: a configurable fetch timeout via `AbortController`, correct active-account labeling across deduplicated refresh-token views, and fan-out propagation of rotated credentials to all duplicate stored accounts. the changes are well-motivated and the new regression tests cover the main scenarios.

**key changes:**
- `fetchUsage` now wraps every network call in an `AbortController` timeout sourced from `getFetchTimeoutMs(loadPluginConfig())`
- deduplication now coerces `refreshToken` to a string and treats falsy/empty tokens as non-deduplicable (each missing-token account appears separately)
- `activeRefreshToken` is captured before the loop so that the `[active]` marker follows the credential identity, not just the array index
- on token rotation, `applyRefreshedCredentials` fans out to every account sharing `previousRefreshToken` in storage
- inline cache-invalidation logic replaced with `invalidateAccountManagerCache()`

**issues found:**
- **logic gap**: the fan-out in `applyRefreshedCredentials` only fires when `refreshResult.refresh !== previousRefreshToken` (rotation). when a non-rotating refresh occurs (new `accessToken`, same `refreshToken`), duplicate accounts still get their stale `accessToken`/`expiresAt` written back to disk via `saveAccounts`, which can cause failures in code paths that access those duplicates directly
- **missing test coverage**: no vitest test exercises the `AbortController` abort path — a regression in signal wiring won't be caught, especially on windows where timer behavior under load differs
- **windows concurrency**: `saveAccounts` → `invalidateAccountManagerCache` is not atomic; antivirus file locks or concurrent `execute()` calls on windows can read stale tokens between the two operations; no in-code comment documents the redaction strategy for `refreshResult.refresh`/`refreshResult.access` in error paths

<h3>Confidence Score: 3/5</h3>

- safe to merge after resolving the non-rotated refresh propagation gap, which leaves stale tokens persisted to disk for duplicate accounts
- the core timeout and deduplication logic is correct, and the rotation fan-out is a real improvement. however the `else` branch in `applyRefreshedCredentials` leaves duplicate accounts with stale access tokens on disk after a non-rotating refresh — a real (if limited-blast-radius) logic bug. the missing timeout test and lack of windows concurrency commentary (per repo policy) also hold this back from a higher score.
- index.ts lines 4390–4398 (non-rotation refresh propagation branch)

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| index.ts | adds fetch timeout via AbortController, deduplication hardening for empty/null refresh tokens, active-account labeling across deduplicated views, and fan-out credential propagation on token rotation; logic gap: non-rotated refreshes don't propagate updated accessToken/expiresAt to duplicate accounts, leaving stale credentials persisted to disk |
| test/index.test.ts | adds three solid regression tests for deduplication, missing-token pass-through, and rotated-token fan-out; missing coverage for the AbortController timeout path introduced in this PR |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant E as execute()
    participant S as storage.accounts
    participant Q as queuedRefresh
    participant F as fetch (CODEX_BASE_URL)
    participant D as disk (saveAccounts)

    E->>S: loadAccounts()
    E->>E: deduplicate by refreshToken (skip empty tokens)
    E->>E: capture activeRefreshToken

    loop for each uniqueIndex i
        E->>S: read account[i]
        alt accessToken missing or expired
            E->>Q: queuedRefresh(account.refreshToken)
            Q-->>E: {type:"success", access, refresh, expires}
            alt refresh rotated (new != old)
                E->>S: fan-out applyRefreshedCredentials<br/>to ALL accounts with old refreshToken
            else no rotation
                E->>S: applyRefreshedCredentials(account[i] only)
                Note over S: ⚠️ duplicate accounts<br/>retain stale accessToken
            end
        end
        E->>F: GET /wham/usage (with AbortController timeout)
        alt timeout fires
            F-->>E: AbortError → "timed out after Xms"
        else response ok
            F-->>E: UsagePayload JSON
        end
        E->>E: format output lines
    end

    alt storageChanged
        E->>D: saveAccounts(storage)
        E->>E: invalidateAccountManagerCache()
        Note over D,E: ⚠️ not atomic on Windows
    end
```

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Aindex.ts%3A4390-4398%0A**Stale%20credentials%20persist%20for%20non-rotated%20refreshes**%0A%0Awhen%20the%20server%20issues%20a%20fresh%20%60accessToken%60%20but%20keeps%20the%20same%20%60refreshToken%60%20%28no%20rotation%29%2C%20the%20%60else%60%20branch%20only%20updates%20the%20single%20%60account%60%20object%20in%20the%20current%20iteration.%20duplicate%20entries%20in%20%60storage.accounts%60%20that%20share%20%60previousRefreshToken%60%20are%20skipped%20by%20deduplication%20and%20never%20receive%20the%20new%20%60accessToken%60%20%2F%20%60expiresAt%60.%20those%20stale%20values%20are%20then%20written%20back%20to%20disk%20via%20%60saveAccounts%60%2C%20so%20any%20code%20path%20outside%20this%20tool%20that%20reads%20those%20duplicate%20account%20objects%20will%20still%20see%20an%20expired%20token.%0A%0Athe%20fan-out%20propagation%20already%20implemented%20in%20the%20rotation%20branch%20should%20apply%20unconditionally%20whenever%20%60previousRefreshToken%60%20is%20set%2C%20regardless%20of%20whether%20the%20token%20was%20rotated%3A%0A%0A%60%60%60%0Aif%20%28previousRefreshToken%29%20%7B%0A%20%20%20%20for%20%28const%20storedAccount%20of%20storage.accounts%29%20%7B%0A%20%20%20%20%20%20%20%20if%20%28storedAccount%3F.refreshToken%20%3D%3D%3D%20previousRefreshToken%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20applyRefreshedCredentials%28storedAccount%29%3B%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%7D%20else%20%7B%0A%20%20%20%20applyRefreshedCredentials%28account%29%3B%0A%7D%0A%60%60%60%0A%0Athis%20also%20closes%20a%20windows%20token-leakage%20window%3A%20stale%20tokens%20sitting%20on%20disk%20can%20be%20picked%20up%20by%20an%20antivirus%20scanner%20or%20a%20concurrent%20read%20before%20%60saveAccounts%60%20replaces%20them.%0A%0A%23%23%23%20Issue%202%20of%203%0Atest%2Findex.test.ts%3A787-951%0A**Missing%20vitest%20coverage%3A%20timeout%2Fabort%20path**%0A%0Athe%20three%20new%20regression%20tests%20cover%20deduplication%2C%20missing%20refresh%20tokens%2C%20and%20rotated-token%20propagation%20%E2%80%94%20good.%20however%20there's%20no%20test%20for%20the%20%60AbortController%60%20timeout%20path%20added%20to%20%60fetchUsage%60.%20recommend%20adding%20something%20like%3A%0A%0A%60%60%60ts%0Ait%28%22times%20out%20and%20throws%20after%20usageFetchTimeoutMs%22%2C%20async%20%28%29%20%3D%3E%20%7B%0A%20%20%20%20%2F%2F%20mock%20a%20fetch%20that%20never%20resolves%20until%20aborted%0A%20%20%20%20globalThis.fetch%20%3D%20vi.fn%28%29.mockImplementation%28%0A%20%20%20%20%20%20%20%20%28_url%3A%20string%2C%20init%3F%3A%20RequestInit%29%20%3D%3E%0A%20%20%20%20%20%20%20%20%20%20%20%20new%20Promise%28%28_resolve%2C%20reject%29%20%3D%3E%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20init%3F.signal%3F.addEventListener%28%22abort%22%2C%20%28%29%20%3D%3E%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20reject%28Object.assign%28new%20Error%28%22AbortError%22%29%2C%20%7B%20name%3A%20%22AbortError%22%20%7D%29%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%29%2C%0A%20%20%20%20%29%3B%0A%20%20%20%20%2F%2F%20configure%20a%20very%20short%20timeout%20in%20the%20plugin%20config%20mock%0A%20%20%20%20%2F%2F%20...%0A%20%20%20%20await%20expect%28plugin.tool%5B%22codex-limits%22%5D.execute%28%29%29.resolves.toContain%28%22timed%20out%22%29%3B%0A%7D%29%3B%0A%60%60%60%0A%0Awithout%20this%2C%20a%20regression%20in%20%60clearTimeout%60%20%2F%20signal%20wiring%20on%20windows%20%28where%20timers%20can%20fire%20differently%20under%20load%29%20won't%20be%20caught.%0A%0A%23%23%23%20Issue%203%20of%203%0Aindex.ts%3A4476-4478%0A**Windows%20concurrency%3A%20%60saveAccounts%60%20%E2%86%92%20%60invalidateAccountManagerCache%60%20is%20not%20atomic**%0A%0A%60saveAccounts%60%20writes%20to%20disk%20and%20then%20%60invalidateAccountManagerCache%60%20drops%20the%20in-memory%20cache.%20on%20windows%2C%20antivirus%20or%20another%20concurrent%20%60execute%28%29%60%20call%20can%20read%20the%20file%20between%20these%20two%20operations%2C%20loading%20stale%20token%20data%20before%20the%20cache%20is%20cleared.%20this%20is%20a%20pre-existing%20pattern%20in%20the%20codebase%2C%20but%20this%20PR%20widens%20the%20blast%20radius%20by%20now%20fanning%20out%20credential%20writes%20to%20all%20duplicate%20accounts%20in%20the%20same%20%60saveAccounts%60%20call.%0A%0Athere's%20also%20no%20mention%20here%20%28or%20in%20a%20comment%29%20of%20the%20logging%2Fredaction%20strategy%20for%20the%20refreshed%20tokens%20that%20travel%20through%20%60applyRefreshedCredentials%60%20%E2%80%94%20if%20any%20error%20thrown%20in%20that%20loop%20ever%20surfaces%20a%20raw%20token%20value%20it%20could%20be%20logged%20unredacted.%20worth%20a%20brief%20comment%20noting%20that%20%60refreshResult.refresh%60%20%2F%20%60refreshResult.access%60%20must%20not%20appear%20in%20user-visible%20error%20strings%20or%20structured%20log%20output.%0A%0A**Rule%20Used%3A**%20What%3A%20Every%20code%20change%20must%20explain%20how%20it%20defend...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3D637a42e6-7a78-40d6-9ef8-6a45e02e73b6%29%29%0A%0A&repo=ndycode%2Foc-chatgpt-multi-auth"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_All_in_Codex-black?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=white"><img alt="Fix All in Codex" src="https://img.shields.io/badge/Fix_All_in_Codex-white?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=black"></picture></a>

<sub>Last reviewed commit: bb446e5</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Rule used - What: Every code change must explain how it defend... ([source](https://app.greptile.com/review/custom-context?memory=637a42e6-7a78-40d6-9ef8-6a45e02e73b6))

<!-- /greptile_comment -->