### PR TITLE
feat: add prompt cache diagnostics to codex-doctor

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -2036,6 +2036,11 @@ export const OpenAIOAuthPlugin: Plugin = async ({ client }: PluginInput) => {
 							);
 							runtimeMetrics.lastRequestAt = Date.now();
 							runtimeMetrics.lastPromptCacheKey = promptCacheKey ?? null;
+							if (promptCacheKey) {
+								runtimeMetrics.promptCacheEnabledRequests++;
+							} else {
+								runtimeMetrics.promptCacheMissingRequests++;
+							}
 							const retryBudget = new RetryBudgetTracker(retryBudgetLimits);
 							const consumeRetryBudget = (
 								bucket: RetryBudgetClass,
@@ -2336,17 +2341,19 @@ while (attempted.size < Math.max(1, accountCount)) {
 								// in-memory only and run on Node's single-threaded event loop, so no
 								// filesystem locking or token-redaction concerns are introduced here.
 								runtimeMetrics.totalRequests++;
-								if (promptCacheKey) {
-									runtimeMetrics.promptCacheEnabledRequests++;
-								} else {
-									runtimeMetrics.promptCacheMissingRequests++;
-								}
 								response = await fetch(url, {
 									...requestInit,
 									headers,
 									signal: fetchController.signal,
 								});
 							} catch (networkError) {
+								if (abortSignal?.aborted && fetchController.signal.aborted) {
+									accountManager.refundToken(account, modelFamily, model);
+									if (networkError instanceof Error) {
+										throw networkError;
+									}
+									throw new Error(String(networkError));
+								}
 								const errorMsg = networkError instanceof Error ? networkError.message : String(networkError);
 								logWarn(`Network error for account ${account.index + 1}: ${errorMsg}`);
 								if (

--- a/lib/ui/beginner.ts
+++ b/lib/ui/beginner.ts
@@ -1,3 +1,5 @@
+import { createHash } from "node:crypto";
+
 export type BeginnerDiagnosticSeverity = "ok" | "warning" | "error";
 
 export interface BeginnerAccountSnapshot {
@@ -53,7 +55,8 @@ export interface BeginnerAccountSummary {
 export function formatPromptCacheKey(value: string | null | undefined): string {
 	const normalized = value?.trim();
 	if (!normalized) return "none";
-	return `${normalized.slice(0, 8)}...`;
+	const fingerprint = createHash("sha256").update(normalized).digest("hex").slice(0, 12);
+	return `masked-${fingerprint}`;
 }
 
 export function formatPromptCacheSnapshot(runtime: Pick<

--- a/test/beginner-ui.test.ts
+++ b/test/beginner-ui.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect } from "vitest";
+import { createHash } from "node:crypto";
+
 import {
 	buildBeginnerChecklist,
 	buildBeginnerDoctorFindings,
@@ -238,11 +240,15 @@ describe("formatPromptCacheKey", () => {
 	});
 
 	it("redacts short values too", () => {
-		expect(formatPromptCacheKey("ses_1234")).toBe("ses_1234...");
+		expect(formatPromptCacheKey("ses_1234")).toBe(
+			`masked-${createHash("sha256").update("ses_1234").digest("hex").slice(0, 12)}`,
+		);
 	});
 
-	it("redacts longer values to an 8-char prefix", () => {
-		expect(formatPromptCacheKey("ses_prompt_cache_key_123")).toBe("ses_prom...");
+	it("redacts longer values to a stable masked fingerprint", () => {
+		expect(formatPromptCacheKey("ses_prompt_cache_key_123")).toBe(
+			`masked-${createHash("sha256").update("ses_prompt_cache_key_123").digest("hex").slice(0, 12)}`,
+		);
 	});
 });
 
@@ -254,7 +260,9 @@ describe("formatPromptCacheSnapshot", () => {
 			lastPromptCacheKey: "ses_prompt_cache_key_123",
 		});
 
-		expect(rendered).toBe("enabled=4, missing=1, lastKey=ses_prom...");
+		expect(rendered).toBe(
+			`enabled=4, missing=1, lastKey=masked-${createHash("sha256").update("ses_prompt_cache_key_123").digest("hex").slice(0, 12)}`,
+		);
 		expect(rendered).not.toContain("ses_prompt_cache_key_123");
 	});
 });


### PR DESCRIPTION
## Summary
- add prompt-cache visibility to beginner runtime diagnostics
- surface prompt-cache warnings in `codex-doctor` when recent requests are missing or inconsistently using `prompt_cache_key`
- align prompt-cache counters with logical transformed requests while keeping `totalRequests` as a fetch-attempt metric

## Why
The bridge relies on host-supplied `prompt_cache_key` values to enable prompt caching. When that key is missing, users lose cache benefits silently. `codex-doctor` should make that visible instead of only reporting account/failure health.

## Changes
- extend beginner runtime snapshots with:
  - `promptCacheEnabledRequests`
  - `promptCacheMissingRequests`
  - `lastPromptCacheKey`
- record prompt-cache presence once per transformed logical request in `index.ts`
- keep `totalRequests` at the fetch boundary so retry/account-rotation attempt metrics remain unchanged
- short-circuit user-triggered aborts before network-failure penalties are applied
- add new doctor findings in `lib/ui/beginner.ts`
  - `prompt-cache-missing`
  - `prompt-cache-inconsistent`
- add shared prompt-cache formatting helpers in `lib/ui/beginner.ts`
  - `formatPromptCacheKey`
  - `formatPromptCacheSnapshot`
- include prompt-cache state in the `codex-doctor --deep` technical snapshot
- add focused unit coverage in `test/beginner-ui.test.ts`

## Safety notes
- Windows concurrency: all prompt-cache telemetry updates remain in-memory only; they do not add filesystem reads/writes or widen Windows file-lock / antivirus race exposure
- Abort handling: user-originated aborts now bypass retry-budget consumption and account-failure penalties, so cancellation does not poison account health
- Token/log redaction: doctor output never prints literal prompt-cache key material; non-empty keys are rendered as a stable masked fingerprint (`masked-<sha256-prefix>`) instead of any raw substring
- Regression coverage: `test/beginner-ui.test.ts` covers empty/short/long key masking, snapshot rendering, and the zero-request doctor guard; `test/index-retry.test.ts` still passes for the surrounding retry path

## Validation
- `npm run typecheck`
- `npm test`

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

this PR surfaces prompt-cache diagnostics in `codex-doctor` by extending `BeginnerRuntimeSnapshot` with `promptCacheEnabledRequests`, `promptCacheMissingRequests`, and `lastPromptCacheKey`, then wiring two new doctor findings (`prompt-cache-missing`, `prompt-cache-inconsistent`) plus a shared sha256-fingerprint formatter that applies to all key lengths. it also short-circuits the retry/failure-penalty machinery for user-originated aborts.

- **counter placement is correct**: prompt-cache counters increment once per logical request (outside both the account-rotation and inner retry loops); `totalRequests` remains at the fetch boundary as a separate attempt metric — this asymmetry is intentional and documented
- **key redaction is complete**: all prior concerns about verbatim key leakage are resolved — `formatPromptCacheKey` now hashes every non-empty key (including short ones like `"ses_1234"`) to `masked-<12-char-sha256-prefix>`; no raw key material appears in either the ui or deep-snapshot render paths
- **abort handling**: user cancellations now refund the consumed token and throw before account failure penalties apply; the in-memory-only approach avoids any windows filesystem or token-exposure concerns
- **gaps**: the new abort-refund branch in `catch` (index.ts lines 2350-2356) has no dedicated vitest case — adding one to `index-retry.test.ts` would lock in the no-penalty guarantee against future refactors

<h3>Confidence Score: 4/5</h3>

- safe to merge; prior key-leakage and counter-placement concerns are fully resolved; one missing test for the new abort-refund branch is the only remaining gap
- both blocking issues from previous review rounds are properly addressed: all key lengths are now hashed, and prompt-cache counters fire once per logical request outside both retry loops. the abort short-circuit is logically correct (refund before penalty, in-memory only, no windows fs exposure). the single outstanding item is a missing vitest case for the abort catch branch — worth adding but not a blocker given the broader retry suite passes and the logic is straightforward
- index.ts catch block lines 2349-2356 — the abort-refund path needs a dedicated test case

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| index.ts | adds prompt-cache counters (once per logical request, correctly outside both retry loops), surfaces them in deep and ui doctor snapshots via the shared formatter, and introduces abort short-circuit in the catch block; no raw key material surfaces; the new catch branch is missing a dedicated test |
| lib/ui/beginner.ts | adds formatPromptCacheKey (sha256 fingerprint for all key lengths, including short ones — prior verbatim-leak concern fully resolved), formatPromptCacheSnapshot, and two new doctor findings (prompt-cache-missing, prompt-cache-inconsistent) with correct totalRequests > 0 guard |
| test/beginner-ui.test.ts | solid coverage of formatPromptCacheKey (null/undefined/whitespace/short/long), formatPromptCacheSnapshot redaction, and all three doctor-finding branches (missing, inconsistent, zero-request guard); no raw keys asserted |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[client fetch called] --> B[transformRequestForCodex]
    B --> C{cacheKey present?}
    C -->|yes| D[promptCacheEnabledRequests++]
    C -->|no| E[promptCacheMissingRequests++]
    D --> F[enter account rotation loop]
    E --> F
    F --> G[consumeToken]
    G --> H[totalRequests++]
    H --> I[fetch URL]
    I -->|user abort| J[refundToken, throw - no penalty]
    I -->|network error| K[failedRequests++, recordFailure, rotate]
    I -->|success| L[process response]
    K --> F
    L --> M[codex-doctor snapshot]
    M --> N{totalRequests gt 0?}
    N -->|no| O[skip cache checks]
    N -->|yes| P{enabledRequests is 0?}
    P -->|yes| Q[finding: prompt-cache-missing]
    P -->|no| R{missingRequests gt 0?}
    R -->|yes| S[finding: prompt-cache-inconsistent]
    R -->|no| T[no cache finding]
    M --> U[formatPromptCacheKey]
    U --> V[sha256 fingerprint - no raw key output]
```

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aindex.ts%3A2349-2356%0A**abort%20refund%20path%20has%20no%20dedicated%20vitest%20coverage**%0A%0Athe%20new%20catch%20branch%20at%20lines%202350-2356%20%28abort%20%E2%86%92%20refund%20token%20%E2%86%92%20throw%29%20is%20the%20core%20safety%20guarantee%20of%20this%20PR%20%E2%80%94%20it%20prevents%20account%20health%20penalties%20for%20user%20cancellations.%20however%2C%20%60test%2Fbeginner-ui.test.ts%60%20only%20covers%20the%20ui%2Fdiagnostic%20layer%2C%20and%20the%20PR%20description%20says%20%60index-retry.test.ts%60%20%22still%20passes%22%20without%20adding%20a%20case%20that%20actually%20exercises%20this%20branch.%0A%0Awithout%20a%20test%2C%20regressions%20in%20the%20abort-refund%20path%20are%20invisible%3A%20if%20the%20%60abortSignal%3F.aborted%20%26%26%20fetchController.signal.aborted%60%20guard%20is%20accidentally%20removed%20or%20reordered%2C%20accounts%20would%20wrongly%20get%20failure%20penalties%20on%20every%20cancel.%0A%0Aadd%20a%20focused%20case%20in%20%60test%2Findex-retry.test.ts%60%20%28or%20a%20new%20%60test%2Findex-abort.test.ts%60%29%20that%3A%0A1.%20sets%20up%20a%20fetch%20mock%20that%20rejects%20with%20an%20%60AbortError%60%0A2.%20pre-fires%20the%20user%20abort%20signal%20before%20or%20during%20the%20fetch%0A3.%20asserts%20that%20%60accountManager.refundToken%60%20was%20called%0A4.%20asserts%20that%20%60accountManager.recordFailure%60%20was%20**not**%20called%0A%0A&repo=ndycode%2Foc-chatgpt-multi-auth"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_All_in_Codex-black?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=white"><img alt="Fix All in Codex" src="https://img.shields.io/badge/Fix_All_in_Codex-white?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=black"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: index.ts
Line: 2349-2356

Comment:
**abort refund path has no dedicated vitest coverage**

the new catch branch at lines 2350-2356 (abort → refund token → throw) is the core safety guarantee of this PR — it prevents account health penalties for user cancellations. however, `test/beginner-ui.test.ts` only covers the ui/diagnostic layer, and the PR description says `index-retry.test.ts` "still passes" without adding a case that actually exercises this branch.

without a test, regressions in the abort-refund path are invisible: if the `abortSignal?.aborted && fetchController.signal.aborted` guard is accidentally removed or reordered, accounts would wrongly get failure penalties on every cancel.

add a focused case in `test/index-retry.test.ts` (or a new `test/index-abort.test.ts`) that:
1. sets up a fetch mock that rejects with an `AbortError`
2. pre-fires the user abort signal before or during the fetch
3. asserts that `accountManager.refundToken` was called
4. asserts that `accountManager.recordFailure` was **not** called

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: ["fix: harden prompt c..."](https://github.com/ndycode/oc-chatgpt-multi-auth/commit/64502ff103f342d799bbb7b5b550c382b537fc32)</sub>

**Context used:**

- Rule used - What: Every code change must explain how it defend... ([source](https://app.greptile.com/review/custom-context?memory=637a42e6-7a78-40d6-9ef8-6a45e02e73b6))

<!-- /greptile_comment -->