### PR TITLE
fix(codex-limits): harden usage fetch and dedup refresh

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -4351,6 +4351,9 @@ while (attempted.size < Math.max(1, accountCount)) {
 									activeIndexByFamily: {},
 								} satisfies AccountStorageV3);
 
+							const uniqueMatch = <T>(matches: T[]): T | undefined =>
+								matches.length === 1 ? matches[0] : undefined;
+
 							let updated = false;
 							if (params.previousRefreshToken) {
 								for (const storedAccount of latestStorage.accounts) {
@@ -4364,28 +4367,30 @@ while (attempted.size < Math.max(1, accountCount)) {
 							if (!updated) {
 								const normalizedOrganizationId = params.organizationId?.trim() ?? "";
 								const normalizedEmail = params.email?.trim().toLowerCase();
+								const orgScopedMatches = params.accountId
+									? latestStorage.accounts.filter(
+											(storedAccount) =>
+												storedAccount.accountId === params.accountId &&
+												(storedAccount.organizationId?.trim() ?? "") === normalizedOrganizationId,
+										)
+									: [];
+								const accountIdMatches = params.accountId
+									? latestStorage.accounts.filter(
+											(storedAccount) => storedAccount.accountId === params.accountId,
+										)
+									: [];
+								const emailMatches =
+									normalizedEmail && !params.accountId
+										? latestStorage.accounts.filter(
+												(storedAccount) =>
+													storedAccount.email?.trim().toLowerCase() === normalizedEmail,
+											)
+										: [];
+
 								const fallbackTarget =
-									(params.accountId
-										? latestStorage.accounts.find(
-												(storedAccount) =>
-													storedAccount.accountId === params.accountId &&
-													(storedAccount.organizationId?.trim() ?? "") === normalizedOrganizationId,
-											)
-										: undefined) ??
-									(params.accountId
-										? latestStorage.accounts.find(
-												(storedAccount) => storedAccount.accountId === params.accountId,
-											)
-										: undefined) ??
-									(normalizedEmail
-										? latestStorage.accounts.find(
-												(storedAccount) =>
-													storedAccount.email?.trim().toLowerCase() === normalizedEmail &&
-													(!params.accountId ||
-														!storedAccount.accountId ||
-														storedAccount.accountId === params.accountId),
-											)
-										: undefined);
+									uniqueMatch(orgScopedMatches) ??
+									uniqueMatch(accountIdMatches) ??
+									uniqueMatch(emailMatches);
 
 								if (fallbackTarget) {
 									applyRefreshedCredentials(fallbackTarget, params.refreshResult);
@@ -4462,7 +4467,8 @@ while (attempted.size < Math.max(1, accountCount)) {
 					for (let i = 0; i < storage.accounts.length; i++) {
 						const acct = storage.accounts[i];
 						if (!acct) continue;
-						const refreshToken = typeof acct.refreshToken === "string" ? acct.refreshToken : "";
+						const refreshToken =
+							typeof acct.refreshToken === "string" ? acct.refreshToken.trim() : "";
 						if (refreshToken && seenTokens.has(refreshToken)) continue;
 						if (refreshToken) seenTokens.add(refreshToken);
 						uniqueIndices.push(i);
@@ -4474,7 +4480,7 @@ while (attempted.size < Math.max(1, accountCount)) {
 					const activeIndex = resolveActiveIndex(storage, "codex");
 					const activeRefreshToken =
 						typeof activeIndex === "number" && activeIndex >= 0 && activeIndex < storage.accounts.length
-							? storage.accounts[activeIndex]?.refreshToken
+							? storage.accounts[activeIndex]?.refreshToken?.trim() || undefined
 							: undefined;
 					let storageChanged = false;
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1085,8 +1085,17 @@ describe("OpenAIOAuthPlugin", () => {
 					{
 						refreshToken: "different-refresh",
 						accountId: "acc-other",
+						organizationId: "org-a",
 						email: "user@example.com",
 						accessToken: "other-access",
+						expiresAt: Date.now() + 3600_000,
+					},
+					{
+						refreshToken: "different-refresh-2",
+						accountId: "acc-other-2",
+						organizationId: "org-b",
+						email: "user@example.com",
+						accessToken: "other-access-2",
 						expiresAt: Date.now() + 3600_000,
 					},
 				],
@@ -1156,6 +1165,11 @@ describe("OpenAIOAuthPlugin", () => {
 				accountId: "acc-other",
 				refreshToken: "different-refresh",
 				accessToken: "other-access",
+			});
+			expect(transactionStorage.accounts[1]).toMatchObject({
+				accountId: "acc-other-2",
+				refreshToken: "different-refresh-2",
+				accessToken: "other-access-2",
 			});
 			const reloadedStorage = await vi.mocked(loadAccounts)();
 			expect(reloadedStorage?.accounts[0]).toMatchObject({


### PR DESCRIPTION
## Summary
- harden `codex-limits` usage fetching with timeout handling, capped/redacted upstream errors, and safer refresh persistence
- preserve active-account labeling across deduplicated credentials and avoid collapsing accounts that have no refresh token
- propagate refreshed credentials across duplicate stored records using fresh storage transactions and expand regression coverage for review findings from PR #70

## Why
PR #70 and the follow-up review cycles surfaced correctness, token-safety, and Windows concurrency gaps around deduplication, refresh propagation, stale-storage writes, blank-token refresh attempts, timeout handling, and ambiguous identity fallback. This PR carries the full remediation set on a clean branch from `main`.

## Verification
- `npm install`
- `npx vitest run test/index.test.ts`
- `npm run typecheck`
- `npm run build`
- `npm run lint`

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---


<h3>Greptile Summary</h3>

this PR hardens `codex-limits` across three axes: token safety (error-body redaction, blank-token refresh guard), timeout correctness (layered `AbortController` handling covering pre-header, mid-body, and post-body abort paths), and refresh propagation correctness (transactional fan-out to all duplicate stored records, active-label preservation across deduped credentials, empty-refreshToken bypass). storage writes are now fully transactional via `persistRefreshedCredentials` rather than direct `saveAccounts`, addressing the windows concurrency gap from PR #70 where stale in-memory state could overwrite a concurrent on-disk write.

key changes:
- `usageFetchTimeoutMs` hoisted outside `fetchUsage` (addresses prior review finding)
- `isAbortError` covers both `Error` and `DOMException` `AbortError` variants for cross-platform safety
- dedup loop skips empty `refreshToken` rather than collapsing distinct no-token accounts
- `persistRefreshedCredentials` opens a fresh storage transaction per refresh, avoiding stale-write races on windows
- `invalidateAccountManagerCache()` replaces the explicit `saveAccounts` + `AccountManager.loadFromDisk()` sequence
- test coverage meaningfully expanded with 9 new cases including three `vi.useFakeTimers()` timeout scenarios

two findings worth addressing:
- the `if (refreshedCount === 0)` fallback in the main loop is unreachable dead code (the non-empty `previousRefreshToken` guard above guarantees `account` itself always matches the in-memory loop, so `refreshedCount >= 1` always) — safe to remove, its intent is covered by `persistRefreshedCredentials`
- the `if (controller.signal.aborted)` check after a _successful_ `response.text()` read can replace a real HTTP error (e.g. 401) with `"Usage request timed out"` in a tight-timer race; on windows VPN connections where reads complete slowly, this discards useful error context

<h3>Confidence Score: 4/5</h3>

- safe to merge after confirming the dead-code branch intent and the post-read abort-check behavior
- the core correctness and token-safety fixes are solid — transactional refresh propagation, blank-token guard, redaction, and abort handling are all well-structured and regression-tested. the two issues flagged (unreachable `refreshedCount === 0` branch, misleading post-read abort check) are low-severity and don't affect the primary code paths, but the dead-code branch could mislead future refactors and the abort check can produce confusing output on windows VPN setups
- the `refreshedCount === 0` dead branch in `index.ts` around the in-memory refresh propagation loop warrants a second look before merge

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| index.ts | adds `sanitizeUsageErrorMessage`, `isAbortError`, `applyRefreshedCredentials`, `persistRefreshedCredentials` helpers; hoists `usageFetchTimeoutMs` outside `fetchUsage`; adds `AbortController` timeout to usage fetch with layered abort handling; fixes dedup to preserve accounts with empty `refreshToken`; propagates refreshed credentials across duplicate stored records via a fresh transaction; preserves active-account label across deduped entries; replaces direct `saveAccounts` with `invalidateAccountManagerCache()` — one dead-code path (`refreshedCount === 0`) is unreachable, and a post-successful-read `controller.signal.aborted` check can mask real HTTP errors with a misleading "timed out" message |
| test/index.test.ts | adds `cloneAccount`/`cloneMockStorage` helpers for isolated test state; upgrades `withAccountStorageTransaction` mock to return generic `T`; adds `saveAccounts` mock that actually mutates `mockStorage`; expands codex-limits coverage with 9 new tests covering dedup-with-active-label, empty-token dedup bypass, credential fan-out, transactional identity fallback, blank-token guard, error redaction, and three timeout scenarios; the post-successful-read abort branch (`text()` succeeds but signal already aborted) has no dedicated test |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Iter as "uniqueIndices iteration"
    participant Mem as "in-memory storage"
    participant Q as "queuedRefresh"
    participant Tx as "withAccountStorageTransaction"
    participant Disk as "disk storage"

    Iter->>Mem: "read account.refreshToken (previousRefreshToken)"
    Iter->>Q: "queuedRefresh(previousRefreshToken)"
    Q-->>Iter: "refreshResult {access, refresh, expires}"
    Iter->>Mem: "applyRefreshedCredentials to all in-memory matches"
    Iter->>Tx: "persistRefreshedCredentials(previousRefreshToken, ...)"
    Tx->>Disk: "read latest storage (fresh transaction)"
    alt "previousRefreshToken matched"
        Tx->>Disk: "update all matching accounts, persist"
    else "fallback: match by accountId or email"
        Tx->>Disk: "update fallback account, persist"
    else "no match found"
        Tx-->>Iter: "logWarn, return false"
    end
    Tx-->>Iter: "persistedRefresh boolean"
    Iter->>Iter: "fetchUsage with AbortController"
    alt "abort fires before headers"
        Iter-->>Iter: "Usage request timed out"
    else "abort fires during body read"
        Iter-->>Iter: "Usage request timed out"
    else "non-OK response"
        Iter-->>Iter: "sanitizeUsageErrorMessage"
    end
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `index.ts`, line 4524-4527 ([link](https://github.com/ndycode/oc-chatgpt-multi-auth/blob/404961b4fe11f43443b9f5cc700a6b63b8d9c84a/index.ts#L4524-L4527)) 

   **`refreshedCount === 0` fallback is unreachable dead code**

   the guard directly above ensures `previousRefreshToken` is always a non-empty string before reaching this block. since `account` is `storage.accounts[i]` and `previousRefreshToken` is `account.refreshToken`, the in-memory loop always finds `account` itself as a matching entry — so `refreshedCount` is guaranteed ≥ 1 and the fallback branch never executes.

   this is not a correctness bug today, but the dead code creates false confidence for future maintainers who may assume this path is exercised in tests, and then restructure surrounding guard logic in ways that introduce regressions (concurrency or token-rotation edge cases are the most likely failure mode on windows). the `persistRefreshedCredentials` transactional fallback already handles the disk-side case where the stored token rotated between the in-memory load and the write, so the intent is fully covered without the dead branch.

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Aindex.ts%3A4456-4459%0A**spurious%20%22timed%20out%22%20can%20replace%20a%20real%20HTTP%20error%20body**%0A%0Aafter%20%60response.text%28%29%60%20returns%20_without_%20throwing%2C%20%60bodyText%60%20is%20fully%20populated.%20the%20subsequent%20%60if%20%28controller.signal.aborted%29%60%20check%20can%20still%20fire%20if%20the%20timer%20expired%20at%20the%20exact%20moment%20the%20body%20finished%20streaming%20%E2%80%94%20in%20which%20case%20we%20discard%20the%20real%20error%20body%20and%20surface%20%60%22Usage%20request%20timed%20out%22%60%20instead%20of%20e.g.%20%60%22HTTP%20401%3A%20...%22%60.%20on%20windows%20laptops%20under%20VPN%20%28slow-but-complete%20reads%20with%20tight%20timeouts%29%2C%20users%20lose%20the%20actual%20error%20signal.%0A%0Aconsider%20dropping%20the%20post-read%20abort%20check%20and%20relying%20solely%20on%20the%20inner-catch%20guard%20%2B%20the%20outer%20%60isAbortError%60%20catch.%20a%20successfully-read%20body%20means%20the%20server%20response%20arrived%20in%20time%3A%0A%0A%60%60%60ts%0Atry%20%7B%0A%20%20%20%20bodyText%20%3D%20%28await%20response.text%28%29%29.slice%280%2C%20usageErrorBodyMaxChars%29%3B%0A%7D%20catch%20%28error%29%20%7B%0A%20%20%20%20if%20%28isAbortError%28error%29%20%7C%7C%20controller.signal.aborted%29%20%7B%0A%20%20%20%20%20%20%20%20throw%20new%20Error%28%22Usage%20request%20timed%20out%22%29%3B%0A%20%20%20%20%7D%0A%20%20%20%20throw%20error%3B%0A%7D%0A%2F%2F%20remove%20the%20if%20%28controller.signal.aborted%29%20check%20here%0Athrow%20new%20Error%28sanitizeUsageErrorMessage%28response.status%2C%20bodyText%29%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Atest%2Findex.test.ts%3A833-872%0A**abort-during-text-read%20test%20covers%20the%20wrong%20execution%20branch**%0A%0Athe%20%60%22surfaces%20usage%20fetch%20timeouts%20without%20leaking%20raw%20abort%20errors%22%60%20test%20stubs%20%60response.ok%20%3D%20false%60%20and%20makes%20%60text%28%29%60%20throw%20an%20%60AbortError%60.%20this%20exercises%20the%20inner-catch%20path%20%28%60isAbortError%28error%29%20%7C%7C%20controller.signal.aborted%60%20on%20the%20%60response.text%28%29%60%20call%29%2C%20but%20the%20next%20test%20%28%60%22surfaces%20usage%20fetch%20timeouts%20before%20response%20headers%20arrive%22%60%29%20and%20the%20one%20after%20%28%60%22during%20successful%20response%20body%20reads%22%60%29%20cover%20the%20other%20two%20branches.%20the%20outer-catch%20branch%20%28%60response.ok%20%3D%20false%60%2C%20%60text%28%29%60%20succeeds%2C%20then%20%60controller.signal.aborted%60%20is%20true%20post-read%29%20has%20no%20test.%20given%20the%20dead-code%20concern%20on%20%60controller.signal.aborted%60%20post-read%20%28see%20inline%20comment%20in%20%60index.ts%60%29%2C%20adding%20a%20test%20that%20covers%20the%20path%20where%20%60text%28%29%60%20returns%20a%20string%20but%20the%20signal%20is%20already%20aborted%20would%20either%20confirm%20the%20branch%20is%20reachable%20or%20surface%20that%20it%20should%20be%20removed.%0A%0A%23%23%23%20Issue%203%20of%203%0Aindex.ts%3A4524-4527%0A**%60refreshedCount%20%3D%3D%3D%200%60%20fallback%20is%20unreachable%20dead%20code**%0A%0Athe%20guard%20directly%20above%20ensures%20%60previousRefreshToken%60%20is%20always%20a%20non-empty%20string%20before%20reaching%20this%20block.%20since%20%60account%60%20is%20%60storage.accounts%5Bi%5D%60%20and%20%60previousRefreshToken%60%20is%20%60account.refreshToken%60%2C%20the%20in-memory%20loop%20always%20finds%20%60account%60%20itself%20as%20a%20matching%20entry%20%E2%80%94%20so%20%60refreshedCount%60%20is%20guaranteed%20%E2%89%A5%201%20and%20the%20fallback%20branch%20never%20executes.%0A%0Athis%20is%20not%20a%20correctness%20bug%20today%2C%20but%20the%20dead%20code%20creates%20false%20confidence%20for%20future%20maintainers%20who%20may%20assume%20this%20path%20is%20exercised%20in%20tests%2C%20and%20then%20restructure%20surrounding%20guard%20logic%20in%20ways%20that%20introduce%20regressions%20%28concurrency%20or%20token-rotation%20edge%20cases%20are%20the%20most%20likely%20failure%20mode%20on%20windows%29.%20the%20%60persistRefreshedCredentials%60%20transactional%20fallback%20already%20handles%20the%20disk-side%20case%20where%20the%20stored%20token%20rotated%20between%20the%20in-memory%20load%20and%20the%20write%2C%20so%20the%20intent%20is%20fully%20covered%20without%20the%20dead%20branch.%0A%0A&repo=ndycode%2Foc-chatgpt-multi-auth"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_All_in_Codex-black?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=white"><img alt="Fix All in Codex" src="https://img.shields.io/badge/Fix_All_in_Codex-white?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=black"></picture></a>

<sub>Last reviewed commit: 404961b</sub>

**Context used:**

- Rule used - What: Every code change must explain how it defend... ([source](https://app.greptile.com/review/custom-context?memory=637a42e6-7a78-40d6-9ef8-6a45e02e73b6))

<!-- /greptile_comment -->