### PR TITLE
make repository language stats TypeScript-only

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+eslint.config.js linguist-detectable=false
+scripts/*.js linguist-detectable=false
+scripts/*.sh linguist-detectable=false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,7 @@ OpenCode plugin: intercepts OpenAI SDK calls, routes through ChatGPT Codex backe
 - Source: root `index.ts` + `lib/`; `dist/` is generated output.
 - ESLint flat config: `no-explicit-any` enforced, unused args prefixed `_`.
 - Tests relax lint rules (see `eslint.config.js`).
-- Build copies `lib/oauth-success.html` to `dist/lib/` via `scripts/copy-oauth-success.js`.
+- Build emits `dist/lib/oauth-success.html` from the TypeScript source via `scripts/copy-oauth-success.js`.
 - ESM only (`"type": "module"`), Node >= 18.
 
 ## ANTI-PATTERNS (THIS PROJECT)

--- a/lib/auth/server.ts
+++ b/lib/auth/server.ts
@@ -1,19 +1,13 @@
 import http from "node:http";
-import fs from "node:fs";
-import path from "node:path";
-import { fileURLToPath } from "node:url";
 import type { OAuthServerInfo } from "../types.js";
 import { logError, logWarn } from "../logger.js";
+import { oauthSuccessHtml } from "../oauth-success.js";
 import {
 	OAUTH_CALLBACK_BIND_URL,
 	OAUTH_CALLBACK_LOOPBACK_HOST,
 	OAUTH_CALLBACK_PATH,
 	OAUTH_CALLBACK_PORT,
 } from "../runtime-contracts.js";
-
-// Resolve path to oauth-success.html (one level up from auth/ subfolder)
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const successHtml = fs.readFileSync(path.join(__dirname, "..", "oauth-success.html"), "utf-8");
 
 /**
  * Start a small local HTTP server that waits for /auth/callback and returns the code
@@ -46,7 +40,7 @@ export function startLocalOAuthServer({ state }: { state: string }): Promise<OAu
 			res.setHeader("X-Frame-Options", "DENY");
 			res.setHeader("X-Content-Type-Options", "nosniff");
 			res.setHeader("Content-Security-Policy", "default-src 'self'; script-src 'none'");
-			res.end(successHtml);
+			res.end(oauthSuccessHtml);
 			(server as http.Server & { _lastCode?: string })._lastCode = code;
 	} catch (err) {
 		logError(`Request handler error: ${(err as Error)?.message ?? String(err)}`);

--- a/lib/oauth-success.ts
+++ b/lib/oauth-success.ts
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+export const oauthSuccessHtml = String.raw`<!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="UTF-8">
@@ -642,7 +642,7 @@
                 if (isNearMouse) {
                     // Matrix green color when near mouse
                     const intensity = 1 - (distanceFromMouse / hoverRadius);
-                    ctx.fillStyle = `rgba(0, 255, 65, ${intensity * 0.95})`;
+                    ctx.fillStyle = \`rgba(0, 255, 65, \${intensity * 0.95})\`;
                     ctx.shadowBlur = 20 * intensity;
                     ctx.shadowColor = '#00ff41';
                 } else {
@@ -705,8 +705,9 @@
             const moveY = (e.clientY - window.innerHeight / 2) / 50;
 
             document.querySelector('.container').style.transform =
-                `translate(${moveX}px, ${moveY}px)`;
+                \`translate(\${moveX}px, \${moveY}px)\`;
         });
     </script>
 </body>
 </html>
+`;

--- a/scripts/copy-oauth-success.js
+++ b/scripts/copy-oauth-success.js
@@ -1,6 +1,6 @@
 import { promises as fs } from "node:fs";
 import { dirname, join, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -11,20 +11,30 @@ function normalizePathForCompare(path) {
 }
 
 function getDefaultPaths() {
-	const src = join(__dirname, "..", "lib", "oauth-success.html");
+	const modulePath = join(__dirname, "..", "dist", "lib", "oauth-success.js");
 	const dest = join(__dirname, "..", "dist", "lib", "oauth-success.html");
-	return { src, dest };
+	return { modulePath, dest };
+}
+
+async function loadOAuthSuccessHtml(modulePath) {
+	const moduleUrl = pathToFileURL(modulePath).href;
+	const mod = await import(moduleUrl);
+	if (typeof mod.oauthSuccessHtml !== "string") {
+		throw new TypeError(`Expected oauthSuccessHtml string export from ${modulePath}`);
+	}
+	return mod.oauthSuccessHtml;
 }
 
 export async function copyOAuthSuccessHtml(options = {}) {
 	const defaults = getDefaultPaths();
-	const src = options.src ?? defaults.src;
+	const modulePath = options.modulePath ?? defaults.modulePath;
 	const dest = options.dest ?? defaults.dest;
+	const html = options.html ?? (await loadOAuthSuccessHtml(modulePath));
 
 	await fs.mkdir(dirname(dest), { recursive: true });
-	await fs.copyFile(src, dest);
+	await fs.writeFile(dest, html, "utf-8");
 
-	return { src, dest };
+	return { modulePath, dest };
 }
 
 const isDirectRun = (() => {

--- a/test/copy-oauth-success.test.ts
+++ b/test/copy-oauth-success.test.ts
@@ -1,31 +1,29 @@
 import { describe, it, expect } from "vitest";
-import { mkdtemp, writeFile, readFile, rm } from "node:fs/promises";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
 describe("copy-oauth-success script", () => {
-  it("exports copyOAuthSuccessHtml() for reuse/testing", async () => {
-    const mod = await import("../scripts/copy-oauth-success.js");
-    expect(typeof mod.copyOAuthSuccessHtml).toBe("function");
-  });
+	it("exports copyOAuthSuccessHtml() for reuse/testing", async () => {
+		const mod = await import("../scripts/copy-oauth-success.js");
+		expect(typeof mod.copyOAuthSuccessHtml).toBe("function");
+	});
 
-  it("copies oauth-success.html to the requested destination", async () => {
-    const mod = await import("../scripts/copy-oauth-success.js");
+	it("copies oauth-success.html to the requested destination", async () => {
+		const mod = await import("../scripts/copy-oauth-success.js");
 
-    const root = await mkdtemp(join(tmpdir(), "opencode-oauth-success-"));
-    const src = join(root, "oauth-success.html");
-    const dest = join(root, "dist", "lib", "oauth-success.html");
+		const root = await mkdtemp(join(tmpdir(), "opencode-oauth-success-"));
+		const dest = join(root, "dist", "lib", "oauth-success.html");
 
-    try {
-      const html = "<!doctype html><html><body>ok</body></html>";
-      await writeFile(src, html, "utf-8");
+		try {
+			const html = "<!doctype html><html><body>ok</body></html>";
 
-      await mod.copyOAuthSuccessHtml({ src, dest });
+			await mod.copyOAuthSuccessHtml({ html, dest });
 
-      const copied = await readFile(dest, "utf-8");
-      expect(copied).toBe(html);
-    } finally {
-      await rm(root, { recursive: true, force: true });
-    }
-  });
+			const copied = await readFile(dest, "utf-8");
+			expect(copied).toBe(html);
+		} finally {
+			await rm(root, { recursive: true, force: true });
+		}
+	});
 });

--- a/test/oauth-server.integration.test.ts
+++ b/test/oauth-server.integration.test.ts
@@ -30,6 +30,7 @@ describe("OAuth Server Integration", () => {
 		const response = await fetch(callbackUrl);
 		expect(response.status).toBe(200);
 		expect(response.headers.get("content-type")).toContain("text/html");
+		expect(await response.text()).toContain("ACCESS GRANTED");
 
 		// Server should have captured the code
 		const result = await serverInfo.waitForCode(testState);

--- a/test/server.unit.test.ts
+++ b/test/server.unit.test.ts
@@ -27,10 +27,8 @@ vi.mock('node:http', () => {
 	};
 });
 
-vi.mock('node:fs', () => ({
-	default: {
-		readFileSync: vi.fn(() => '<html>Success</html>'),
-	},
+vi.mock('../lib/oauth-success.js', () => ({
+	oauthSuccessHtml: '<html>Success</html>',
 }));
 
 vi.mock('../lib/logger.js', () => ({


### PR DESCRIPTION
## Summary

- move the tracked OAuth success page source into `lib/oauth-success.ts` and keep the generated `dist/lib/oauth-success.html` build artifact
- serve the OAuth callback page directly from the TypeScript source in `lib/auth/server.ts`
- add narrow `.gitattributes` rules so helper JavaScript and shell files stop counting toward GitHub Linguist stats

## Testing

- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm test`
- [ ] Not applicable

## Compliance Confirmation

- [x] This change stays within the repository scope and OpenAI Terms of Service expectations.
- [x] This change uses official authentication flows only and does not add bypass, scraping, or credential-sharing behavior.
- [x] I updated tests and documentation when the change affected users, maintainers, or repository behavior.

## Notes

- Linked issue: none
- Follow-up work or rollout notes: also ran `npm run typecheck`; GitHub Linguist should recalculate to TypeScript-only after merge/reindex.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Optimized OAuth success page delivery mechanism to ensure consistent response handling.

* **Tests**
  * Enhanced OAuth server integration tests to verify success page content is returned correctly.

* **Chores**
  * Added build configuration to control GitHub language detection.

* **Documentation**
  * Updated documentation describing the OAuth success page build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->