### PR TITLE
fix: update config metadata for gpt-5.4 family and Codex context windows

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -6,8 +6,8 @@ This directory contains the official OpenCode config templates for the ChatGPT C
 
 | File | OpenCode version | Description |
 |------|------------------|-------------|
-| [`opencode-modern.json`](./opencode-modern.json) | **v1.0.210+** | Variant-based config: 7 base models with 26 total presets |
-| [`opencode-legacy.json`](./opencode-legacy.json) | **v1.0.209 and below** | Legacy explicit entries: 26 individual model definitions |
+| [`opencode-modern.json`](./opencode-modern.json) | **v1.0.210+** | Variant-based config: 9 base models with 34 total presets |
+| [`opencode-legacy.json`](./opencode-legacy.json) | **v1.0.209 and below** | Legacy explicit entries: 34 individual model definitions |
 
 ## Quick pick
 
@@ -34,16 +34,16 @@ opencode --version
 OpenCode v1.0.210+ added model `variants`, so one model entry can expose multiple reasoning levels. That keeps modern config much smaller while preserving the same effective presets.
 
 Both templates include:
-- GPT-5.4, GPT-5.4 Mini, GPT-5 Codex, GPT-5.1, GPT-5.1 Codex, GPT-5.1 Codex Max, GPT-5.1 Codex Mini
+- GPT-5.4, GPT-5.4 Pro, GPT-5.4 Mini, GPT-5.4 Nano, GPT-5 Codex, GPT-5.1, GPT-5.1 Codex, GPT-5.1 Codex Max, GPT-5.1 Codex Mini
 - Reasoning variants per model family
 - `store: false` and `include: ["reasoning.encrypted_content"]`
-- Context metadata (`gpt-5.4*`: 1,000,000 context / 128,000 output; other shipped models: 272,000 / 128,000)
+- Context metadata (`gpt-5.4`/`gpt-5.4-pro`: 1,050,000; `gpt-5.4-mini`/`gpt-5.4-nano`/Codex models: 400,000; `gpt-5.1`: 272,000; all output: 128,000)
 
 Use `opencode debug config` to verify that these template entries were merged into your effective config. `opencode models openai` currently shows OpenCode's built-in provider catalog and can omit config-defined entries such as `gpt-5.4-mini`.
 
 If your OpenCode runtime supports global compaction tuning, you can also set:
-- `model_context_window = 1000000`
-- `model_auto_compact_token_limit = 900000`
+- `model_context_window = 1050000`
+- `model_auto_compact_token_limit = 950000`
 
 ## Spark model note
 

--- a/config/opencode-legacy.json
+++ b/config/opencode-legacy.json
@@ -18,7 +18,7 @@
         "gpt-5.4-none": {
           "name": "GPT 5.4 None (OAuth)",
           "limit": {
-            "context": 1000000,
+            "context": 1050000,
             "output": 128000
           },
           "modalities": {
@@ -43,7 +43,7 @@
         "gpt-5.4-low": {
           "name": "GPT 5.4 Low (OAuth)",
           "limit": {
-            "context": 1000000,
+            "context": 1050000,
             "output": 128000
           },
           "modalities": {
@@ -68,7 +68,7 @@
         "gpt-5.4-medium": {
           "name": "GPT 5.4 Medium (OAuth)",
           "limit": {
-            "context": 1000000,
+            "context": 1050000,
             "output": 128000
           },
           "modalities": {
@@ -93,7 +93,7 @@
         "gpt-5.4-high": {
           "name": "GPT 5.4 High (OAuth)",
           "limit": {
-            "context": 1000000,
+            "context": 1050000,
             "output": 128000
           },
           "modalities": {
@@ -118,7 +118,7 @@
         "gpt-5.4-xhigh": {
           "name": "GPT 5.4 Extra High (OAuth)",
           "limit": {
-            "context": 1000000,
+            "context": 1050000,
             "output": 128000
           },
           "modalities": {
@@ -143,7 +143,7 @@
         "gpt-5.4-mini-none": {
           "name": "GPT 5.4 Mini None (OAuth)",
           "limit": {
-            "context": 1000000,
+            "context": 400000,
             "output": 128000
           },
           "modalities": {
@@ -168,7 +168,7 @@
         "gpt-5.4-mini-low": {
           "name": "GPT 5.4 Mini Low (OAuth)",
           "limit": {
-            "context": 1000000,
+            "context": 400000,
             "output": 128000
           },
           "modalities": {
@@ -193,7 +193,7 @@
         "gpt-5.4-mini-medium": {
           "name": "GPT 5.4 Mini Medium (OAuth)",
           "limit": {
-            "context": 1000000,
+            "context": 400000,
             "output": 128000
           },
           "modalities": {
@@ -218,7 +218,7 @@
         "gpt-5.4-mini-high": {
           "name": "GPT 5.4 Mini High (OAuth)",
           "limit": {
-            "context": 1000000,
+            "context": 400000,
             "output": 128000
           },
           "modalities": {
@@ -243,7 +243,207 @@
         "gpt-5.4-mini-xhigh": {
           "name": "GPT 5.4 Mini Extra High (OAuth)",
           "limit": {
-            "context": 1000000,
+            "context": 400000,
+            "output": 128000
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "options": {
+            "reasoningEffort": "xhigh",
+            "reasoningSummary": "detailed",
+            "textVerbosity": "medium",
+            "include": [
+              "reasoning.encrypted_content"
+            ],
+            "store": false
+          }
+        },
+        "gpt-5.4-pro-medium": {
+          "name": "GPT 5.4 Pro Medium (OAuth)",
+          "limit": {
+            "context": 1050000,
+            "output": 128000
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "options": {
+            "reasoningEffort": "medium",
+            "reasoningSummary": "detailed",
+            "textVerbosity": "medium",
+            "include": [
+              "reasoning.encrypted_content"
+            ],
+            "store": false
+          }
+        },
+        "gpt-5.4-pro-high": {
+          "name": "GPT 5.4 Pro High (OAuth)",
+          "limit": {
+            "context": 1050000,
+            "output": 128000
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "options": {
+            "reasoningEffort": "high",
+            "reasoningSummary": "detailed",
+            "textVerbosity": "medium",
+            "include": [
+              "reasoning.encrypted_content"
+            ],
+            "store": false
+          }
+        },
+        "gpt-5.4-pro-xhigh": {
+          "name": "GPT 5.4 Pro Extra High (OAuth)",
+          "limit": {
+            "context": 1050000,
+            "output": 128000
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "options": {
+            "reasoningEffort": "xhigh",
+            "reasoningSummary": "detailed",
+            "textVerbosity": "medium",
+            "include": [
+              "reasoning.encrypted_content"
+            ],
+            "store": false
+          }
+        },
+        "gpt-5.4-nano-none": {
+          "name": "GPT 5.4 Nano None (OAuth)",
+          "limit": {
+            "context": 400000,
+            "output": 128000
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "options": {
+            "reasoningEffort": "none",
+            "reasoningSummary": "auto",
+            "textVerbosity": "medium",
+            "include": [
+              "reasoning.encrypted_content"
+            ],
+            "store": false
+          }
+        },
+        "gpt-5.4-nano-low": {
+          "name": "GPT 5.4 Nano Low (OAuth)",
+          "limit": {
+            "context": 400000,
+            "output": 128000
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "options": {
+            "reasoningEffort": "low",
+            "reasoningSummary": "auto",
+            "textVerbosity": "medium",
+            "include": [
+              "reasoning.encrypted_content"
+            ],
+            "store": false
+          }
+        },
+        "gpt-5.4-nano-medium": {
+          "name": "GPT 5.4 Nano Medium (OAuth)",
+          "limit": {
+            "context": 400000,
+            "output": 128000
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "options": {
+            "reasoningEffort": "medium",
+            "reasoningSummary": "auto",
+            "textVerbosity": "medium",
+            "include": [
+              "reasoning.encrypted_content"
+            ],
+            "store": false
+          }
+        },
+        "gpt-5.4-nano-high": {
+          "name": "GPT 5.4 Nano High (OAuth)",
+          "limit": {
+            "context": 400000,
+            "output": 128000
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "options": {
+            "reasoningEffort": "high",
+            "reasoningSummary": "detailed",
+            "textVerbosity": "medium",
+            "include": [
+              "reasoning.encrypted_content"
+            ],
+            "store": false
+          }
+        },
+        "gpt-5.4-nano-xhigh": {
+          "name": "GPT 5.4 Nano Extra High (OAuth)",
+          "limit": {
+            "context": 400000,
             "output": 128000
           },
           "modalities": {
@@ -268,7 +468,7 @@
         "gpt-5.1-codex-max-low": {
           "name": "GPT 5.1 Codex Max Low (OAuth)",
           "limit": {
-            "context": 272000,
+            "context": 400000,
             "output": 128000
           },
           "modalities": {
@@ -293,7 +493,7 @@
         "gpt-5.1-codex-max-medium": {
           "name": "GPT 5.1 Codex Max Medium (OAuth)",
           "limit": {
-            "context": 272000,
+            "context": 400000,
             "output": 128000
           },
           "modalities": {
@@ -318,7 +518,7 @@
         "gpt-5.1-codex-max-high": {
           "name": "GPT 5.1 Codex Max High (OAuth)",
           "limit": {
-            "context": 272000,
+            "context": 400000,
             "output": 128000
           },
           "modalities": {
@@ -343,7 +543,7 @@
         "gpt-5.1-codex-max-xhigh": {
           "name": "GPT 5.1 Codex Max Extra High (OAuth)",
           "limit": {
-            "context": 272000,
+            "context": 400000,
             "output": 128000
           },
           "modalities": {
@@ -368,7 +568,7 @@
         "gpt-5.1-codex-low": {
           "name": "GPT 5.1 Codex Low (OAuth)",
           "limit": {
-            "context": 272000,
+            "context": 400000,
             "output": 128000
           },
           "modalities": {
@@ -393,7 +593,7 @@
         "gpt-5.1-codex-medium": {
           "name": "GPT 5.1 Codex Medium (OAuth)",
           "limit": {
-            "context": 272000,
+            "context": 400000,
             "output": 128000
           },
           "modalities": {
@@ -418,7 +618,7 @@
         "gpt-5.1-codex-high": {
           "name": "GPT 5.1 Codex High (OAuth)",
           "limit": {
-            "context": 272000,
+            "context": 400000,
             "output": 128000
           },
           "modalities": {
@@ -443,7 +643,7 @@
         "gpt-5.1-codex-mini-medium": {
           "name": "GPT 5.1 Codex Mini Medium (OAuth)",
           "limit": {
-            "context": 272000,
+            "context": 400000,
             "output": 128000
           },
           "modalities": {
@@ -468,7 +668,7 @@
         "gpt-5.1-codex-mini-high": {
           "name": "GPT 5.1 Codex Mini High (OAuth)",
           "limit": {
-            "context": 272000,
+            "context": 400000,
             "output": 128000
           },
           "modalities": {
@@ -593,7 +793,7 @@
         "gpt-5-codex-low": {
           "name": "GPT 5 Codex Low (OAuth)",
           "limit": {
-            "context": 272000,
+            "context": 400000,
             "output": 128000
           },
           "modalities": {
@@ -618,7 +818,7 @@
         "gpt-5-codex-medium": {
           "name": "GPT 5 Codex Medium (OAuth)",
           "limit": {
-            "context": 272000,
+            "context": 400000,
             "output": 128000
           },
           "modalities": {
@@ -643,7 +843,7 @@
         "gpt-5-codex-high": {
           "name": "GPT 5 Codex High (OAuth)",
           "limit": {
-            "context": 272000,
+            "context": 400000,
             "output": 128000
           },
           "modalities": {

--- a/config/opencode-modern.json
+++ b/config/opencode-modern.json
@@ -18,7 +18,7 @@
         "gpt-5.4": {
           "name": "GPT 5.4 (OAuth)",
           "limit": {
-            "context": 1000000,
+            "context": 1050000,
             "output": 128000
           },
           "modalities": {
@@ -58,10 +58,86 @@
             }
           }
         },
+        "gpt-5.4-pro": {
+          "name": "GPT 5.4 Pro (OAuth)",
+          "limit": {
+            "context": 1050000,
+            "output": 128000
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "variants": {
+            "medium": {
+              "reasoningEffort": "medium",
+              "reasoningSummary": "detailed",
+              "textVerbosity": "medium"
+            },
+            "high": {
+              "reasoningEffort": "high",
+              "reasoningSummary": "detailed",
+              "textVerbosity": "medium"
+            },
+            "xhigh": {
+              "reasoningEffort": "xhigh",
+              "reasoningSummary": "detailed",
+              "textVerbosity": "medium"
+            }
+          }
+        },
         "gpt-5.4-mini": {
           "name": "GPT 5.4 Mini (OAuth)",
           "limit": {
-            "context": 1000000,
+            "context": 400000,
+            "output": 128000
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "variants": {
+            "none": {
+              "reasoningEffort": "none",
+              "reasoningSummary": "auto",
+              "textVerbosity": "medium"
+            },
+            "low": {
+              "reasoningEffort": "low",
+              "reasoningSummary": "auto",
+              "textVerbosity": "medium"
+            },
+            "medium": {
+              "reasoningEffort": "medium",
+              "reasoningSummary": "auto",
+              "textVerbosity": "medium"
+            },
+            "high": {
+              "reasoningEffort": "high",
+              "reasoningSummary": "detailed",
+              "textVerbosity": "medium"
+            },
+            "xhigh": {
+              "reasoningEffort": "xhigh",
+              "reasoningSummary": "detailed",
+              "textVerbosity": "medium"
+            }
+          }
+        },
+        "gpt-5.4-nano": {
+          "name": "GPT 5.4 Nano (OAuth)",
+          "limit": {
+            "context": 400000,
             "output": 128000
           },
           "modalities": {
@@ -104,7 +180,7 @@
         "gpt-5.1-codex-max": {
           "name": "GPT 5.1 Codex Max (OAuth)",
           "limit": {
-            "context": 272000,
+            "context": 400000,
             "output": 128000
           },
           "modalities": {
@@ -142,7 +218,7 @@
         "gpt-5.1-codex": {
           "name": "GPT 5.1 Codex (OAuth)",
           "limit": {
-            "context": 272000,
+            "context": 400000,
             "output": 128000
           },
           "modalities": {
@@ -175,7 +251,7 @@
         "gpt-5.1-codex-mini": {
           "name": "GPT 5.1 Codex Mini (OAuth)",
           "limit": {
-            "context": 272000,
+            "context": 400000,
             "output": 128000
           },
           "modalities": {
@@ -241,7 +317,7 @@
         "gpt-5-codex": {
           "name": "GPT 5 Codex (OAuth)",
           "limit": {
-            "context": 272000,
+            "context": 400000,
             "output": 128000
           },
           "modalities": {


### PR DESCRIPTION
## Summary

Updates both config templates (`opencode-modern.json` and `opencode-legacy.json`) with correct context window sizes and adds missing model entries for the GPT-5.4 family.

## Changes

### New model entries
- **gpt-5.4-pro** (medium/high/xhigh only) — 1,050,000 context
- **gpt-5.4-nano** (none/low/medium/high/xhigh) — 400,000 context

### Context window corrections (from OpenAI docs)
| Model | Before | After |
|-------|--------|-------|
| gpt-5.4, gpt-5.4-pro | 1,000,000 | 1,050,000 |
| gpt-5.4-mini, gpt-5.4-nano | 1,000,000 | 400,000 |
| All Codex models | 272,000 | 400,000 |

### Documentation
- Updated `config/README.md` model list (7 → 9 base models, 26 → 34 presets)
- Updated compaction tuning recommendations (1,000,000 → 1,050,000)
- Verified effective preset totals directly from the templates:
  - modern config: `9` base models / `34` effective presets
  - legacy config: `34` explicit model entries

## Files changed
- `config/opencode-modern.json` — added pro/nano, fixed Codex context
- `config/opencode-legacy.json` — added 8 new entries (3 pro + 5 nano), fixed Codex context
- `config/README.md` — updated counts, model list, context metadata line

## Safety notes
- Windows concurrency: this PR is config-only and does not change runtime file I/O behavior; existing config-loading/storage guards remain unchanged
- Token/log redaction: no auth tokens, prompt-cache keys, or new logged values are introduced by these template edits
- Regression coverage: no runtime code paths changed; validation stayed at typecheck + full test suite, including existing storage/concurrency coverage such as `test/audit.race.test.ts`

## Testing
- `npm run typecheck` — clean
- `npm test` — 2009/2009 pass