### PR TITLE
docs: refresh config guidance for current main structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ What the installer does:
 
 - writes `~/.config/opencode/opencode.json`
 - backs up an existing config before changing it
+- normalizes the plugin entry to `"oc-chatgpt-multi-auth"`
 - clears the cached plugin copy so OpenCode reinstalls the latest package
 
 ## Example Usage
@@ -120,7 +121,7 @@ Start here if the plugin does not load or authenticate correctly:
 
 Common first checks:
 
-- confirm `"plugin": ["oc-chatgpt-multi-auth@latest"]` is present in your OpenCode config
+- confirm `"plugin": ["oc-chatgpt-multi-auth"]` is present in your OpenCode config
 - rerun `opencode auth login`
 - inspect `~/.opencode/logs/codex-plugin/` after running one request with `ENABLE_PLUGIN_REQUEST_LOGGING=1`
 

--- a/config/README.md
+++ b/config/README.md
@@ -6,8 +6,8 @@ This directory contains the official OpenCode config templates for the ChatGPT C
 
 | File | OpenCode version | Description |
 |------|------------------|-------------|
-| [`opencode-modern.json`](./opencode-modern.json) | **v1.0.210+** | Variant-based config: 6 base models with 21 total presets |
-| [`opencode-legacy.json`](./opencode-legacy.json) | **v1.0.209 and below** | Legacy explicit entries: 21 individual model definitions |
+| [`opencode-modern.json`](./opencode-modern.json) | **v1.0.210+** | Variant-based config: 7 base models with 26 total presets |
+| [`opencode-legacy.json`](./opencode-legacy.json) | **v1.0.209 and below** | Legacy explicit entries: 26 individual model definitions |
 
 ## Quick pick
 
@@ -34,10 +34,12 @@ opencode --version
 OpenCode v1.0.210+ added model `variants`, so one model entry can expose multiple reasoning levels. That keeps modern config much smaller while preserving the same effective presets.
 
 Both templates include:
-- GPT-5.4, GPT-5 Codex, GPT-5.1, GPT-5.1 Codex, GPT-5.1 Codex Max, GPT-5.1 Codex Mini
+- GPT-5.4, GPT-5.4 Mini, GPT-5 Codex, GPT-5.1, GPT-5.1 Codex, GPT-5.1 Codex Max, GPT-5.1 Codex Mini
 - Reasoning variants per model family
 - `store: false` and `include: ["reasoning.encrypted_content"]`
 - Context metadata (`gpt-5.4*`: 1,000,000 context / 128,000 output; other shipped models: 272,000 / 128,000)
+
+Use `opencode debug config` to verify that these template entries were merged into your effective config. `opencode models openai` currently shows OpenCode's built-in provider catalog and can omit config-defined entries such as `gpt-5.4-mini`.
 
 If your OpenCode runtime supports global compaction tuning, you can also set:
 - `model_context_window = 1000000`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -9,7 +9,7 @@ Complete reference for configuring `oc-chatgpt-multi-auth`. Most of this is opti
 ```json
 {
   "$schema": "https://opencode.ai/config.json",
-  "plugin": ["oc-chatgpt-multi-auth@latest"],
+  "plugin": ["oc-chatgpt-multi-auth"],
   "provider": {
     "openai": {
       "options": {
@@ -46,7 +46,7 @@ controls how much thinking the model does.
 | `gpt-5.1-codex-mini` | medium, high |
 | `gpt-5.1` | none, low, medium, high |
 
-the shipped config templates include 21 presets and do not add optional IDs by default. add `gpt-5.4-pro` and/or `gpt-5.3-codex-spark` manually only for entitled workspaces.
+the shipped config templates include 7 base model families and 26 shipped presets overall (26 modern variants or 26 legacy explicit entries). add `gpt-5.4-pro` and/or `gpt-5.3-codex-spark` manually only for entitled workspaces.
 for context sizing, shipped templates use:
 - `gpt-5.4`, `gpt-5.4-mini`, and `gpt-5.4-pro`: `context=1000000`, `output=128000`
 - other shipped families: `context=272000`, `output=128000`
@@ -54,6 +54,7 @@ for context sizing, shipped templates use:
 model normalization aliases:
 - legacy `gpt-5`, `gpt-5-mini`, `gpt-5-nano` map to `gpt-5.4` (not to `gpt-5.4-mini`)
 - snapshot ids `gpt-5.4-2026-03-05*`, `gpt-5.4-mini-2026-03-05*`, and `gpt-5.4-pro-2026-03-05*` map to stable `gpt-5.4` / `gpt-5.4-mini` / `gpt-5.4-pro`
+- `opencode debug config` is the reliable way to confirm merged custom/template model entries; `opencode models openai` currently shows only the built-in provider catalog
 
 if your OpenCode runtime supports global compaction tuning, you can set:
 - `model_context_window = 1000000`
@@ -254,7 +255,7 @@ same settings for all models:
 
 ```json
 {
-  "plugin": ["oc-chatgpt-multi-auth@latest"],
+  "plugin": ["oc-chatgpt-multi-auth"],
   "provider": {
     "openai": {
       "options": {
@@ -301,7 +302,7 @@ model options override global options.
 global (`~/.config/opencode/opencode.json`):
 ```json
 {
-  "plugin": ["oc-chatgpt-multi-auth@latest"],
+  "plugin": ["oc-chatgpt-multi-auth"],
   "provider": {
     "openai": {
       "options": { "reasoningEffort": "medium" }

--- a/docs/development/ARCHITECTURE.md
+++ b/docs/development/ARCHITECTURE.md
@@ -368,7 +368,7 @@ let include: Vec<String> = if reasoning.is_some() {
 **Alternative**: Single global config
 
 **Problem**:
-- `gpt-5-codex` optimal settings differ from `gpt-5-nano`
+- `gpt-5-codex` optimal settings differ from `gpt-5.4` or `gpt-5.4-mini`
 - Users want quick switching between quality levels
 - No way to save "presets"
 
@@ -472,12 +472,12 @@ The plugin now includes a beginner-focused operational layer in `index.ts` and `
 
 2. **Checklist and wizard flow**
    - `codex-setup` renders a checklist (`add account`, `set active`, `verify health`, `label accounts`, `learn commands`).
-   - `codex-setup wizard=true` launches an interactive menu when terminal supports TTY interaction.
+   - `codex-setup --wizard` launches an interactive menu when terminal supports TTY interaction.
    - Wizard gracefully falls back to checklist output when menus are unavailable.
 
 3. **Doctor + next-action diagnostics**
    - `codex-doctor` maps runtime/account states into severity findings (`ok`, `warning`, `error`) with specific action text.
-   - `codex-doctor fix=true` performs safe remediation:
+   - `codex-doctor --fix` performs safe remediation:
      - refreshes tokens using queued refresh,
      - persists refreshed credentials,
      - switches active account to healthiest eligible account when beneficial.

--- a/docs/development/CONFIG_FIELDS.md
+++ b/docs/development/CONFIG_FIELDS.md
@@ -1,390 +1,58 @@
-# Config Fields: Complete Guide
+# Config Fields
 
-Understanding the difference between config key, `id`, and `name` fields in OpenCode model configuration.
+This document summarizes the current config fields that matter for `oc-chatgpt-multi-auth`.
 
-## The Three Fields
+## Top-Level Fields
 
-```json
-{
-  "provider": {
-    "openai": {
-      "models": {
-        "THIS-IS-THE-CONFIG-KEY": {
-          "id": "this-is-the-id-field",
-          "name": "This is the name field"
-        }
-      }
-    }
-  }
-}
-```
+### `plugin`
 
----
-
-## What Each Field Controls
-
-### Config Key (Property Name)
-
-**Example:** `"gpt-5-codex-low"`
-
-**Used For:**
-- ✅ CLI `--model` flag: `--model=openai/gpt-5-codex-low`
-- ✅ OpenCode internal lookups: `provider.info.models["gpt-5-codex-low"]`
-- ✅ TUI persistence: Saved to `~/.opencode/tui` as `model_id = "gpt-5-codex-low"`
-- ✅ Custom command frontmatter: `model: openai/gpt-5-codex-low`
-- ✅ Agent configuration: `"model": "openai/gpt-5-codex-low"`
-- ✅ **Plugin config lookup**: `userConfig.models["gpt-5-codex-low"]`
-- ✅ Passed to custom loaders: `getModel(sdk, "gpt-5-codex-low")`
-
-**This is the PRIMARY identifier throughout OpenCode!**
-
----
-
-### `id` Field (Optional - NOT NEEDED for OpenAI)
-
-**Example:** `"gpt-5-codex"`
-
-**What it's used for:**
-- ⚠️ **Other providers**: Some providers use this for `sdk.languageModel(id)`
-- ⚠️ **Sorting**: Used for model priority sorting in OpenCode
-- ⚠️ **Documentation**: Indicates the "canonical" model ID
-
-**What it's NOT used for with OpenAI:**
-- ❌ **NOT sent to AI SDK** (config key is sent instead)
-- ❌ **NOT used by plugin** (plugin receives config key)
-- ❌ **NOT required** (OpenCode defaults it to config key)
-
-**Code Reference:** (`tmp/opencode/packages/opencode/src/provider/provider.ts:252`)
-```typescript
-const parsedModel: ModelsDev.Model = {
-  id: model.id ?? modelID,  // ← Defaults to config key if omitted
-  ...
-}
-```
-
-**OpenAI Custom Loader:** (`tmp/opencode/packages/opencode/src/provider/provider.ts:58-65`)
-```typescript
-openai: async () => {
-  return {
-    async getModel(sdk: any, modelID: string) {
-      return sdk.responses(modelID)  // ← Receives CONFIG KEY, not id field!
-    }
-  }
-}
-```
-
-**Our plugin receives:** `body.model = "gpt-5-codex-low"` (config key, NOT id field)
-
-**Recommendation:** **Omit the `id` field** for OpenAI provider - it's redundant and creates confusion. OpenCode will auto-set it to the config key.
-
----
-
-### `name` Field (Optional)
-
-**Example:** `"GPT 5 Codex Low (OAuth)"`
-
-**Used For:**
-- ✅ **TUI Model Picker**: Display name shown in the model selection UI
-- ℹ️ **Documentation**: Human-friendly description
-
-**Code Reference:** (`tmp/opencode/packages/opencode/src/provider/provider.ts:253`)
-```typescript
-const parsedModel: ModelsDev.Model = {
-  name: model.name ?? existing?.name ?? modelID,  // Defaults to config key
-  ...
-}
-```
-
-**If omitted:** Falls back to config key for display
-
----
-
-## Complete Flow Diagram
-
-```
-┌─────────────────────────────────────────────────────────────────┐
-│                    What Users See & Use                         │
-├─────────────────────────────────────────────────────────────────┤
-│                                                                 │
-│  CLI Usage:                                                     │
-│  $ opencode run --model=openai/gpt-5-codex-low                 │
-│                                 └──────┬──────┘                 │
-│                                   CONFIG KEY                    │
-│                                                                 │
-│  TUI Display:                                                   │
-│  ┌──────────────────────────────────┐                          │
-│  │ Select Model:                    │                          │
-│  │                                  │                          │
-│  │ ○ GPT 5 Codex Low (OAuth) ←──────┼── name field            │
-│  │ ○ GPT 5 Codex Medium (OAuth)     │                          │
-│  │ ○ GPT 5 Codex High (OAuth)       │                          │
-│  └──────────────────────────────────┘                          │
-│                                                                 │
-│  Config Lookup (Plugin):                                       │
-│  userConfig.models["gpt-5-codex-low"].options                  │
-│                     └──────┬──────┘                             │
-│                       CONFIG KEY                                │
-│                                                                 │
-└─────────────────────────────────────────────────────────────────┘
-
-┌─────────────────────────────────────────────────────────────────┐
-│                    Internal Flow                                │
-├─────────────────────────────────────────────────────────────────┤
-│                                                                 │
-│  1. User Selection                                              │
-│     opencode run --model=openai/gpt-5-codex-low                │
-│     OpenCode parses: providerID="openai"                        │
-│                      modelID="gpt-5-codex-low" ← CONFIG KEY    │
-│                                                                 │
-│  2. OpenCode Provider Lookup                                    │
-│     provider.info.models["gpt-5-codex-low"]                     │
-│                          └──────┬──────┘                        │
-│                            CONFIG KEY                           │
-│                                                                 │
-│  3. Custom Loader Call (OpenAI)                                 │
-│     getModel(sdk, "gpt-5-codex-low")                            │
-│                   └──────┬──────┘                               │
-│                     CONFIG KEY                                  │
-│                                                                 │
-│  4. AI SDK Request Creation                                     │
-│     { model: "gpt-5-codex-low", ... }                           │
-│              └──────┬──────┘                                    │
-│                CONFIG KEY                                       │
-│                                                                 │
-│  5. Custom fetch() (Our Plugin)                                 │
-│     body.model = "gpt-5-codex-low"                              │
-│                  └──────┬──────┘                                │
-│                    CONFIG KEY                                   │
-│                                                                 │
-│  6. Plugin Config Lookup                                        │
-│     userConfig.models["gpt-5-codex-low"].options                │
-│                       └──────┬──────┘                           │
-│                         CONFIG KEY                              │
-│     Result: { reasoningEffort: "low", ... } ✅ FOUND           │
-│                                                                 │
-│  7. Plugin Normalization                                        │
-│     normalizeModel("gpt-5-codex-low")                           │
-│     Returns: "gpt-5-codex" ← SENT TO CODEX API                 │
-│                                                                 │
-│  8. TUI Persistence                                             │
-│     ~/.opencode/tui:                                            │
-│       provider_id = "openai"                                    │
-│       model_id = "gpt-5-codex-low" ← CONFIG KEY persisted      │
-│                                                                 │
-└─────────────────────────────────────────────────────────────────┘
-```
-
----
-
-## Field Purpose Summary
-
-### Config Key: The Real Identifier
-
-```json
-"gpt-5-codex-low": { ... }
- └──────┬──────┘
-   CONFIG KEY
-```
-
-**Purpose:**
-- 🎯 **PRIMARY identifier** - used everywhere in OpenCode
-- 🎯 **Plugin receives this** - what our plugin sees in `body.model`
-- 🎯 **Config lookup key** - how plugin finds per-model options
-- 🎯 **Persisted value** - saved in TUI state
-
-**Best Practice:** Use Codex CLI preset names (`gpt-5-codex-low`, `gpt-5-high`, etc.)
-
----
-
-### `id` Field: Documentation/Metadata
-
-```json
-"id": "gpt-5-codex"
-       └─────┬─────┘
-         ID FIELD
-```
-
-**Purpose:**
-- 📝 **Documents** what base model this variant uses
-- 📝 **Helps sorting** in model lists
-- 📝 **Clarity** - shows relationship between variants
-
-**Best Practice:** Set to the base API model name (`gpt-5-codex`, `gpt-5`, etc.)
-
-**Note:** For OpenAI provider, this is NOT sent to the API! The plugin normalizes the config key instead.
-
----
-
-### `name` Field: UI Display
-
-```json
-"name": "GPT 5 Codex Low (OAuth)"
-         └──────────┬──────────┘
-              NAME FIELD
-```
-
-**Purpose:**
-- 🎨 **TUI display** - what users see in model picker
-- 🎨 **User-friendly** - can be descriptive
-- 🎨 **Differentiation** - helps distinguish from API key models
-
-**Best Practice:** Human-friendly name with context (OAuth, API, subscription type, etc.)
-
----
-
-## Real-World Examples
-
-### Example 1: Our Current Config ✅
+Use the plain package name in OpenCode config:
 
 ```json
 {
-  "gpt-5-codex-low": {
-    "id": "gpt-5-codex",
-    "name": "GPT 5 Codex Low (OAuth)",
-    "options": { "reasoningEffort": "low" }
-  }
+  "plugin": ["oc-chatgpt-multi-auth"]
 }
 ```
 
-**When user selects `openai/gpt-5-codex-low`:**
-- CLI: Uses `"gpt-5-codex-low"` (config key)
-- TUI: Shows `"GPT 5 Codex Low (OAuth)"` (name field)
-- Plugin receives: `body.model = "gpt-5-codex-low"` (config key)
-- Plugin looks up: `models["gpt-5-codex-low"]` ✅ Found
-- Plugin sends to API: `"gpt-5-codex"` (normalized)
+The installer normalizes to this unpinned value on purpose.
 
-**Result:** ✅ Everything works perfectly!
+### `model`
 
----
-
-### Example 2: Multiple Variants of Same Model ✅
+Sets the default selected model:
 
 ```json
 {
-  "gpt-5-codex-low": {
-    "id": "gpt-5-codex",
-    "name": "GPT 5 Codex Low (OAuth)"
-  },
-  "gpt-5-codex-high": {
-    "id": "gpt-5-codex",
-    "name": "GPT 5 Codex High (OAuth)"
-  }
+  "model": "openai/gpt-5.4"
 }
 ```
 
-**Why this works:**
-- Config keys are different: `"gpt-5-codex-low"` vs `"gpt-5-codex-high"` ✅
-- Same `id` is fine - it's just metadata
-- Different `name` values help distinguish in TUI
+Modern OpenCode pairs this with `--variant` at runtime.
 
-**Result:** ✅ Two variants of same base model, different settings
+## `provider.openai.options`
 
----
+These are the global defaults the plugin receives for every OpenAI request.
 
-### Example 3: If We Made Config Key = ID ❌
+Common fields:
 
-```json
-{
-  "gpt-5-codex": {
-    "id": "gpt-5-codex",
-    "name": "GPT 5 Codex Low (OAuth)",
-    "options": { "reasoningEffort": "low" }
-  },
-  "gpt-5-codex": {  // ❌ DUPLICATE KEY ERROR!
-    "id": "gpt-5-codex",
-    "name": "GPT 5 Codex High (OAuth)",
-    "options": { "reasoningEffort": "high" }
-  }
-}
-```
+| Field | Purpose |
+|------|---------|
+| `reasoningEffort` | default reasoning depth |
+| `reasoningSummary` | reasoning summary style |
+| `textVerbosity` | output verbosity |
+| `include` | extra response fields, typically `reasoning.encrypted_content` |
+| `store` | must stay `false` for this plugin |
 
-**Problem:** JavaScript objects can't have duplicate keys!
-
-**Result:** ❌ Can't have multiple variants
-
----
-
-## Why We Need Different Config Keys
-
-**Problem:** Need multiple configurations for the same API model
-
-**Solution:** Different config keys → same `id`
-
-```json
-{
-  "gpt-5-codex-low": {          // ← Unique config key #1
-    "id": "gpt-5-codex",         // ← Same base model
-    "options": { "reasoningEffort": "low" }
-  },
-  "gpt-5-codex-medium": {       // ← Unique config key #2
-    "id": "gpt-5-codex",         // ← Same base model
-    "options": { "reasoningEffort": "medium" }
-  },
-  "gpt-5-codex-high": {         // ← Unique config key #3
-    "id": "gpt-5-codex",         // ← Same base model
-    "options": { "reasoningEffort": "high" }
-  }
-}
-```
-
-**Result:**
-- 3 selectable variants in TUI ✅
-- Same API model (`gpt-5-codex`) ✅
-- Different reasoning settings ✅
-- Plugin correctly applies per-variant options ✅
-
----
-
-## Backwards Compatibility
-
-### Config Changes are Safe ✅
-
-**Old Plugin + Old Config:**
-```json
-"GPT 5 Codex Low (ChatGPT Subscription)": {
-  "id": "gpt-5-codex",
-  "options": { "reasoningEffort": "low" }
-}
-```
-**Result:** ❌ Per-model options broken (existing bug in old plugin)
-
-**New Plugin + Old Config:**
-```json
-"GPT 5 Codex Low (ChatGPT Subscription)": {
-  "id": "gpt-5-codex",
-  "options": { "reasoningEffort": "low" }
-}
-```
-**Result:** ✅ Per-model options work! (bug fixed)
-
-**New Plugin + New Config:**
-```json
-"gpt-5-codex-low": {
-  "id": "gpt-5-codex",
-  "name": "GPT 5 Codex Low (OAuth)",
-  "options": { "reasoningEffort": "low" }
-}
-```
-**Result:** ✅ Per-model options work! (bug fixed + cleaner naming)
-
-**Conclusion:**
-- ✅ Existing configs continue to work
-- ✅ New configs work better
-- ✅ Users can migrate at their own pace
-
----
-
-## Required Configuration Fields
-
-### `store` Field: Critical for AI SDK 2.0.50+
-
-**⚠️ Required as of AI SDK 2.0.50 (released Oct 12, 2025)**
+Example:
 
 ```json
 {
   "provider": {
     "openai": {
       "options": {
+        "reasoningEffort": "medium",
+        "reasoningSummary": "auto",
+        "textVerbosity": "medium",
+        "include": ["reasoning.encrypted_content"],
         "store": false
       }
     }
@@ -392,28 +60,35 @@ const parsedModel: ModelsDev.Model = {
 }
 ```
 
-**What it does:**
-- `false` (required): Prevents AI SDK from using `item_reference` for conversation history
-- `true` (default): Uses server-side storage with references (incompatible with Codex API)
+## `provider.openai.models`
 
-**Why required:**
-AI SDK 2.0.50 introduced automatic use of `item_reference` items to reduce payload size when `store: true`. However:
-- Codex API requires `store: false` (stateless mode)
-- `item_reference` items cannot be resolved without server-side storage
-- Without this setting, multi-turn conversations fail with: `"Item with id 'fc_xxx' not found"`
+This field differs slightly between the modern and legacy shipped templates.
 
-**Where to set:**
+### Modern template fields
+
+Modern templates define base model families and expose presets through `variants`.
+
+Example:
+
 ```json
 {
   "provider": {
     "openai": {
-      "options": {
-        "store": false  // ← Global: applies to all models
-      },
       "models": {
-        "gpt-5-codex-low": {
-          "options": {
-            "store": false  // ← Per-model: redundant but explicit
+        "gpt-5.4": {
+          "name": "GPT 5.4 (OAuth)",
+          "limit": {
+            "context": 1000000,
+            "output": 128000
+          },
+          "modalities": {
+            "input": ["text", "image"],
+            "output": ["text"]
+          },
+          "variants": {
+            "none": { "reasoningEffort": "none" },
+            "medium": { "reasoningEffort": "medium" },
+            "xhigh": { "reasoningEffort": "xhigh" }
           }
         }
       }
@@ -422,275 +97,109 @@ AI SDK 2.0.50 introduced automatic use of `item_reference` items to reduce paylo
 }
 ```
 
-**Recommendation:** Set in global `options` since it's required for all models using this plugin.
+Important fields:
 
-**Note:** The plugin also includes a `chat.params` hook that automatically injects `store: false`, but explicit configuration is recommended for clarity and forward compatibility.
+| Field | Purpose |
+|------|---------|
+| model key (`gpt-5.4`) | base model family exposed to OpenCode |
+| `name` | human-readable picker label |
+| `limit` | context/output metadata shown to OpenCode |
+| `modalities` | allowed input/output types |
+| `variants` | reasoning/verbosity presets selected with `--variant` |
+| `options` | per-model defaults when needed |
 
----
+Modern selection example:
 
-## Recommended Structure
+```bash
+opencode run "task" --model=openai/gpt-5.4-mini --variant=high
+```
 
-### Recommended: Config Key + Name ✅
+### Legacy template fields
+
+Legacy templates expose each preset as its own model key.
+
+Example:
 
 ```json
 {
-  "gpt-5-codex-low": {
-    "name": "GPT 5 Codex Low (OAuth)",
-    "options": { "reasoningEffort": "low" }
+  "provider": {
+    "openai": {
+      "models": {
+        "gpt-5.4-high": {
+          "name": "GPT 5.4 High (OAuth)",
+          "limit": {
+            "context": 1000000,
+            "output": 128000
+          },
+          "modalities": {
+            "input": ["text", "image"],
+            "output": ["text"]
+          },
+          "options": {
+            "reasoningEffort": "high",
+            "reasoningSummary": "detailed",
+            "textVerbosity": "medium",
+            "include": ["reasoning.encrypted_content"],
+            "store": false
+          }
+        }
+      }
+    }
   }
 }
 ```
 
-**Benefits:**
-- ✅ Clean config key: `gpt-5-codex-low` (matches Codex CLI presets)
-- ✅ Friendly display: `"GPT 5 Codex Low (OAuth)"` (UX)
-- ✅ No redundant fields
-- ✅ OpenCode auto-sets `id` to config key
+Legacy selection example:
 
-**Why no `id` field?**
-- For OpenAI provider, the `id` field is NOT used (custom loader receives config key)
-- OpenCode defaults `id` to config key if omitted
-- Including it is redundant and creates confusion
-
----
-
-### Minimal Structure (Works but less friendly)
-
-```json
-{
-  "gpt-5-codex-low": {
-    "options": { "reasoningEffort": "low" }
-  }
-}
+```bash
+opencode run "task" --model=openai/gpt-5.4-high
 ```
 
-**What happens:**
-- `id` defaults to: `"gpt-5-codex-low"` (config key)
-- `name` defaults to: `"gpt-5-codex-low"` (config key)
-- TUI shows: `"gpt-5-codex-low"` (less friendly)
-- Plugin normalizes: `"gpt-5-codex-low"` → `"gpt-5-codex"` for API
-- **Works perfectly, just less user-friendly**
+## Model Normalization
 
----
+The plugin normalizes selected model IDs before the upstream API call.
 
-### With id Field (Redundant but Harmless)
+Examples:
 
-```json
-{
-  "gpt-5-codex-low": {
-    "id": "gpt-5-codex",
-    "name": "GPT 5 Codex Low (OAuth)",
-    "options": { "reasoningEffort": "low" }
-  }
-}
+| Selected model | Effective upstream family |
+|------|---------|
+| `openai/gpt-5.4` | `gpt-5.4` |
+| `openai/gpt-5.4-mini-xhigh` | `gpt-5.4-mini` |
+| `openai/gpt-5.1-codex-high` | `gpt-5.1-codex` |
+| `openai/gpt-5-mini` | `gpt-5.4` |
+| `openai/gpt-5-nano` | `gpt-5.4` |
+
+This normalization is why legacy aliases and snapshot-like IDs can still route to a stable family while preserving the user-facing config surface.
+
+## Verification Notes
+
+Use these commands when validating config fields:
+
+```bash
+opencode debug config
+ENABLE_PLUGIN_REQUEST_LOGGING=1 opencode run "ping" --model=openai/gpt-5.4
 ```
 
-**What happens:**
-- `id` field is stored but NOT used by OpenAI custom loader
-- Adds documentation value but is technically redundant
-- Works fine, just verbose
+Important behavior:
 
----
+- `opencode debug config` shows merged config-defined models and variants.
+- `opencode models openai` currently shows only the built-in provider catalog.
+- Because of that, config-defined entries such as `gpt-5.4-mini` may not appear in `opencode models openai` even when they are active in the effective config.
 
-## Summary Table
+## Account Metadata Fields
 
-| Use Case | Which Field? | Example Value |
-|----------|-------------|---------------|
-| **CLI `--model` flag** | Config Key | `openai/gpt-5-codex-low` |
-| **Custom commands** | Config Key | `model: openai/gpt-5-codex-low` |
-| **Agent config** | Config Key | `"model": "openai/gpt-5-codex-low"` |
-| **TUI display** | `name` field | `"GPT 5 Codex Low (OAuth)"` |
-| **Plugin config lookup** | Config Key | `models["gpt-5-codex-low"]` |
-| **AI SDK receives** | Config Key | `body.model = "gpt-5-codex-low"` |
-| **Plugin normalizes** | Transformed | `"gpt-5-codex"` (sent to API) |
-| **TUI persistence** | Config Key | `model_id = "gpt-5-codex-low"` |
-| **Documentation** | `id` field | `"gpt-5-codex"` (base model) |
-| **Model sorting** | `id` field | Used for priority ranking |
+Account storage also includes user-facing metadata fields used by the `codex-*` tools:
 
----
+| Field | Purpose |
+|------|---------|
+| `accountLabel` | display label |
+| `accountTags` | grouping/filter tags |
+| `accountNote` | short reminder text |
 
-## Key Insight for OpenAI Provider
-
-```
-CONFIG KEY is the real identifier! 👑
-  ├─ Used for selection (CLI, TUI, commands)
-  ├─ Used for persistence (saved to ~/.opencode/tui)
-  ├─ Passed to custom loader (getModel receives this)
-  ├─ Sent to AI SDK (body.model = this)
-  └─ Received by plugin (our plugin sees this)
-
-id field is metadata 📝
-  ├─ Documents base model
-  ├─ Used for sorting
-  └─ NOT sent to AI SDK (custom loader uses config key)
-
-name field is UI sugar 🎨
-  └─ Makes TUI model picker user-friendly
-```
-
----
-
-## Why The Bug Happened
-
-**Old Plugin Logic (Broken):**
-```typescript
-const normalizedModel = normalizeModel(body.model);  // "gpt-5-codex-low" → "gpt-5-codex"
-const modelConfig = getModelConfig(normalizedModel, userConfig);  // Lookup "gpt-5-codex"
-```
-
-**Problem:**
-- Plugin received: `"gpt-5-codex-low"` (config key)
-- Plugin normalized first: `"gpt-5-codex"`
-- Plugin looked up config: `models["gpt-5-codex"]` ❌ NOT FOUND
-- Config key was: `models["gpt-5-codex-low"]`
-- **Result:** Per-model options ignored!
-
-**New Plugin Logic (Fixed):**
-```typescript
-const originalModel = body.model;  // "gpt-5-codex-low" (config key)
-const normalizedModel = normalizeModel(body.model);  // "gpt-5-codex" (for API)
-const modelConfig = getModelConfig(originalModel, userConfig);  // Lookup "gpt-5-codex-low" ✅
-```
-
-**Fix:**
-- Use original value (config key) for config lookup ✅
-- Normalize separately for API call ✅
-- **Result:** Per-model options applied correctly!
-
----
-
-## Testing the Understanding
-
-### Test Case 1: Which model does plugin send to API?
-
-**Config:**
-```json
-{
-  "my-custom-name": {
-    "id": "gpt-5-codex",
-    "name": "My Custom Display Name",
-    "options": { "reasoningEffort": "high" }
-  }
-}
-```
-
-**User runs:** `--model=openai/my-custom-name`
-
-**Question:** What model does plugin send to Codex API?
-
-**Answer:**
-1. Plugin receives: `body.model = "my-custom-name"`
-2. Plugin normalizes: `"my-custom-name"` → `"gpt-5-codex"` (contains "codex")
-3. Plugin sends to API: `"gpt-5-codex"` ✅
-
-**The `id` field is NOT used for this!**
-
----
-
-### Test Case 2: How does TUI know what to display?
-
-**Config:**
-```json
-{
-  "ugly-key-123": {
-    "id": "gpt-5",
-    "name": "Beautiful Display Name"
-  }
-}
-```
-
-**Question:** What does TUI model picker show?
-
-**Answer:** `"Beautiful Display Name"` (from `name` field)
-
-**If `name` was omitted:** Would show `"ugly-key-123"` (config key)
-
----
-
-### Test Case 3: How does plugin find config?
-
-**Config:**
-```json
-{
-  "gpt-5-codex-low": {
-    "id": "gpt-5-codex",
-    "options": { "reasoningEffort": "low" }
-  }
-}
-```
-
-**User selects:** `openai/gpt-5-codex-low`
-
-**Question:** How does plugin find the options?
-
-**Answer:**
-1. Plugin receives: `body.model = "gpt-5-codex-low"`
-2. Plugin looks up: `userConfig.models["gpt-5-codex-low"]` ✅
-3. Plugin finds: `{ reasoningEffort: "low" }` ✅
-
-**The lookup uses config key, NOT the `id` field!**
-
----
-
-## Common Mistakes
-
-### ❌ Using id as Config Key
-
-```json
-{
-  "gpt-5-codex": {  // ❌ Can't have multiple variants
-    "id": "gpt-5-codex"
-  }
-}
-```
-
-### ❌ Thinking id Controls Plugin Lookup
-
-```json
-{
-  "my-model": {
-    "id": "gpt-5-codex-low",  // ❌ Plugin won't look up by this!
-    "options": { ... }
-  }
-}
-```
-
-**Plugin looks up by:** `"my-model"` (config key), not `"gpt-5-codex-low"` (id)
-
-### ❌ Forgetting name Field
-
-```json
-{
-  "gpt-5-codex-low": {
-    "id": "gpt-5-codex"
-    // Missing: "name" field
-  }
-}
-```
-
-**Result:** TUI shows `"gpt-5-codex-low"` (works but less friendly)
-
----
-
-## Account Metadata Fields (Storage)
-
-In addition to OpenCode model config fields, account storage now includes user-facing metadata used by `codex-*` account tools:
-
-| Field | Type | Purpose | Updated By |
-|-------|------|---------|------------|
-| `accountLabel` | `string` | Friendly workspace/account label for display | `codex-label` |
-| `accountTags` | `string[]` | Lowercase grouping tags for filtering (`codex-list tag=...`) | `codex-tag` |
-| `accountNote` | `string` | Short per-account reminder text | `codex-note` |
-
-Notes:
-- `accountTags` are normalized (trimmed, lowercased, deduplicated).
-- Empty label/tag/note inputs clear the corresponding field.
-- These fields persist in V3 storage and migrate through normalization paths.
-
----
+These fields are updated by `codex-label`, `codex-tag`, and `codex-note`.
 
 ## See Also
 
-- [CONFIG_FLOW.md](./CONFIG_FLOW.md) - Complete config system guide
-- [ARCHITECTURE.md](./ARCHITECTURE.md) - Technical architecture
-- [BUGS_FIXED.md](./BUGS_FIXED.md) - Bug fixes and testing
+- [CONFIG_FLOW.md](./CONFIG_FLOW.md)
+- [ARCHITECTURE.md](./ARCHITECTURE.md)
+- [../../docs/configuration.md](../../configuration.md)

--- a/docs/development/CONFIG_FLOW.md
+++ b/docs/development/CONFIG_FLOW.md
@@ -1,275 +1,95 @@
-# OpenCode Config Flow: Complete Guide
+# OpenCode Config Flow
 
-This document explains how OpenCode configuration flows from user files through the plugin system to the Codex API.
+This document describes the current config surfaces used by `oc-chatgpt-multi-auth` on `main`.
 
-## Table of Contents
-- [Config Loading Order](#config-loading-order)
-- [Provider Options Flow](#provider-options-flow)
-- [Model Selection & Persistence](#model-selection--persistence)
-- [Plugin Configuration](#plugin-configuration)
-- [Examples](#examples)
-- [Best Practices](#best-practices)
+## Primary Config Surfaces
 
----
+### Global OpenCode config
 
-## Config Loading Order
+The installer writes and updates:
 
-OpenCode loads and merges configuration from multiple sources in this order (**last wins**):
-
-### 1. Global Config
-```
-~/.opencode/config.json
-~/.opencode/opencode.json
-~/.opencode/opencode.jsonc
+```text
+~/.config/opencode/opencode.json
 ```
 
-### 2. Project Configs (traversed upward from cwd)
-```
-<project>/.opencode/opencode.json
-<parent>/.opencode/opencode.json
-... (up to worktree root)
+That file is the primary global config surface used by the shipped install flow in this repository.
+
+### Project override
+
+Project-specific overrides can live in:
+
+```text
+<project>/.opencode.json
 ```
 
-### 3. Custom Config (via flags)
+Use that when you want per-project model or provider overrides without changing the global install.
+
+### One-shot overrides
+
+OpenCode can also accept override content at process start:
+
 ```bash
 OPENCODE_CONFIG=/path/to/config.json opencode
-# or
-OPENCODE_CONFIG_CONTENT='{"model":"openai/gpt-5"}' opencode
+OPENCODE_CONFIG_CONTENT='{"model":"openai/gpt-5.4"}' opencode
 ```
 
-### 4. Auth Configs
-```
-# From .well-known/opencode endpoints (for OAuth providers)
-https://auth.example.com/.well-known/opencode
-```
+### Plugin runtime config
 
-**Source**: `tmp/opencode/packages/opencode/src/config/config.ts:26-51`
+Plugin-specific runtime settings live outside the OpenCode config file:
 
----
-
-## Provider Options Flow
-
-Options are merged at multiple stages before reaching the plugin:
-
-### Stage 1: Database Defaults
-Models.dev provides baseline capabilities for each provider/model.
-
-### Stage 2: Environment Variables
-```bash
-export OPENAI_API_KEY="sk-..."
+```text
+~/.opencode/openai-codex-auth-config.json
 ```
 
-### Stage 3: Custom Loaders
-Plugins can inject options via the `loader()` function.
+That file controls plugin behavior such as retry policy, beginner safe mode, fallback policy, TUI output, and per-project account storage.
 
-### Stage 4: User Config (HIGHEST PRIORITY)
-```json
-{
-  "provider": {
-    "openai": {
-      "options": {
-        "reasoningEffort": "medium",
-        "textVerbosity": "low"
-      }
-    }
-  }
-}
-```
+## Installer Flow
 
-**Result**: User config overrides everything else.
+`scripts/install-opencode-codex-auth.js` performs these steps:
 
-**Source**: `tmp/opencode/packages/opencode/src/provider/provider.ts:236-339`
+1. Load the selected template (`config/opencode-modern.json` by default, `config/opencode-legacy.json` with `--legacy`).
+2. Back up an existing `~/.config/opencode/opencode.json`.
+3. Normalize the plugin list so it ends with plain `oc-chatgpt-multi-auth`.
+4. Replace `provider.openai` with the selected shipped template block.
+5. Clear the cached OpenCode plugin copy under `~/.cache/opencode/`.
 
----
+Important detail:
 
-## Model Selection & Persistence
+- The installer intentionally writes the plugin entry as `oc-chatgpt-multi-auth`, not `oc-chatgpt-multi-auth@latest`.
 
-### Display Names vs Internal IDs
+## Shipped Template Structure
 
-**Your Config** (`config/opencode-legacy.json`):
-```json
-{
-  "provider": {
-    "openai": {
-      "models": {
-        "gpt-5-codex-medium": {
-          "name": "GPT 5 Codex Medium (OAuth)",
-          "limit": {
-            "context": 272000,
-            "output": 128000
-          },
-          "options": {
-            "reasoningEffort": "medium",
-            "reasoningSummary": "auto",
-            "textVerbosity": "medium",
-            "include": [
-              "reasoning.encrypted_content"
-            ],
-            "store": false
-          }
-        }
-      }
-    }
-  }
-}
-```
+### Modern template
 
-**What OpenCode Uses**:
-- **UI Display**: "GPT 5 Codex Medium (OAuth)" ✅
-- **Persistence**: `provider_id: "openai"` + `model_id: "gpt-5-codex-medium"` ✅
-- **Plugin lookup**: `models["gpt-5-codex-medium"]` → used to build Codex request ✅
+`config/opencode-modern.json` is the default for OpenCode `v1.0.210+`.
 
-### TUI Persistence
+It currently ships:
 
-The TUI stores recently used models in `~/.opencode/tui`:
+- 7 base model families
+- 26 total variants
+- `gpt-5.4` and `gpt-5.4-mini` at 1,000,000 context / 128,000 output
+- `store: false` plus `include: ["reasoning.encrypted_content"]`
 
-```toml
-[[recently_used_models]]
-provider_id = "openai"
-model_id = "gpt-5-codex"
-last_used = 2025-10-12T10:30:00Z
-```
+Example shape:
 
-**Key Point**: Custom display names are **UI-only**. The underlying `id` field is what gets persisted and sent to APIs.
-
-**Source**: `tmp/opencode/packages/tui/internal/app/state.go:54-79`
-
----
-
-## Plugin Configuration
-
-### How This Plugin Receives Config
-
-**Plugin Entry Point** (`index.ts:64-86`):
-```typescript
-async loader(getAuth: () => Promise<Auth>, provider: unknown) {
-  const providerConfig = provider as {
-    options?: Record<string, unknown>;
-    models?: UserConfig["models"]
-  };
-
-  const userConfig: UserConfig = {
-    global: providerConfig?.options || {},  // Global options
-    models: providerConfig?.models || {},   // Per-model options
-  };
-
-  // ... use userConfig in custom fetch()
-}
-```
-
-### Config Structure
-
-```typescript
-type UserConfig = {
-  global: {
-    // Applied to ALL models
-    reasoningEffort?: "minimal" | "low" | "medium" | "high";
-    textVerbosity?: "low" | "medium" | "high";
-    include?: string[];
-  };
-  models: {
-    [modelName: string]: {
-      options?: {
-        // Override global for specific model
-        reasoningEffort?: "minimal" | "low" | "medium" | "high";
-        textVerbosity?: "low" | "medium" | "high";
-      };
-    };
-  };
-};
-```
-
-### Option Precedence
-
-For a given model, options are merged:
-1. **Global options** (`provider.openai.options`)
-2. **Model-specific options** (`provider.openai.models[modelName].options`) ← WINS
-
-**Implementation**: `lib/request/request-transformer.ts:getModelConfig()`
-
----
-
-## Examples
-
-### Example 1: Global Options Only
 ```json
 {
   "plugin": ["oc-chatgpt-multi-auth"],
-  "provider": {
-    "openai": {
-      "options": {
-        "reasoningEffort": "medium",
-        "textVerbosity": "medium",
-        "include": ["reasoning.encrypted_content"]
-      }
-    }
-  }
-}
-```
-
-**Result**: All OpenAI models use these options.
-
-### Example 2: Per-Model Override
-```json
-{
-  "plugin": ["oc-chatgpt-multi-auth"],
-  "provider": {
-    "openai": {
-      "options": {
-        "reasoningEffort": "medium",
-        "textVerbosity": "medium"
-      },
-      "models": {
-        "gpt-5-codex-high": {
-          "name": "GPT 5 Codex High (OAuth)",
-          "options": {
-            "reasoningEffort": "high",
-            "reasoningSummary": "detailed"
-          }
-        },
-        "gpt-5-nano": {
-          "name": "GPT 5 Nano (OAuth)",
-          "options": {
-            "reasoningEffort": "minimal",
-            "textVerbosity": "low"
-          }
-        }
-      }
-    }
-  }
-}
-```
-
-**Result**:
-- `gpt-5-codex-high` uses `reasoningEffort: "high"` (overridden) + `textVerbosity: "medium"` (from global)
-- `gpt-5-nano` uses `reasoningEffort: "minimal"` + `textVerbosity: "low"` (both overridden)
-
-### Example 3: Full Configuration
-```json
-{
-  "$schema": "https://opencode.ai/config.json",
-  "plugin": ["oc-chatgpt-multi-auth"],
-  "model": "openai/gpt-5-codex-medium",
   "provider": {
     "openai": {
       "options": {
         "reasoningEffort": "medium",
         "reasoningSummary": "auto",
         "textVerbosity": "medium",
-        "include": ["reasoning.encrypted_content"]
+        "include": ["reasoning.encrypted_content"],
+        "store": false
       },
       "models": {
-        "gpt-5-codex-low": {
-          "name": "GPT 5 Codex Low (OAuth)",
-          "options": {
-            "reasoningEffort": "low"
-          }
-        },
-        "gpt-5-codex-high": {
-          "name": "GPT 5 Codex High (OAuth)",
-          "options": {
-            "reasoningEffort": "high",
-            "reasoningSummary": "detailed"
+        "gpt-5.4": {
+          "name": "GPT 5.4 (OAuth)",
+          "variants": {
+            "medium": { "reasoningEffort": "medium" },
+            "high": { "reasoningEffort": "high" }
           }
         }
       }
@@ -278,133 +98,72 @@ For a given model, options are merged:
 }
 ```
 
----
+Modern OpenCode selection uses:
 
-## Best Practices
-
-### 1. Use Per-Model Options for Variants
-Instead of duplicating global options, override only what's different:
-
-❌ **Bad**:
-```json
-{
-  "models": {
-    "gpt-5-low": {
-      "id": "gpt-5",
-      "options": {
-        "reasoningEffort": "low",
-        "textVerbosity": "low",
-        "include": ["reasoning.encrypted_content"]
-      }
-    },
-    "gpt-5-high": {
-      "id": "gpt-5",
-      "options": {
-        "reasoningEffort": "high",
-        "textVerbosity": "high",
-        "include": ["reasoning.encrypted_content"]
-      }
-    }
-  }
-}
+```bash
+opencode run "task" --model=openai/gpt-5.4 --variant=high
 ```
 
-✅ **Good**:
-```json
-{
-  "options": {
-    "include": ["reasoning.encrypted_content"]
-  },
-  "models": {
-    "gpt-5-low": {
-      "id": "gpt-5",
-      "options": {
-        "reasoningEffort": "low",
-        "textVerbosity": "low"
-      }
-    },
-    "gpt-5-high": {
-      "id": "gpt-5",
-      "options": {
-        "reasoningEffort": "high",
-        "textVerbosity": "high"
-      }
-    }
-  }
-}
+### Legacy template
+
+`config/opencode-legacy.json` is for OpenCode `v1.0.209` and earlier.
+
+It currently ships:
+
+- 26 explicit model entries
+- separate model IDs such as `gpt-5.4-high` and `gpt-5.4-mini-xhigh`
+- the same OpenAI provider defaults (`store: false`, `reasoning.encrypted_content`)
+
+Legacy OpenCode selection uses:
+
+```bash
+opencode run "task" --model=openai/gpt-5.4-high
 ```
 
-### 2. Keep Display Names Meaningful
-Custom model names help you remember what each variant does:
+## Runtime Resolution
 
-```json
-{
-  "models": {
-    "GPT 5 Codex - Fast & Cheap": {
-      "id": "gpt-5-codex",
-      "options": { "reasoningEffort": "low" }
-    },
-    "GPT 5 Codex - Balanced": {
-      "id": "gpt-5-codex",
-      "options": { "reasoningEffort": "medium" }
-    },
-    "GPT 5 Codex - Max Quality": {
-      "id": "gpt-5-codex",
-      "options": { "reasoningEffort": "high" }
-    }
-  }
-}
+At runtime, OpenCode passes `provider.openai.options` and `provider.openai.models` into the plugin loader. The plugin then:
+
+1. Reads global provider options.
+2. Reads per-model definitions.
+3. Applies request-shaping behavior (`native` by default, `legacy` when explicitly enabled).
+4. Normalizes selected model IDs to canonical upstream Codex/ChatGPT model families before the final API call.
+
+Examples:
+
+- `openai/gpt-5.4` stays `gpt-5.4`
+- `openai/gpt-5.4-mini-xhigh` normalizes to `gpt-5.4-mini`
+- legacy aliases such as `gpt-5-mini` normalize to `gpt-5.4`
+
+## Verification
+
+Use these commands when checking the effective config:
+
+```bash
+opencode debug config
+ENABLE_PLUGIN_REQUEST_LOGGING=1 opencode run "ping" --model=openai/gpt-5.4
 ```
 
-### 3. Set Defaults at Global Level
-Most common settings should be global:
+Important runtime behavior:
 
-```json
-{
-  "options": {
-    "reasoningEffort": "medium",
-    "reasoningSummary": "auto",
-    "textVerbosity": "medium",
-    "include": ["reasoning.encrypted_content"]
-  }
-}
-```
+- `opencode debug config` shows merged provider models from your config.
+- `opencode models openai` currently shows OpenCode's built-in provider catalog only.
+- Because of that, config-defined entries such as `gpt-5.4-mini` can appear in `opencode debug config` while being omitted from `opencode models openai`.
 
-### 4. Use Config Files, Not Environment Variables
-While you can set `CODEX_MODE=0` to disable the bridge prompt, it's better to document such settings in config files:
+## File Locations
 
-❌ **Bad**: `CODEX_MODE=0 opencode`
-
-✅ **Good**: Create `~/.opencode/openai-codex-auth-config.json`:
-```json
-{
-  "codexMode": false
-}
-```
-
----
-
-## Troubleshooting
-
-### Config Not Being Applied
-1. Check config file syntax with `jq . < config.json`
-2. Verify config file location (use absolute paths)
-3. Check OpenCode logs for config load errors
-4. Use `OPENCODE_CONFIG_CONTENT` to test minimal configs
-
-### Model Not Persisting
-1. TUI remembers the `id` field, not the display name
-2. Check `~/.opencode/tui` for recently used models
-3. Verify your config has the correct `id` field
-
-### Options Not Taking Effect
-1. Model-specific options override global options
-2. Plugin receives merged config from OpenCode
-3. Add debug logging to verify what plugin receives
-
----
+| Path | Purpose |
+|------|---------|
+| `~/.config/opencode/opencode.json` | global OpenCode config used by the installer |
+| `<project>/.opencode.json` | project-local OpenCode override |
+| `~/.opencode/openai-codex-auth-config.json` | plugin runtime config |
+| `~/.opencode/auth/openai.json` | OAuth token storage |
+| `~/.opencode/openai-codex-accounts.json` | global account storage |
+| `~/.opencode/projects/<project-key>/openai-codex-accounts.json` | per-project account storage |
+| `~/.opencode/logs/codex-plugin/` | plugin request/debug logs |
 
 ## See Also
-- [ARCHITECTURE.md](./ARCHITECTURE.md) - Plugin architecture and design decisions
-- [OpenCode Config Schema](https://opencode.ai/config.json) - Official schema
-- [Models.dev](https://models.dev) - Model capability database
+
+- [CONFIG_FIELDS.md](./CONFIG_FIELDS.md)
+- [ARCHITECTURE.md](./ARCHITECTURE.md)
+- [../../config/README.md](../../config/README.md)

--- a/docs/development/TESTING.md
+++ b/docs/development/TESTING.md
@@ -1,791 +1,151 @@
-# Complete Test Scenarios
+# Testing Guide
 
-Comprehensive testing matrix for all config scenarios and backwards compatibility.
+This guide describes the current validation surface for `oc-chatgpt-multi-auth` on `main`.
 
-## Current Coverage Additions (Beginner + Backup Hardening)
+## Release-Grade Commands
 
-The current codebase includes dedicated tests for the beginner operations layer and safer import/export flows:
-
-- `test/beginner-ui.test.ts`
-  - checklist summary behavior
-  - doctor findings and severity mapping
-  - next-action recommendation logic
-- `test/index.test.ts`
-  - `codex-doctor fix` remediation behavior
-  - `codex-setup wizard` fallback behavior
-  - interactive index command handling for `codex-switch`, `codex-label`, `codex-remove`
-  - `codex-tag`, `codex-note`, and `codex-list` tag-filter behavior
-  - `codex-export` default timestamped path behavior
-  - `codex-import dryRun` preview behavior
-- `test/storage.test.ts`
-  - `previewImportAccounts()` result validation
-  - `createTimestampedBackupPath()` path generation
-- `test/plugin-config.test.ts`
-  - `beginnerSafeMode` default + env override (`CODEX_AUTH_BEGINNER_SAFE_MODE`)
-- `test/schemas.test.ts`
-  - schema validation for `accountTags` and `accountNote`
-
-Recommended validation command before release:
+Run these before opening a PR:
 
 ```bash
 npm run lint
 npm run typecheck
 npm test
+npm run build
 ```
 
-## Test Scenarios Matrix
-
-### Scenario 1: Default OpenCode Models (No Custom Config)
-
-**Config:**
-```json
-{
-  "plugin": ["oc-chatgpt-multi-auth"]
-}
-```
-
-**Available Models:** (from OpenCode's models.dev database)
-- `gpt-5`
-- `gpt-5-codex`
-- `gpt-5-mini`
-- `gpt-5-nano`
-
-**Test Cases:**
-
-| User Selects | Plugin Receives | Normalizes To | Config Lookup | API Receives | Result |
-|--------------|-----------------|---------------|---------------|--------------|--------|
-| `openai/gpt-5` | `"gpt-5"` | `"gpt-5.4"` | `models["gpt-5"]` → undefined | `"gpt-5.4"` | ✅ Uses global options |
-| `openai/gpt-5-codex` | `"gpt-5-codex"` | `"gpt-5-codex"` | `models["gpt-5-codex"]` → undefined | `"gpt-5-codex"` | ✅ Uses global options |
-| `openai/gpt-5-mini` | `"gpt-5-mini"` | `"gpt-5.4"` | `models["gpt-5-mini"]` → undefined | `"gpt-5.4"` | ✅ Uses global options |
-| `openai/gpt-5-nano` | `"gpt-5-nano"` | `"gpt-5.4"` | `models["gpt-5-nano"]` → undefined | `"gpt-5.4"` | ✅ Uses global options |
-
-**Expected Behavior:**
-- ✅ All models work with global options
-- ✅ Normalized correctly for API
-- ✅ No errors
-
----
-
-### Scenario 2: Custom Config with Preset Names (New Style)
-
-**Config:**
-```json
-{
-  "plugin": ["oc-chatgpt-multi-auth"],
-  "provider": {
-    "openai": {
-      "options": {
-        "reasoningEffort": "medium"
-      },
-      "models": {
-        "gpt-5-codex-low": {
-          "name": "GPT 5 Codex Low (OAuth)",
-          "options": { "reasoningEffort": "low" }
-        },
-        "gpt-5-codex-high": {
-          "name": "GPT 5 Codex High (OAuth)",
-          "options": { "reasoningEffort": "high" }
-        }
-      }
-    }
-  }
-}
-```
-
-**Test Cases:**
-
-| User Selects | Plugin Receives | Config Lookup | Resolved Options | API Receives | Result |
-|--------------|-----------------|---------------|------------------|--------------|--------|
-| `openai/gpt-5-codex-low` | `"gpt-5-codex-low"` | Found ✅ | `{ reasoningEffort: "low" }` | `"gpt-5-codex"` | ✅ Per-model |
-| `openai/gpt-5-codex-high` | `"gpt-5-codex-high"` | Found ✅ | `{ reasoningEffort: "high" }` | `"gpt-5-codex"` | ✅ Per-model |
-| `openai/gpt-5-codex` | `"gpt-5-codex"` | Not found | `{ reasoningEffort: "medium" }` | `"gpt-5-codex"` | ✅ Global |
-
-**Expected Behavior:**
-- ✅ Custom variants use per-model options
-- ✅ Default `gpt-5-codex` uses global options
-- ✅ Both normalize to `"gpt-5-codex"` for API
-
----
-
-### Scenario 3: Old Config (Backwards Compatibility)
-
-**Config:**
-```json
-{
-  "plugin": ["oc-chatgpt-multi-auth"],
-  "provider": {
-    "openai": {
-      "options": {
-        "reasoningEffort": "medium"
-      },
-      "models": {
-        "GPT 5 Codex Low (ChatGPT Subscription)": {
-          "id": "gpt-5-codex",
-          "options": { "reasoningEffort": "low" }
-        }
-      }
-    }
-  }
-}
-```
-
-**Test Cases:**
-
-| User Selects | Plugin Receives | Config Lookup | Resolved Options | API Receives | Result |
-|--------------|-----------------|---------------|------------------|--------------|--------|
-| `openai/GPT 5 Codex Low (ChatGPT Subscription)` | `"GPT 5 Codex Low (ChatGPT Subscription)"` | Found ✅ | `{ reasoningEffort: "low" }` | `"gpt-5-codex"` | ✅ Per-model |
-
-**Expected Behavior:**
-- ✅ Old config keys still work
-- ✅ Per-model options applied correctly
-- ✅ Normalizes correctly for API
-
----
-
-### Scenario 4: Mixed Config (Default + Custom)
-
-**Config:**
-```json
-{
-  "plugin": ["oc-chatgpt-multi-auth"],
-  "provider": {
-    "openai": {
-      "models": {
-        "gpt-5-codex-low": {
-          "name": "GPT 5 Codex Low (OAuth)",
-          "options": { "reasoningEffort": "low" }
-        }
-      }
-    }
-  }
-}
-```
-
-**Available Models:**
-- `gpt-5-codex-low` (custom)
-- `gpt-5-codex` (default from models.dev)
-- `gpt-5` (default from models.dev)
-
-**Test Cases:**
-
-| User Selects | Config Lookup | Uses Options | Result |
-|--------------|---------------|--------------|--------|
-| `openai/gpt-5-codex-low` | Found ✅ | Per-model | ✅ Custom config |
-| `openai/gpt-5-codex` | Not found | Global | ✅ Default model |
-| `openai/gpt-5` | Not found | Global | ✅ Default model |
-
-**Expected Behavior:**
-- ✅ Custom variants use per-model options
-- ✅ Default models use global options
-- ✅ Both types coexist peacefully
-
----
-
-### Scenario 5: Edge Cases
-
-#### 5a: Model Name with Uppercase
-
-**Config:**
-```json
-{
-  "models": {
-    "GPT-5-CODEX-HIGH": {
-      "options": { "reasoningEffort": "high" }
-    }
-  }
-}
-```
-
-**Test:**
-```
-User selects: openai/GPT-5-CODEX-HIGH
-Plugin receives: "GPT-5-CODEX-HIGH"
-normalizeModel: "GPT-5-CODEX-HIGH" → "gpt-5-codex" ✅ (includes "codex")
-Config lookup: models["GPT-5-CODEX-HIGH"] → Found ✅
-API receives: "gpt-5-codex" ✅
-```
-
-**Result:** ✅ Works (case-insensitive includes())
-
----
-
-#### 5b: Model Name with Special Characters
-
-**Config:**
-```json
-{
-  "models": {
-    "my-gpt5-codex-variant": {
-      "options": { "reasoningEffort": "high" }
-    }
-  }
-}
-```
-
-**Test:**
-```
-User selects: openai/my-gpt5-codex-variant
-Plugin receives: "my-gpt5-codex-variant"
-normalizeModel: "my-gpt5-codex-variant" → "gpt-5-codex" ✅ (includes "codex")
-Config lookup: models["my-gpt5-codex-variant"] → Found ✅
-API receives: "gpt-5-codex" ✅
-```
-
-**Result:** ✅ Works (normalization handles it)
-
----
-
-#### 5c: No Config, No Model Specified
-
-**Config:**
-```json
-{
-  "plugin": ["oc-chatgpt-multi-auth"]
-}
-```
-
-**Test:**
-```
-User selects: (none - uses OpenCode default)
-Plugin receives: undefined or default from OpenCode
-normalizeModel: undefined → "gpt-5.4" ✅ (fallback)
-Config lookup: models[undefined] → undefined
-API receives: "gpt-5.4" ✅
-```
-
-**Result:** ✅ Works (safe fallback)
-
----
-
-#### 5d: Only `gpt-5` in Name (No `codex`)
-
-**Config:**
-```json
-{
-  "models": {
-    "my-gpt-5-variant": {
-      "options": { "reasoningEffort": "high" }
-    }
-  }
-}
-```
-
-**Test:**
-```
-User selects: openai/my-gpt-5-variant
-Plugin receives: "my-gpt-5-variant"
-normalizeModel: "my-gpt-5-variant" → "gpt-5.4" ✅ (includes "gpt-5", not "codex")
-Config lookup: models["my-gpt-5-variant"] → Found ✅
-API receives: "gpt-5.4" ✅
-```
-
-**Result:** ✅ Works (correct model selected)
-
----
-
-### Scenario 6: Multi-Turn Conversation (store:false Test)
-
-**Config:** Any
-
-**Test Sequence:**
-```
-Turn 1: > write hello to test.txt
-Turn 2: > read the file
-Turn 3: > what did you write?
-Turn 4: > now delete it
-```
-
-**What Plugin Should Do:**
-
-| Turn | Input Has IDs? | Filter Result | Encrypted Content | Result |
-|------|---------------|---------------|-------------------|--------|
-| 1 | No | No filtering needed | Received in response | ✅ Works |
-| 2 | Yes (from Turn 1) | ALL removed ✅ | Sent back in request | ✅ Works |
-| 3 | Yes (from Turn 1-2) | ALL removed ✅ | Sent back in request | ✅ Works |
-| 4 | Yes (from Turn 1-3) | ALL removed ✅ | Sent back in request | ✅ Works |
-
-**Expected Behavior:**
-- ✅ No "item not found" errors on any turn
-- ✅ Context preserved via encrypted reasoning
-- ✅ Debug log shows: "Successfully removed all X message IDs"
-
----
-
-## Backwards Compatibility Testing
-
-### Test Matrix
-
-| Plugin Version | Config Format | Expected Result |
-|----------------|--------------|-----------------|
-| **Old (<2.1.2)** | Long names + id | ❌ Per-model options broken, ID errors |
-| **Old (<2.1.2)** | Short names | ❌ Per-model options broken, ID errors |
-| **New (2.1.2+)** | Long names + id | ✅ **ALL FIXED** |
-| **New (2.1.2+)** | Short names | ✅ **ALL FIXED** |
-| **New (2.1.2+)** | Short names (no id) | ✅ **OPTIMAL** |
-
-### Backwards Compatibility Tests
-
-#### Test 1: Old Plugin User Upgrades
-
-**Before (Plugin v2.1.1):**
-```json
-{
-  "models": {
-    "GPT 5 Codex Low (ChatGPT Subscription)": {
-      "id": "gpt-5-codex",
-      "options": { "reasoningEffort": "low" }
-    }
-  }
-}
-```
-
-**After (Plugin v2.1.2):**
-- Keep same config
-- Plugin now finds per-model options ✅
-- No "item not found" errors ✅
-
-**Result:** ✅ **Works without config changes**
-
----
-
-#### Test 2: New User with Recommended Config
-
-**Config:**
-```json
-{
-  "models": {
-    "gpt-5-codex-low": {
-      "name": "GPT 5 Codex Low (OAuth)",
-      "options": { "reasoningEffort": "low" }
-    }
-  }
-}
-```
-
-**Expected:**
-- CLI: `--model=openai/gpt-5-codex-low` ✅
-- TUI: Shows "GPT 5 Codex Low (OAuth)" ✅
-- Plugin: Finds and applies per-model options ✅
-- API: Receives `"gpt-5-codex"` ✅
-
-**Result:** ✅ **Optimal experience**
-
----
-
-#### Test 3: Minimal Config (No Custom Models)
-
-**Config:**
-```json
-{
-  "plugin": ["oc-chatgpt-multi-auth"],
-  "model": "openai/gpt-5-codex"
-}
-```
-
-**Expected:**
-- Uses default OpenCode model: `gpt-5-codex`
-- Plugin applies: Global options + Codex defaults
-- No errors ✅
-
-**Result:** ✅ **Works out of the box**
-
----
-
-## Debug Logging Test Cases
-
-### Enable Debug Mode
+What they cover:
+
+- `lint`: ESLint for TypeScript sources and `scripts/`
+- `typecheck`: `tsc --noEmit`
+- `test`: Vitest suite across auth, config, request transformation, storage, UI, recovery, and rotation
+- `build`: compile TypeScript and copy `lib/oauth-success.html` into `dist/lib/`
+
+## Current High-Value Test Areas
+
+Representative suites on `main`:
+
+| File / area | Focus |
+|------|---------|
+| `test/gpt54-models.test.ts` | GPT-5.4 family defaults and model surface |
+| `test/request-transformer.test.ts` | model normalization, request shaping, `store: false`, reasoning options |
+| `test/config.test.ts` | config loading and provider model handling |
+| `test/plugin-config.test.ts` | plugin runtime config defaults and env overrides |
+| `test/index.test.ts` | tool registration, beginner flows, account command behavior |
+| `test/beginner-ui.test.ts` | checklist, doctor findings, next-action output |
+| `test/storage.test.ts` / `test/storage-async.test.ts` | account persistence, backup paths, import/export safety |
+| `test/recovery*.test.ts` | recovery storage and resume behavior |
+| `test/rotation*.test.ts` / `test/refresh-queue.test.ts` | multi-account rotation, refresh serialization, retry flow |
+| `test/auth*.test.ts` / `test/oauth-server.integration.test.ts` | OAuth flow and auth edge cases |
+| `test/ui-*.test.ts` | TUI formatting, runtime, theme behavior |
+
+The repository also includes `test/property/` and `test/chaos/` directories for higher-variance regression coverage.
+
+## Documentation-Adjacent Checks
+
+When documentation changes touch setup or config guidance, verify the docs against the live repo surface:
+
+1. Confirm commands exist in `index.ts`.
+2. Confirm config examples match `config/opencode-modern.json`, `config/opencode-legacy.json`, and `config/minimal-opencode.json`.
+3. Confirm install/update guidance matches `scripts/install-opencode-codex-auth.js`.
+4. Confirm repo scripts listed in docs still exist in `package.json`.
+
+Useful commands:
 
 ```bash
-DEBUG_CODEX_PLUGIN=1 opencode run "test" --model=openai/gpt-5-codex-low
+rg -n "codex-setup|codex-doctor|codex-next|codex-help" index.ts
+rg -n "\"build\"|\"typecheck\"|\"lint\"|\"test\"" package.json
 ```
 
-### Expected Debug Output
+## Manual Smoke Checks
 
-#### Case 1: Custom Model with Config
+Use these when a change affects setup, auth flow, or account operations.
 
-```
-[openai-codex-plugin] Debug logging ENABLED
-[openai-codex-plugin] Model config lookup: "gpt-5-codex-low" → normalized to "gpt-5-codex" for API {
-  hasModelSpecificConfig: true,
-  resolvedConfig: {
-    reasoningEffort: 'low',
-    textVerbosity: 'medium',
-    reasoningSummary: 'auto',
-    include: ['reasoning.encrypted_content']
-  }
-}
-[openai-codex-plugin] Filtering 0 message IDs from input: []
-```
-
-✅ **Verify:** `hasModelSpecificConfig: true` confirms per-model options found
-
----
-
-#### Case 2: Default Model (No Custom Config)
+### Install + config smoke
 
 ```bash
-DEBUG_CODEX_PLUGIN=1 opencode run "test" --model=openai/gpt-5-codex
+npx -y oc-chatgpt-multi-auth@latest --dry-run
+opencode debug config
 ```
 
-```
-[openai-codex-plugin] Debug logging ENABLED
-[openai-codex-plugin] Model config lookup: "gpt-5-codex" → normalized to "gpt-5-codex" for API {
-  hasModelSpecificConfig: false,
-  resolvedConfig: {
-    reasoningEffort: 'medium',
-    textVerbosity: 'medium',
-    reasoningSummary: 'auto',
-    include: ['reasoning.encrypted_content']
-  }
-}
-[openai-codex-plugin] Filtering 0 message IDs from input: []
-```
+Verify:
 
-✅ **Verify:** `hasModelSpecificConfig: false` confirms using global options
+- the global config path is `~/.config/opencode/opencode.json`
+- the plugin entry resolves to `oc-chatgpt-multi-auth`
+- the selected template contributes the expected `provider.openai` block
 
----
-
-#### Case 3: Multi-Turn with ID Filtering
-
-```
-[openai-codex-plugin] Filtering 3 message IDs from input: ['msg_abc123', 'rs_xyz789', 'msg_def456']
-[openai-codex-plugin] Successfully removed all 3 message IDs
-```
-
-✅ **Verify:** All IDs removed, no warnings
-
----
-
-#### Case 4: Warning if IDs Leak (Should Never Happen)
-
-```
-[openai-codex-plugin] WARNING: 1 IDs still present after filtering: ['msg_abc123']
-```
-
-❌ **This would indicate a bug** - should never appear
-
----
-
-## Integration Test Plan
-
-### Manual Testing Procedure
-
-#### Step 1: Fresh Install Test
+### Model surface smoke
 
 ```bash
-# 1. Clear cache
-(cd ~ && rm -rf .cache/opencode/node_modules/oc-chatgpt-multi-auth)
-
-# 2. Use minimal config
-cat > ~/.config/opencode/opencode.json <<'EOF'
-{
-  "plugin": ["oc-chatgpt-multi-auth"],
-  "model": "openai/gpt-5-codex"
-}
-EOF
-
-# 3. Test default model
-DEBUG_CODEX_PLUGIN=1 opencode run "write hello world to test.txt"
+opencode debug config
+opencode models openai
 ```
 
-**Verify:**
-- ✅ Plugin installs automatically
-- ✅ Auth works
-- ✅ Debug log shows: `hasModelSpecificConfig: false`
-- ✅ Model normalizes to `"gpt-5-codex"`
-- ✅ No errors
+Important note:
 
----
+- `opencode debug config` shows merged custom/template model entries
+- `opencode models openai` currently shows only OpenCode's built-in provider catalog
 
-#### Step 2: Custom Config Test
+### Request-path smoke
 
 ```bash
-# Update config with custom models
-cat > ~/.config/opencode/opencode.json <<'EOF'
-{
-  "plugin": ["oc-chatgpt-multi-auth"],
-  "provider": {
-    "openai": {
-      "models": {
-        "gpt-5-codex-low": {
-          "name": "GPT 5 Codex Low (OAuth)",
-          "options": { "reasoningEffort": "low" }
-        },
-        "gpt-5-codex-high": {
-          "name": "GPT 5 Codex High (OAuth)",
-          "options": { "reasoningEffort": "high" }
-        }
-      }
-    }
-  }
-}
-EOF
-
-# Test per-model options
-DEBUG_CODEX_PLUGIN=1 opencode run "test low" --model=openai/gpt-5-codex-low
-DEBUG_CODEX_PLUGIN=1 opencode run "test high" --model=openai/gpt-5-codex-high
+ENABLE_PLUGIN_REQUEST_LOGGING=1 opencode run "ping" --model=openai/gpt-5.4
 ```
 
-**Verify:**
-- ✅ Debug log shows: `hasModelSpecificConfig: true` for both
-- ✅ Different `reasoningEffort` values in logs
-- ✅ TUI shows friendly names
+Verify:
 
----
+- log files appear under `~/.opencode/logs/codex-plugin/`
+- transformed requests keep `store: false`
+- `reasoning.encrypted_content` is included
 
-#### Step 3: Multi-Turn Test (Critical for store:false)
+### Beginner command smoke
+
+Run these in an interactive session:
+
+```text
+codex-setup
+codex-setup --wizard
+codex-doctor
+codex-doctor --fix
+codex-next
+codex-list
+```
+
+Verify:
+
+- checklist and wizard output render cleanly
+- doctor findings and next-action output remain coherent
+- commands that omit `index` degrade gracefully outside interactive TTYs
+
+## Failure Triage
+
+If validation fails, sort the failure first:
+
+| Surface | Typical command |
+|------|---------|
+| lint/style | `npm run lint` |
+| type drift | `npm run typecheck` |
+| runtime or transform behavior | `npm test -- request-transformer` |
+| account storage / migration | `npm test -- storage` |
+| UI command output | `npm test -- index` or `npm test -- beginner-ui` |
+
+For request-path debugging:
 
 ```bash
-DEBUG_CODEX_PLUGIN=1 opencode --model=openai/gpt-5-codex-medium
+DEBUG_CODEX_PLUGIN=1 ENABLE_PLUGIN_REQUEST_LOGGING=1 CODEX_PLUGIN_LOG_BODIES=1 opencode run "ping" --model=openai/gpt-5.4
 ```
 
-```
-> write "test content" to file1.txt
-> read file1.txt
-> what did you just write?
-> create file2.txt with different content
-> compare the two files
-```
+Use that only when you need payload-level detail because it can log sensitive request and response bodies.
 
-**Verify:**
-- ✅ No "item not found" errors on ANY turn
-- ✅ Debug shows IDs removed on turns 2+
-- ✅ Context is maintained across turns
-- ✅ All tool calls work correctly
+## PR Checklist
 
----
-
-#### Step 4: Model Switching Test
-
-```bash
-DEBUG_CODEX_PLUGIN=1 opencode
-```
-
-```
-> /model openai/gpt-5-codex-low
-> write hello to test.txt
-> /model openai/gpt-5-codex-high
-> write goodbye to test2.txt
-```
-
-**Verify:**
-- ✅ Different reasoning efforts logged for each model
-- ✅ Per-model options applied correctly
-- ✅ No errors when switching
-
----
-
-#### Step 5: TUI Persistence Test
-
-```bash
-# 1. Start opencode
-opencode --model=openai/gpt-5-codex-high
-
-# 2. Run a command
-> write test
-
-# 3. Exit (ctrl+c)
-
-# 4. Restart
-opencode
-
-# 5. Check which model is selected
-> /model
-```
-
-**Verify:**
-- ✅ Last used model is `gpt-5-codex-high`
-- ✅ Model is auto-selected on restart
-- ✅ TUI shows correct model highlighted
-
----
-
-## Normalization Edge Cases
-
-### Test: normalizeModel() Coverage
-
-```typescript
-normalizeModel("gpt-5.4")               // → "gpt-5.4" ✅
-normalizeModel("gpt-5.4-xhigh")         // → "gpt-5.4" ✅
-normalizeModel("gpt-5.4-pro-high")      // → "gpt-5.4-pro" ✅
-normalizeModel("gpt-5.2-codex")         // → "gpt-5-codex" ✅
-normalizeModel("gpt-5.2-codex-high")    // → "gpt-5-codex" ✅
-normalizeModel("gpt-5.2-xhigh")         // → "gpt-5.2" ✅
-normalizeModel("gpt-5.1-codex-max-xhigh")// → "gpt-5.1-codex-max" ✅
-normalizeModel("gpt-5.1-codex-mini-high")// → "gpt-5.1-codex-mini" ✅
-normalizeModel("codex-mini-latest")     // → "gpt-5.1-codex-mini" ✅
-normalizeModel("gpt-5.1-codex")         // → "gpt-5-codex" ✅
-normalizeModel("gpt-5.1")               // → "gpt-5.1" ✅
-normalizeModel("my-codex-model")        // → "gpt-5-codex" ✅
-normalizeModel("gpt-5")                 // → "gpt-5.4" ✅
-normalizeModel("gpt-5-mini")            // → "gpt-5.4" ✅
-normalizeModel("gpt-5-nano")            // → "gpt-5.4" ✅
-normalizeModel("GPT 5.4 Pro High")      // → "gpt-5.4-pro" ✅
-normalizeModel(undefined)                 // → "gpt-5.4" ✅
-normalizeModel("random-model")          // → "gpt-5.4" ✅ (fallback)
-```
-
-**Implementation:**
-```typescript
-export function normalizeModel(model: string | undefined): string {
-  if (!model) return "gpt-5.4";
-
-  const modelId = model.includes("/") ? model.split("/").pop() ?? model : model;
-  const mappedModel = getNormalizedModel(modelId);
-  if (mappedModel) return mappedModel;
-
-  const normalized = modelId.toLowerCase();
-
-  if (normalized.includes("gpt-5.4-pro") || normalized.includes("gpt 5.4 pro")) {
-    return "gpt-5.4-pro";
-  }
-  if (normalized.includes("gpt-5.4") || normalized.includes("gpt 5.4")) {
-    return "gpt-5.4";
-  }
-  if (normalized.includes("gpt-5.2-codex") || normalized.includes("gpt 5.2 codex")) {
-    return "gpt-5-codex";
-  }
-  if (normalized.includes("gpt-5.2") || normalized.includes("gpt 5.2")) {
-    return "gpt-5.2";
-  }
-  if (normalized.includes("gpt-5.1-codex-max") || normalized.includes("gpt 5.1 codex max")) {
-    return "gpt-5.1-codex-max";
-  }
-  if (normalized.includes("gpt-5.1-codex-mini") || normalized.includes("gpt 5.1 codex mini")) {
-    return "gpt-5.1-codex-mini";
-  }
-  if (normalized.includes("codex")) {
-    return "gpt-5-codex";
-  }
-  if (normalized.includes("gpt-5") || normalized.includes("gpt 5")) {
-    return "gpt-5.4";
-  }
-  return "gpt-5.4";
-}
-```
-
-**Why this works:**
-- ✅ Case-insensitive (`.toLowerCase()` + `.includes()`)
-- ✅ Pattern-based (works with any naming)
-- ✅ Legacy GPT-5 fallback (`gpt-5*` aliases → `gpt-5.4`) + safe unknown fallback (`gpt-5.4`)
-- ✅ Codex priority with explicit Codex Mini support (`codex-mini*` → `codex-mini-latest`)
-
----
-
-## Expected Failures (These Should Error)
-
-### Invalid Model Selection
-
-```bash
-opencode run "test" --model=openai/claude-3.5
-```
-
-**Expected:** ❌ Error before plugin (OpenCode rejects unknown model)
-
-### Missing Authentication
-
-```bash
-# Without running: opencode auth login
-opencode run "test" --model=openai/gpt-5-codex
-```
-
-**Expected:** ❌ 401 Unauthorized error
-
----
-
-## Success Criteria
-
-### All Tests Must Pass
-
-- [ ] Default models work without custom config
-- [ ] Custom config variants use per-model options
-- [ ] Old config format still works (backwards compat)
-- [ ] Mixed default + custom models work
-- [ ] Multi-turn conversations have no ID errors
-- [ ] Model switching works correctly
-- [ ] TUI persistence remembers last used model
-- [ ] Debug logging shows correct information
-- [ ] All normalization edge cases work
-
-### No Errors
-
-- [ ] No "item not found" errors
-- [ ] No TypeScript errors
-- [ ] No authentication errors (after login)
-- [ ] No config validation errors
-
----
-
-## Automated Test Suggestions
-
-### Unit Tests (Future)
-
-```typescript
-describe('normalizeModel', () => {
-  test('handles all default models', () => {
-    expect(normalizeModel('gpt-5')).toBe('gpt-5.4')
-    expect(normalizeModel('gpt-5-codex')).toBe('gpt-5-codex')
-    expect(normalizeModel('gpt-5-codex-mini')).toBe('gpt-5.1-codex-mini')
-    expect(normalizeModel('gpt-5-mini')).toBe('gpt-5.4')
-    expect(normalizeModel('gpt-5-nano')).toBe('gpt-5.4')
-  })
-
-  test('handles custom preset names', () => {
-    expect(normalizeModel('gpt-5-codex-low')).toBe('gpt-5-codex')
-    expect(normalizeModel('openai/gpt-5-codex-mini-high')).toBe('gpt-5.1-codex-mini')
-    expect(normalizeModel('gpt-5-high')).toBe('gpt-5.4')
-  })
-
-  test('handles legacy names', () => {
-    expect(normalizeModel('GPT 5 Codex Low (ChatGPT Subscription)')).toBe('gpt-5-codex')
-  })
-
-  test('handles edge cases', () => {
-    expect(normalizeModel(undefined)).toBe('gpt-5.4')
-    expect(normalizeModel('codex-mini-latest')).toBe('gpt-5.1-codex-mini')
-    expect(normalizeModel('random')).toBe('gpt-5.4')
-  })
-})
-
-describe('getModelConfig', () => {
-  test('returns per-model options when found', () => {
-    const config = getModelConfig('gpt-5-codex-low', {
-      global: { reasoningEffort: 'medium' },
-      models: {
-        'gpt-5-codex-low': {
-          options: { reasoningEffort: 'low' }
-        }
-      }
-    })
-    expect(config.reasoningEffort).toBe('low')
-  })
-
-  test('returns global options when model not in config', () => {
-    const config = getModelConfig('gpt-5-codex', {
-      global: { reasoningEffort: 'medium' },
-      models: {}
-    })
-    expect(config.reasoningEffort).toBe('medium')
-  })
-})
-
-describe('filterInput', () => {
-  test('removes all message IDs', () => {
-    const input = [
-      { id: 'msg_123', role: 'user', content: [] },
-      { id: 'rs_456', role: 'assistant', content: [] },
-      { role: 'user', content: [] }  // No ID
-    ]
-    const result = filterInput(input)
-    expect(result.every(item => !item.id)).toBe(true)
-  })
-})
-```
-
----
+- `npm run lint`
+- `npm run typecheck`
+- `npm test`
+- `npm run build`
+- Manual doc/config spot-check if the PR changes docs, setup, or config templates
 
 ## See Also
 
-- [IMPLEMENTATION_SUMMARY.md](./IMPLEMENTATION_SUMMARY.md) - Complete summary
-- [CONFIG_FIELDS.md](./CONFIG_FIELDS.md) - Field usage guide
-- [BUGS_FIXED.md](./BUGS_FIXED.md) - Bug analysis
+- [ARCHITECTURE.md](./ARCHITECTURE.md)
+- [CONFIG_FLOW.md](./CONFIG_FLOW.md)
+- [../../test/README.md](../../test/README.md)

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -25,7 +25,7 @@ See [config/README.md](../config/README.md) for the template split.
 
 ## What models are included by default?
 
-The shipped templates focus on current GPT-5 and Codex families such as `gpt-5.4`, `gpt-5-codex`, and `gpt-5.1-*`. Optional or entitlement-gated model IDs can be added manually when your workspace supports them.
+The shipped templates focus on current GPT-5 and Codex families such as `gpt-5.4`, `gpt-5.4-mini`, `gpt-5-codex`, and `gpt-5.1-*`. Optional or entitlement-gated model IDs can be added manually when your workspace supports them.
 
 ## Can I use multiple accounts?
 
@@ -41,4 +41,4 @@ Start with [Troubleshooting](troubleshooting.md), rerun `opencode auth login`, a
 
 ## I used the old package name. What changed?
 
-The package was renamed from `opencode-openai-codex-auth-multi` to `oc-chatgpt-multi-auth`. If you still reference the old name in your OpenCode config, replace it with `oc-chatgpt-multi-auth@latest`.
+The package was renamed from `opencode-openai-codex-auth-multi` to `oc-chatgpt-multi-auth`. If you still reference the old name in your OpenCode config, replace it with `oc-chatgpt-multi-auth`.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -27,7 +27,7 @@ opencode auth login
 opencode run "Explain this repository" --model=openai/gpt-5.4 --variant=medium
 ```
 
-The installer updates `~/.config/opencode/opencode.json`, backs up the previous config, and clears the cached plugin copy so OpenCode reinstalls the latest package.
+The installer updates `~/.config/opencode/opencode.json`, backs up the previous config, normalizes the plugin entry to `oc-chatgpt-multi-auth`, and clears the cached plugin copy so OpenCode reinstalls the latest package.
 
 If you are on OpenCode `v1.0.209` or earlier, use:
 
@@ -86,7 +86,7 @@ If you are not using the installer, edit `~/.config/opencode/opencode.json` manu
 ```json
 {
   "$schema": "https://opencode.ai/config.json",
-  "plugin": ["oc-chatgpt-multi-auth@latest"]
+  "plugin": ["oc-chatgpt-multi-auth"]
 }
 ```
 
@@ -100,6 +100,7 @@ The repository ships two supported templates:
 | `v1.0.209` and earlier | [`config/opencode-legacy.json`](../config/opencode-legacy.json) |
 
 The templates include the supported GPT-5/Codex families, required `store: false` handling, and `reasoning.encrypted_content` for multi-turn sessions.
+Current templates expose 7 shipped base model families and 26 shipped presets overall (26 modern variants or 26 legacy explicit entries), including `gpt-5.4-mini`.
 
 Optional model IDs such as `gpt-5.4-pro` or entitlement-gated Spark variants should be added manually only when your workspace supports them.
 
@@ -123,6 +124,8 @@ ENABLE_PLUGIN_REQUEST_LOGGING=1 opencode run "test" --model=openai/gpt-5.4
 ```
 
 The first request should create logs under `~/.opencode/logs/codex-plugin/`.
+
+Use `opencode debug config` when you want to verify that template-defined or custom models were merged into your effective config. `opencode models openai` currently shows OpenCode's built-in provider catalog and can omit config-defined entries such as `gpt-5.4-mini`.
 
 ## Multi-Account Setup
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -11,7 +11,7 @@ If you prefer guided recovery before manual debugging, run:
 ```text
 codex-setup
 codex-doctor
-codex-doctor fix=true
+codex-doctor --fix
 codex-next
 ```
 
@@ -41,7 +41,7 @@ The package was renamed from `opencode-openai-codex-auth-multi` to `oc-chatgpt-m
 Update your `~/.config/opencode/opencode.json`:
 ```json
 {
-  "plugin": ["oc-chatgpt-multi-auth@latest"]
+  "plugin": ["oc-chatgpt-multi-auth"]
 }
 ```
 
@@ -64,7 +64,7 @@ Update your `~/.config/opencode/opencode.json`:
 1. **Verify config path and plugin list**:
    - Global: `~/.config/opencode/opencode.json`
    - Project: `./.opencode.json`
-   - Entry should include: `"plugin": ["oc-chatgpt-multi-auth@latest"]`
+   - Entry should include: `"plugin": ["oc-chatgpt-multi-auth"]`
 2. **Confirm plugin cache location** (npm plugins are cached, not stored in `~/.opencode/plugins/`):
    ```bash
    ls ~/.cache/opencode/node_modules/oc-chatgpt-multi-auth
@@ -77,7 +77,7 @@ Update your `~/.config/opencode/opencode.json`:
    ```bash
    npm view oc-chatgpt-multi-auth version
    ```
-5. **If the plugin is present but still won’t load**, upgrade to v4.8.1+ (fixes Node ESM load issues with `@opencode-ai/plugin`).
+5. **If the plugin is present but still won’t load**, rerun `npx -y oc-chatgpt-multi-auth@latest` so the installer refreshes the config and clears OpenCode's cached plugin copy.
 
 </details>
 
@@ -90,7 +90,7 @@ Update your `~/.config/opencode/opencode.json`:
 
 **What’s normal:**
 - The first request may fetch **Codex instructions** and/or the **OpenCode codex prompt** from GitHub.
-- v4.14.1+ uses **stale-while-revalidate caching** and a **startup prewarm** to reduce first-turn latency.
+- Current releases use **stale-while-revalidate caching** and a **startup prewarm** to reduce first-turn latency.
 
 **Tuning knobs:**
 1. Disable prewarm (if you prefer zero background fetches at startup):
@@ -222,7 +222,7 @@ Failed to access Codex API
 **Cause:** The plugin is using the wrong workspace/account id (personal vs business).
 
 **Solutions:**
-1. Upgrade to `oc-chatgpt-multi-auth@5.1.0` or newer (workspace routing logic was hardened for Business + Personal dual accounts).
+1. Upgrade to the current release of `oc-chatgpt-multi-auth` (workspace routing logic was hardened for Business + Personal dual accounts in the 5.x line).
 2. Re-run `opencode auth login` and select the correct workspace when prompted.
 3. If running non-interactively, set `CODEX_AUTH_ACCOUNT_ID` to the workspace account id and re-login.
 4. Verify the workspace has Codex access in the ChatGPT UI.
@@ -259,14 +259,14 @@ Failed to access Codex API
 6. Run guided diagnostics and safe auto-remediation:
    ```text
    codex-doctor
-   codex-doctor fix=true
+   codex-doctor --fix
    ```
 7. If you are onboarding or returning after a long gap, run:
    ```text
    codex-setup
-   codex-setup wizard=true
+   codex-setup --wizard
    codex-next
-   ```
+```
 
 </details>
 
@@ -300,6 +300,8 @@ opencode run "test" --model=openai/gpt-5-codex-low  # Must match config key
 | Wrong | Correct |
 |-------|---------|
 | `--model=gpt-5-codex-low` | `--model=openai/gpt-5-codex-low` |
+
+**Note:** `opencode models openai` currently shows only OpenCode's built-in provider catalog. If you add template-defined or custom models, use `opencode debug config` to confirm they were merged into the effective config.
 
 </details>
 


### PR DESCRIPTION
## Summary

- What changed?
  - Refreshed the public setup/config docs and the maintainer config/testing docs to match current `main`, including the shipped template counts, current plugin entry shape, current guided-command syntax, and the current `gpt-5.4-mini` model surface.
- Why is this needed?
  - Several docs pages still described the older config surface (`oc-chatgpt-multi-auth@latest` in `plugin`, 6 models / 21 presets, `wizard=true` / `fix=true`, older maintainer notes). That no longer matches the repo templates or installer behavior on `main`.

## Testing

- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm test`
- [ ] Not applicable

## Compliance Confirmation

- [x] This change stays within the repository scope and OpenAI Terms of Service expectations.
- [x] This change uses official authentication flows only and does not add bypass, scraping, or credential-sharing behavior.
- [x] I updated tests and documentation when the change affected users, maintainers, or repository behavior.

## Notes

- Linked issue: none
- Follow-up work or rollout notes:
  - Also ran `npm run typecheck`.
  - Documented the current OpenCode behavior where `opencode debug config` shows merged custom/template models but `opencode models openai` still shows only the built-in provider catalog, which is why config-defined entries like `gpt-5.4-mini` can be active without appearing in the model lister.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GPT-5.4 Mini to available models (7 base model families with 26 total presets)

* **Documentation**
  * Simplified and reorganized configuration, architecture, and troubleshooting documentation for improved clarity
  * Enhanced getting-started guide with model availability details and verification instructions

* **Style**
  * Updated CLI command syntax (--wizard and --fix flags instead of parameter assignments)
  * Simplified plugin package naming conventions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---


<h3>Greptile Summary</h3>

this pr refreshes 10 documentation files to align with the current `main` config surface: unpinning the plugin entry from `oc-chatgpt-multi-auth@latest` to the plain package name, updating model/preset counts from 6/21 to 7/26 (adding `gpt-5.4-mini`), correcting guided-command flag syntax (`fix=true` → `--fix`, `wizard=true` → `--wizard`), and adding a repeated clarification that `opencode debug config` is the reliable verification tool while `opencode models openai` shows only the built-in catalog.

- the changes are internally consistent across all 10 files and match the stated intent of the pr
- one formatting regression in `docs/troubleshooting.md` at the `codex-setup --wizard` / `codex-next` code block: the closing fence was de-indented to column 0, which breaks markdown rendering inside the `<details>` numbered-list block on github
- `docs/development/TESTING.md` was condensed from 791 to 151 lines; the new version is accurate but drops all normalization edge-case tables, the `store:false` multi-turn scenario matrix, and any mention of Windows filesystem / token-leakage regression coverage — worth noting since `CODEX_PLUGIN_LOG_BODIES=1` is now explicitly documented
- `docs/development/CONFIG_FIELDS.md` lost the config-key-vs-`id` distinction section; that was the documented root cause of the v2.1.2 bug fix and is useful institutional context for future contributors
- no code changes were made; no concurrency, token-safety, or redaction concerns are introduced by the docs themselves, though the new body-logging note in `TESTING.md` could benefit from a stronger security caveat

<h3>Confidence Score: 4/5</h3>

- safe to merge after fixing the code-fence indentation regression in docs/troubleshooting.md
- docs-only pr with consistent, accurate updates across all 10 files; one real formatting bug (de-indented closing fence) breaks github rendering in a visible troubleshooting section; no code changes so no concurrency or token-safety risk introduced directly, but the new body-logging note lacks an adequate security caveat and windows filesystem race coverage is absent from the condensed TESTING.md
- docs/troubleshooting.md (indentation bug at the codex-setup --wizard block), docs/development/TESTING.md (missing windows/token-safety coverage mention and insufficient body-logging warning)

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| docs/troubleshooting.md | plugin entry updated from `@latest` to plain name and command flags corrected (`fix=true` → `--fix`, `wizard=true` → `--wizard`), but one closing code fence was de-indented to column 0, breaking markdown rendering inside the numbered-list block |
| docs/development/TESTING.md | heavily condensed from 791 lines to 151; the new guide correctly captures the current test surface but drops all normalization edge-case tables, the multi-turn `store:false` scenario matrix, and any mention of Windows filesystem / token-leakage regression coverage; `CODEX_PLUGIN_LOG_BODIES=1` is documented without a sufficient security warning |
| docs/development/CONFIG_FIELDS.md | condensed from 390 lines to 58; content is accurate for the current modern/legacy template surface, but the removed config-key-vs-id distinction and bug-history section are useful institutional knowledge for future contributors adding model families |
| docs/development/CONFIG_FLOW.md | simplified and re-focused on the current installer flow and `~/.config/opencode/opencode.json` path; file-locations table and runtime resolution notes are accurate and helpful; no issues found |
| docs/development/ARCHITECTURE.md | two targeted corrections: `gpt-5-nano` → `gpt-5.4`/`gpt-5.4-mini` in the design-decision section, and guided-command flag syntax updated to `--wizard`/`--fix`; changes are accurate and minimal |
| README.md | two clean fixes: added the plugin-entry normalisation bullet to the installer description and updated the troubleshooting check from `@latest` to the plain package name; no issues |
| config/README.md | model and preset counts updated from 6/21 to 7/26, `gpt-5.4-mini` added to the template list, and an `opencode debug config` vs `opencode models openai` clarification note added; all accurate |
| docs/configuration.md | three `@latest` plugin references normalised to plain name; preset count updated to 7 base families / 26 presets; `opencode debug config` note added; all changes consistent with other docs |
| docs/faq.md | `gpt-5.4-mini` added to the default models answer and the package-rename answer updated to drop `@latest`; both changes are correct |
| docs/getting-started.md | installer description updated with plugin-entry normalisation step, plugin reference de-pinned to plain name, template count updated to 7/26, and `opencode debug config` caveat added; accurate and consistent |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["user runs installer\nnpx -y oc-chatgpt-multi-auth@latest"] --> B["backs up existing\n~/.config/opencode/opencode.json"]
    B --> C["normalizes plugin entry\nto plain 'oc-chatgpt-multi-auth'"]
    C --> D{"OpenCode version?"}
    D -->|"v1.0.210+"| E["writes opencode-modern.json block\n7 base models, 26 variants"]
    D -->|"v1.0.209 and below"| F["writes opencode-legacy.json block\n26 explicit model entries"]
    E --> G["clears ~/.cache/opencode/\nnode_modules/oc-chatgpt-multi-auth"]
    F --> G
    G --> H["OpenCode loads merged config"]
    H --> I{"verify config surface"}
    I -->|"merged models"| J["opencode debug config\n✅ shows template + custom entries"]
    I -->|"built-in catalog only"| K["opencode models openai\n⚠️ omits config-defined entries\ne.g. gpt-5.4-mini"]
    H --> L["runtime request"]
    L --> M["plugin loader reads\nprovider.openai.options + models"]
    M --> N["normalize model ID\ne.g. gpt-5-mini → gpt-5.4"]
    N --> O["apply store: false +\nreasoning.encrypted_content"]
    O --> P["Codex API call"]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `docs/troubleshooting.md`, line 474-477 ([link](https://github.com/ndycode/oc-chatgpt-multi-auth/blob/ac372e6398c0efc585811d7353aec047dc2e0821/docs/troubleshooting.md#L474-L477)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Closing code fence de-indented, breaking numbered list block**

   the closing ` ``` ` was pulled from 3-space indent to column 0. inside a `<details>` block this causes the fence to not close the numbered-list item's code block correctly — markdown renderers (GitHub included) will treat everything after it as outside the list, breaking the visual structure.

   
   ```

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: docs/troubleshooting.md
   Line: 474-477

   Comment:
   **Closing code fence de-indented, breaking numbered list block**

   the closing ` ``` ` was pulled from 3-space indent to column 0. inside a `<details>` block this causes the fence to not close the numbered-list item's code block correctly — markdown renderers (GitHub included) will treat everything after it as outside the list, breaking the visual structure.

   
   ```

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/codex?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20docs%2Ftroubleshooting.md%0ALine%3A%20474-477%0A%0AComment%3A%0A**Closing%20code%20fence%20de-indented%2C%20breaking%20numbered%20list%20block**%0A%0Athe%20closing%20%60%20%60%60%60%20%60%20was%20pulled%20from%203-space%20indent%20to%20column%200.%20inside%20a%20%60%3Cdetails%3E%60%20block%20this%20causes%20the%20fence%20to%20not%20close%20the%20numbered-list%20item's%20code%20block%20correctly%20%E2%80%94%20markdown%20renderers%20%28GitHub%20included%29%20will%20treat%20everything%20after%20it%20as%20outside%20the%20list%2C%20breaking%20the%20visual%20structure.%0A%0A%60%60%60suggestion%0A%20%20%20codex-setup%20--wizard%0A%20%20%20codex-next%0A%20%20%20%60%60%60%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=ndycode%2Foc-chatgpt-multi-auth"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_in_Codex-black?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=white"><img alt="Fix in Codex" src="https://img.shields.io/badge/Fix_in_Codex-white?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=black"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Adocs%2Ftroubleshooting.md%3A474-477%0A**Closing%20code%20fence%20de-indented%2C%20breaking%20numbered%20list%20block**%0A%0Athe%20closing%20%60%20%60%60%60%20%60%20was%20pulled%20from%203-space%20indent%20to%20column%200.%20inside%20a%20%60%3Cdetails%3E%60%20block%20this%20causes%20the%20fence%20to%20not%20close%20the%20numbered-list%20item's%20code%20block%20correctly%20%E2%80%94%20markdown%20renderers%20%28GitHub%20included%29%20will%20treat%20everything%20after%20it%20as%20outside%20the%20list%2C%20breaking%20the%20visual%20structure.%0A%0A%60%60%60suggestion%0A%20%20%20codex-setup%20--wizard%0A%20%20%20codex-next%0A%20%20%20%60%60%60%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%204%0Adocs%2Fdevelopment%2FTESTING.md%3A1-4%0A**Windows%20filesystem%20%2F%20token%20safety%20coverage%20not%20mentioned**%0A%0Athe%20old%20%60TESTING.md%60%20enumerated%20the%20test%20suites%20explicitly%20but%20neither%20the%20old%20nor%20the%20new%20version%20calls%20out%20Windows-specific%20concurrency%20coverage%20or%20token-leakage%20regression%20tests.%20the%20current%20table%20references%20%60test%2Fstorage-async.test.ts%60%20and%20%60test%2Frotation*.test.ts%60%2C%20but%20there%20is%20no%20mention%20of%3A%0A%0A-%20audit-log%20write-queue%20behaviour%20on%20Windows%20%28antivirus%20file-lock%20races%29%0A-%20token%20redaction%20strategy%20in%20debug%20log%20paths%20%28especially%20since%20%60CODEX_PLUGIN_LOG_BODIES%3D1%60%20was%20just%20documented%29%0A-%20any%20%60*.race.test.ts%60%20or%20%60*.windows.test.ts%60%20entries%0A%0Aif%20those%20tests%20exist%2C%20adding%20a%20row%20to%20the%20table%20would%20prevent%20future%20contributors%20from%20removing%20them%20unaware.%20if%20they%20don't%20exist%20yet%2C%20this%20is%20a%20gap%20worth%20tracking.%0A%0A**Rule%20Used%3A**%20What%3A%20Every%20code%20change%20must%20explain%20how%20it%20defend...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3D637a42e6-7a78-40d6-9ef8-6a45e02e73b6%29%29%0A%0A%23%23%23%20Issue%203%20of%204%0Adocs%2Fdevelopment%2FTESTING.md%3A115-116%0A**%60CODEX_PLUGIN_LOG_BODIES%3D1%60%20security%20note%20is%20too%20brief**%0A%0Athe%20note%20says%20%22can%20log%20sensitive%20request%20and%20response%20bodies%22%20but%20doesn't%20call%20out%20that%20OAuth%20tokens%20and%20encrypted%20reasoning%20payloads%20both%20flow%20through%20the%20same%20log%20path.%20on%20Windows%20those%20log%20files%20are%20written%20without%20explicit%20file-lock%20sequencing%20and%20an%20antivirus%20scan%20mid-write%20can%20produce%20a%20corrupt%20or%20partially-readable%20file%20that%20exposes%20partial%20token%20material.%0A%0Arecommend%20expanding%20the%20warning%20to%20at%20least%20mention%3A%20log%20files%20are%20unredacted%20at%20body-level%20and%20should%20not%20be%20left%20enabled%20in%20shared%20or%20CI%20environments%2C%20and%20that%20the%20log%20directory%20should%20have%20restricted%20permissions%20%280700%20on%20unix%3B%20equivalent%20ACL%20on%20Windows%29.%0A%0A**Rule%20Used%3A**%20What%3A%20Every%20code%20change%20must%20explain%20how%20it%20defend...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3D637a42e6-7a78-40d6-9ef8-6a45e02e73b6%29%29%0A%0A%23%23%23%20Issue%204%20of%204%0Adocs%2Fdevelopment%2FCONFIG_FIELDS.md%3A1-3%0A**Loss%20of%20config-key%20vs%20%60id%60%20field%20distinction%20may%20confuse%20contributors**%0A%0Athe%20removed%20section%20explained%20in%20detail%20that%20OpenCode%20passes%20the%20*config%20key*%20%28not%20the%20%60id%60%20field%29%20to%20the%20plugin's%20custom%20loader%2C%20and%20showed%20exactly%20why%20%60body.model%60%20equals%20the%20config%20key.%20that%20distinction%20is%20the%20root%20cause%20of%20a%20real%20bug%20that%20was%20fixed%20in%20v2.1.2.%20%0A%0Athe%20new%20doc%20is%20much%20shorter%20and%20correct%20for%20the%20current%20template%20surface%2C%20but%20a%20contributor%20adding%20a%20new%20model%20family%20in%20the%20future%20won't%20know%20why%20omitting%20%60id%60%20is%20safe%20for%20OpenAI.%20consider%20keeping%20a%20single-paragraph%20%22how%20the%20plugin%20sees%20%60body.model%60%22%20note%20or%20linking%20to%20the%20relevant%20source%20file%20so%20the%20context%20isn't%20entirely%20lost.%0A%0A&repo=ndycode%2Foc-chatgpt-multi-auth"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_All_in_Codex-black?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=white"><img alt="Fix All in Codex" src="https://img.shields.io/badge/Fix_All_in_Codex-white?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=black"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: docs/troubleshooting.md
Line: 474-477

Comment:
**Closing code fence de-indented, breaking numbered list block**

the closing ` ``` ` was pulled from 3-space indent to column 0. inside a `<details>` block this causes the fence to not close the numbered-list item's code block correctly — markdown renderers (GitHub included) will treat everything after it as outside the list, breaking the visual structure.

```suggestion
   codex-setup --wizard
   codex-next
   ```
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: docs/development/TESTING.md
Line: 1-4

Comment:
**Windows filesystem / token safety coverage not mentioned**

the old `TESTING.md` enumerated the test suites explicitly but neither the old nor the new version calls out Windows-specific concurrency coverage or token-leakage regression tests. the current table references `test/storage-async.test.ts` and `test/rotation*.test.ts`, but there is no mention of:

- audit-log write-queue behaviour on Windows (antivirus file-lock races)
- token redaction strategy in debug log paths (especially since `CODEX_PLUGIN_LOG_BODIES=1` was just documented)
- any `*.race.test.ts` or `*.windows.test.ts` entries

if those tests exist, adding a row to the table would prevent future contributors from removing them unaware. if they don't exist yet, this is a gap worth tracking.

**Rule Used:** What: Every code change must explain how it defend... ([source](https://app.greptile.com/review/custom-context?memory=637a42e6-7a78-40d6-9ef8-6a45e02e73b6))

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: docs/development/TESTING.md
Line: 115-116

Comment:
**`CODEX_PLUGIN_LOG_BODIES=1` security note is too brief**

the note says "can log sensitive request and response bodies" but doesn't call out that OAuth tokens and encrypted reasoning payloads both flow through the same log path. on Windows those log files are written without explicit file-lock sequencing and an antivirus scan mid-write can produce a corrupt or partially-readable file that exposes partial token material.

recommend expanding the warning to at least mention: log files are unredacted at body-level and should not be left enabled in shared or CI environments, and that the log directory should have restricted permissions (0700 on unix; equivalent ACL on Windows).

**Rule Used:** What: Every code change must explain how it defend... ([source](https://app.greptile.com/review/custom-context?memory=637a42e6-7a78-40d6-9ef8-6a45e02e73b6))

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: docs/development/CONFIG_FIELDS.md
Line: 1-3

Comment:
**Loss of config-key vs `id` field distinction may confuse contributors**

the removed section explained in detail that OpenCode passes the *config key* (not the `id` field) to the plugin's custom loader, and showed exactly why `body.model` equals the config key. that distinction is the root cause of a real bug that was fixed in v2.1.2. 

the new doc is much shorter and correct for the current template surface, but a contributor adding a new model family in the future won't know why omitting `id` is safe for OpenAI. consider keeping a single-paragraph "how the plugin sees `body.model`" note or linking to the relevant source file so the context isn't entirely lost.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: ["docs: refresh curren..."](https://github.com/ndycode/oc-chatgpt-multi-auth/commit/ac372e6398c0efc585811d7353aec047dc2e0821)</sub>

**Context used:**

- Rule used - What: Every code change must explain how it defend... ([source](https://app.greptile.com/review/custom-context?memory=637a42e6-7a78-40d6-9ef8-6a45e02e73b6))

<!-- /greptile_comment -->