### PR TITLE
fix(safety): serialize auth-failure increment + flip destructive defaults

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1871,7 +1871,7 @@ while (attempted.size < Math.max(1, accountCount)) {
 				runtimeMetrics.accountRotations++;
 				runtimeMetrics.lastError = (err as Error)?.message ?? String(err);
 				runtimeMetrics.lastErrorCategory = "auth-refresh";
-				const failures = accountManager.incrementAuthFailures(account);
+				const failures = await accountManager.incrementAuthFailures(account);
 				const accountLabel = formatAccountLabel(account, account.index);
 				
 				if (failures >= ACCOUNT_LIMITS.MAX_AUTH_FAILURES_BEFORE_REMOVAL) {
@@ -5993,14 +5993,41 @@ while (attempted.size < Math.max(1, accountCount)) {
 				},
 			}),
 			"codex-remove": tool({
-				description: "Remove one Codex account entry by index (1-based) or interactive picker when index is omitted.",
+				description:
+					"Remove one Codex account entry by index (1-based) or interactive picker when index is omitted. " +
+					"Requires confirm=true to proceed; this is a destructive operation and OAuth state cannot be recovered.",
 				args: {
 					index: tool.schema.number().optional().describe(
 						"Account number to remove (1-based, e.g., 1 for first account)",
 					),
+					confirm: tool.schema.boolean().optional().describe(
+						"Must be set to true to actually remove the account. " +
+							"When omitted or false, the tool is a no-op and returns a guidance message. " +
+							"This guard prevents silent loss of OAuth credentials from a mistyped index.",
+					),
 				},
-				async execute({ index }: { index?: number } = {}) {
+				async execute({ index, confirm }: { index?: number; confirm?: boolean } = {}) {
 					const ui = resolveUiRuntime();
+					// Destructive-operation guard: require explicit `confirm: true`.
+					// Rationale: audit `docs/audits/04-high-priority.md` (codex-remove
+					// has no confirmation step) — removing an account deletes OAuth
+					// refresh-token material, which is unrecoverable without a fresh
+					// `opencode auth login`.
+					if (confirm !== true) {
+						const guidance =
+							"codex-remove requires confirm=true to proceed. " +
+							"Removing an account deletes its OAuth credentials and cannot be undone. " +
+							"Re-run as: codex-remove index=<N> confirm=true";
+						if (ui.v2Enabled) {
+							return [
+								...formatUiHeader(ui, "Remove account"),
+								"",
+								formatUiItem(ui, "Confirmation required.", "warning"),
+								formatUiItem(ui, guidance, "muted"),
+							].join("\n");
+						}
+						return guidance;
+					}
 					const storage = await loadAccounts();
 					if (!storage || storage.accounts.length === 0) {
 						if (ui.v2Enabled) {

--- a/lib/accounts.ts
+++ b/lib/accounts.ts
@@ -215,6 +215,13 @@ export class AccountManager {
 	private saveDebounceTimer: ReturnType<typeof setTimeout> | null = null;
 	private pendingSave: Promise<void> | null = null;
 	private authFailuresByRefreshToken: Map<string, number> = new Map();
+	/**
+	 * Per-refresh-token promise chain used to serialize concurrent
+	 * `incrementAuthFailures` calls. Prevents lost updates when two org-variant
+	 * accounts that share a refresh token observe an auth failure at once — see
+	 * audit finding `docs/audits/03-critical-issues.md` (ledger id `47`).
+	 */
+	private incrementAuthFailuresChain: Map<string, Promise<number>> = new Map();
 
 	static async loadFromDisk(authFallback?: OAuthAuthDetails): Promise<AccountManager> {
 		const stored = await loadAccounts();
@@ -725,11 +732,46 @@ export class AccountManager {
 		delete account.cooldownReason;
 	}
 
-	incrementAuthFailures(account: ManagedAccount): number {
-		const currentFailures = this.authFailuresByRefreshToken.get(account.refreshToken) ?? 0;
-		const newFailures = currentFailures + 1;
-		this.authFailuresByRefreshToken.set(account.refreshToken, newFailures);
-		return newFailures;
+	/**
+	 * Atomically increment the auth-failure counter for the account's refresh
+	 * token and return the post-increment value.
+	 *
+	 * The read-modify-write is serialized through a per-refresh-token promise
+	 * chain so that concurrent callers (for example, two org-variant accounts
+	 * sharing a refresh token that fail auth simultaneously) cannot lose an
+	 * increment. Without serialization both callers could read the same stale
+	 * value, both compute `+1`, and both write the same result — masking a hard
+	 * auth failure and causing the manager to keep hammering a dead token.
+	 *
+	 * Callers must `await` the returned promise before branching on the
+	 * threshold (see `index.ts` auth-refresh failure path).
+	 */
+	async incrementAuthFailures(account: ManagedAccount): Promise<number> {
+		const key = account.refreshToken;
+		const prev = this.incrementAuthFailuresChain.get(key) ?? Promise.resolve(0);
+		const next = prev.then(() => {
+			const currentFailures = this.authFailuresByRefreshToken.get(key) ?? 0;
+			const newFailures = currentFailures + 1;
+			this.authFailuresByRefreshToken.set(key, newFailures);
+			return newFailures;
+		});
+		this.incrementAuthFailuresChain.set(key, next);
+		try {
+			return await next;
+		} finally {
+			// Drop the chain entry only if no later caller has already replaced it.
+			if (this.incrementAuthFailuresChain.get(key) === next) {
+				this.incrementAuthFailuresChain.delete(key);
+			}
+		}
+	}
+
+	/**
+	 * Return the current auth-failure counter for the account's refresh token
+	 * without mutating state. Intended for tests and diagnostics.
+	 */
+	getAuthFailures(account: ManagedAccount): number {
+		return this.authFailuresByRefreshToken.get(account.refreshToken) ?? 0;
 	}
 
 	/**

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -59,7 +59,17 @@ export function getWorkspaceIdentityKey(account: {
 	return `refreshToken:${refreshToken}`;
 }
 
-export type ImportBackupMode = "none" | "best-effort" | "required";
+/**
+ * Backup policy for `importAccounts`.
+ *
+ * - `none`: do not create a pre-import backup (destructive; opt-in only).
+ * - `timestamped`: create a timestamped pre-import backup, continue on failure.
+ *   This is the default — see audit finding `docs/audits/04-high-priority.md`.
+ * - `best-effort`: legacy alias for `timestamped`, retained for callers that
+ *   were written against the prior enum.
+ * - `required`: backup must succeed or the import aborts.
+ */
+export type ImportBackupMode = "none" | "timestamped" | "best-effort" | "required";
 
 export interface ImportAccountsOptions {
 	/**
@@ -68,10 +78,9 @@ export interface ImportAccountsOptions {
 	 */
 	preImportBackupPrefix?: string;
 	/**
-	 * Backup policy before import apply:
-	 * - none: do not create a pre-import backup
-	 * - best-effort: attempt backup, continue on failure
-	 * - required: backup must succeed or import aborts
+	 * Backup policy before import apply. Defaults to `"timestamped"` so that the
+	 * prior on-disk state is preserved unless the caller explicitly opts out via
+	 * `{ backupMode: "none" }`.
 	 */
 	backupMode?: ImportBackupMode;
 }
@@ -1302,15 +1311,28 @@ export async function previewImportAccounts(
 
 /**
  * Exports current accounts to a JSON file for backup/migration.
- * @param filePath - Destination file path
- * @param force - If true, overwrite existing file (default: true)
- * @throws Error if file exists and force is false, or if no accounts to export
+ *
+ * Safety default (audit `docs/audits/04-high-priority.md`):
+ * `force` defaults to `false` so an existing export file is never silently
+ * overwritten. Callers that need the prior destructive behaviour must opt in
+ * via `exportAccounts(path, true)`.
+ *
+ * @param filePath - Destination file path.
+ * @param force - If true, overwrite any existing file at `filePath`. Defaults to
+ *   `false`; when false and the file exists, a `StorageError` is thrown.
+ * @throws StorageError if the file already exists and `force` is `false`.
+ * @throws Error if there are no accounts to export.
  */
-export async function exportAccounts(filePath: string, force = true): Promise<void> {
+export async function exportAccounts(filePath: string, force = false): Promise<void> {
   const resolvedPath = resolvePath(filePath);
-  
+
   if (!force && existsSync(resolvedPath)) {
-    throw new Error(`File already exists: ${resolvedPath}`);
+    throw new StorageError(
+      `Refusing to overwrite existing export file: ${resolvedPath}. Pass force=true to overwrite.`,
+      "EEXIST",
+      resolvedPath,
+      "Re-run the export with force=true if you intend to replace the existing file, or choose a new path.",
+    );
   }
   
   const storage = await withAccountStorageTransaction((current) => Promise.resolve(current));
@@ -1329,6 +1351,12 @@ export async function exportAccounts(filePath: string, force = true): Promise<vo
  * Imports accounts from a JSON file, merging with existing accounts.
  * Deduplicates by identity key first (organizationId -> accountId -> refreshToken),
  * then applies legacy email dedupe only to entries without organizationId/accountId.
+ *
+ * Safety default (audit `docs/audits/04-high-priority.md`):
+ * `options.backupMode` defaults to `"timestamped"` so a pre-import snapshot of
+ * the existing accounts file is always written before apply. Callers that need
+ * the prior destructive default must pass `{ backupMode: "none" }` explicitly.
+ *
  * @param filePath - Source file path
  * @throws Error if file is invalid or would exceed MAX_ACCOUNTS
  */
@@ -1337,7 +1365,7 @@ export async function importAccounts(
 	options: ImportAccountsOptions = {},
 ): Promise<ImportAccountsResult> {
   const { resolvedPath, normalized } = await readAndNormalizeImportFile(filePath);
-  const backupMode = options.backupMode ?? "none";
+  const backupMode = options.backupMode ?? "timestamped";
   const backupPrefix = options.preImportBackupPrefix ?? "codex-pre-import-backup";
   
   const {

--- a/test/accounts.test.ts
+++ b/test/accounts.test.ts
@@ -757,7 +757,7 @@ describe("AccountManager", () => {
   });
 
   describe("auth failure tracking", () => {
-    it("increments consecutive auth failures", () => {
+    it("increments consecutive auth failures", async () => {
       const now = Date.now();
       const stored = {
         version: 3 as const,
@@ -769,13 +769,13 @@ describe("AccountManager", () => {
 
       const manager = new AccountManager(undefined, stored);
       const account = manager.getCurrentAccount()!;
-      
-      expect(manager.incrementAuthFailures(account)).toBe(1);
-      expect(manager.incrementAuthFailures(account)).toBe(2);
-      expect(manager.incrementAuthFailures(account)).toBe(3);
+
+      expect(await manager.incrementAuthFailures(account)).toBe(1);
+      expect(await manager.incrementAuthFailures(account)).toBe(2);
+      expect(await manager.incrementAuthFailures(account)).toBe(3);
     });
 
-    it("clears auth failures", () => {
+    it("clears auth failures", async () => {
       const now = Date.now();
       const stored = {
         version: 3 as const,
@@ -789,17 +789,17 @@ describe("AccountManager", () => {
       const account = manager.getCurrentAccount()!;
 
       // Increment failures twice
-      expect(manager.incrementAuthFailures(account)).toBe(1);
-      expect(manager.incrementAuthFailures(account)).toBe(2);
+      expect(await manager.incrementAuthFailures(account)).toBe(1);
+      expect(await manager.incrementAuthFailures(account)).toBe(2);
 
       // Clear failures
       manager.clearAuthFailures(account);
 
       // After clearing, increment should start from 0 (returning 1)
-      expect(manager.incrementAuthFailures(account)).toBe(1);
+      expect(await manager.incrementAuthFailures(account)).toBe(1);
     });
 
-    it("tracks failures per refreshToken across multiple accounts", () => {
+    it("tracks failures per refreshToken across multiple accounts", async () => {
       const now = Date.now();
       const stored = {
         version: 3 as const,
@@ -820,13 +820,14 @@ describe("AccountManager", () => {
       const account3 = accounts[2];
       const account4 = accounts[3];
 
-      // Increment failures on first account (token-1)
-      expect(manager.incrementAuthFailures(account1)).toBe(1);
-      expect(manager.incrementAuthFailures(account2)).toBe(2);
-      expect(manager.incrementAuthFailures(account3)).toBe(3);
+      // Increment failures on first account (token-1). Calls are issued
+      // sequentially (serial awaits) so the counter advances deterministically.
+      expect(await manager.incrementAuthFailures(account1)).toBe(1);
+      expect(await manager.incrementAuthFailures(account2)).toBe(2);
+      expect(await manager.incrementAuthFailures(account3)).toBe(3);
 
       // Different token should start from 0
-      expect(manager.incrementAuthFailures(account4)).toBe(1);
+      expect(await manager.incrementAuthFailures(account4)).toBe(1);
     });
 
     it("removes all accounts with the same refreshToken", () => {
@@ -856,7 +857,7 @@ describe("AccountManager", () => {
       expect(manager.getAccountsSnapshot()[0].refreshToken).toBe("token-2");
     });
 
-    it("clears auth failure counter when removing accounts with same refreshToken", () => {
+    it("clears auth failure counter when removing accounts with same refreshToken", async () => {
       const now = Date.now();
       const stored = {
         version: 3 as const,
@@ -873,12 +874,12 @@ describe("AccountManager", () => {
       const account1 = accounts[0];
 
       // Increment auth failures for token-1
-      expect(manager.incrementAuthFailures(account1)).toBe(1);
-      expect(manager.incrementAuthFailures(account1)).toBe(2);
-      expect(manager.incrementAuthFailures(accounts[1])).toBe(3);
+      expect(await manager.incrementAuthFailures(account1)).toBe(1);
+      expect(await manager.incrementAuthFailures(account1)).toBe(2);
+      expect(await manager.incrementAuthFailures(accounts[1])).toBe(3);
 
       // Verify failures are tracked
-      expect(manager.incrementAuthFailures(account1)).toBe(4);
+      expect(await manager.incrementAuthFailures(account1)).toBe(4);
 
       // Remove all accounts with token-1
       const removedCount = manager.removeAccountsWithSameRefreshToken(account1);
@@ -889,7 +890,7 @@ describe("AccountManager", () => {
         "authFailuresByRefreshToken",
       ) as Map<string, number>;
       expect(failuresByRefreshToken.has("token-1")).toBe(false);
-      expect(manager.incrementAuthFailures(account1)).toBe(1);
+      expect(await manager.incrementAuthFailures(account1)).toBe(1);
     });
   });
 
@@ -1065,7 +1066,7 @@ describe("AccountManager", () => {
       expect(account.accountIdSource).toBe("org");
     });
 
-    it("clears stale auth failure state when refresh token rotates", () => {
+    it("clears stale auth failure state when refresh token rotates", async () => {
       const now = Date.now();
       const stored = {
         version: 3 as const,
@@ -1077,7 +1078,7 @@ describe("AccountManager", () => {
 
       const manager = new AccountManager(undefined, stored);
       const account = manager.getCurrentAccount()!;
-      expect(manager.incrementAuthFailures(account)).toBe(1);
+      expect(await manager.incrementAuthFailures(account)).toBe(1);
 
       const newAuth: OAuthAuthDetails = {
         type: "oauth",
@@ -1093,7 +1094,7 @@ describe("AccountManager", () => {
         "authFailuresByRefreshToken",
       ) as Map<string, number>;
       expect(failuresByRefreshToken.has("old-token")).toBe(false);
-      expect(manager.incrementAuthFailures(account)).toBe(1);
+      expect(await manager.incrementAuthFailures(account)).toBe(1);
     });
   });
 
@@ -2077,5 +2078,71 @@ describe("AccountManager", () => {
       expect(byIndex.get(3)?.eligible).toBe(true);
       expect(byIndex.get(3)?.reasons).toEqual(["eligible"]);
     });
+  });
+});
+
+describe("incrementAuthFailures serialization (audit ledger 47)", () => {
+  it("accumulates exactly N when N concurrent increments race on a shared refresh token", async () => {
+    const now = Date.now();
+    // Two org-variant accounts sharing the same refresh token — the exact
+    // topology that triggers the audited CRITICAL race.
+    const stored = {
+      version: 3 as const,
+      activeIndex: 0,
+      accounts: [
+        { refreshToken: "shared-token", addedAt: now, lastUsed: now },
+        {
+          refreshToken: "shared-token",
+          organizationId: "org-a",
+          addedAt: now,
+          lastUsed: now,
+        },
+      ],
+    };
+
+    const manager = new AccountManager(undefined, stored);
+    const snapshot = manager.getAccountsSnapshot();
+    const a1 = snapshot[0];
+    const a2 = snapshot[1];
+
+    const concurrentCalls = 100;
+    const results = await Promise.all(
+      Array.from({ length: concurrentCalls }, (_, idx) =>
+        // Alternate callers to simulate both org variants hitting the method
+        manager.incrementAuthFailures(idx % 2 === 0 ? a1 : a2),
+      ),
+    );
+
+    expect(manager.getAuthFailures(a1)).toBe(concurrentCalls);
+    // Both accounts see the same counter since they share refreshToken.
+    expect(manager.getAuthFailures(a2)).toBe(concurrentCalls);
+
+    // Every resolved value must be distinct and cover 1..N contiguously.
+    const sorted = [...results].sort((x, y) => x - y);
+    for (let i = 0; i < concurrentCalls; i += 1) {
+      expect(sorted[i]).toBe(i + 1);
+    }
+  });
+
+  it("keeps counters isolated per refresh token under concurrent load", async () => {
+    const now = Date.now();
+    const stored = {
+      version: 3 as const,
+      activeIndex: 0,
+      accounts: [
+        { refreshToken: "token-A", addedAt: now, lastUsed: now },
+        { refreshToken: "token-B", addedAt: now, lastUsed: now },
+      ],
+    };
+    const manager = new AccountManager(undefined, stored);
+    const [accA, accB] = manager.getAccountsSnapshot();
+
+    await Promise.all([
+      ...Array.from({ length: 50 }, () => manager.incrementAuthFailures(accA)),
+      ...Array.from({ length: 25 }, () => manager.incrementAuthFailures(accB)),
+    ]);
+
+    expect(manager.getAuthFailures(accA)).toBe(50);
+    expect(manager.getAuthFailures(accB)).toBe(25);
   });
 });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -510,7 +510,7 @@ type PluginType = {
 		"codex-note": ToolExecute<{ index?: number; note: string }>;
 		"codex-dashboard": OptionalToolExecute<{ format?: string; includeSensitive?: boolean }>;
 		"codex-health": OptionalToolExecute<{ format?: string; includeSensitive?: boolean }>;
-		"codex-remove": OptionalToolExecute<{ index?: number }>;
+		"codex-remove": OptionalToolExecute<{ index?: number; confirm?: boolean }>;
 		"codex-refresh": ToolExecute;
 		"codex-export": ToolExecute<{ path?: string; force?: boolean; timestamped?: boolean }>;
 		"codex-import": ToolExecute<{ path: string; dryRun?: boolean }>;
@@ -1958,20 +1958,20 @@ describe("OpenAIOAuthPlugin", () => {
 	describe("codex-remove tool", () => {
 		it("returns error when no accounts", async () => {
 			mockStorage.accounts = [];
-			const result = await plugin.tool["codex-remove"].execute({ index: 1 });
+			const result = await plugin.tool["codex-remove"].execute({ index: 1, confirm: true });
 			expect(result).toContain("No Codex accounts configured");
 		});
 
 		it("returns guidance when index is omitted in non-interactive mode", async () => {
 			mockStorage.accounts = [{ refreshToken: "r1", email: "user@example.com" }];
-			const result = await plugin.tool["codex-remove"].execute();
+			const result = await plugin.tool["codex-remove"].execute({ confirm: true });
 			expect(result).toContain("Missing account number");
 			expect(result).toContain("codex-remove index=2");
 		});
 
 		it("returns error for invalid index", async () => {
 			mockStorage.accounts = [{ refreshToken: "r1" }];
-			const result = await plugin.tool["codex-remove"].execute({ index: 5 });
+			const result = await plugin.tool["codex-remove"].execute({ index: 5, confirm: true });
 			expect(result).toContain("Invalid account number");
 		});
 
@@ -1980,16 +1980,48 @@ describe("OpenAIOAuthPlugin", () => {
 				{ refreshToken: "r1", email: "user1@example.com" },
 				{ refreshToken: "r2", email: "user2@example.com" },
 			];
-			const result = await plugin.tool["codex-remove"].execute({ index: 1 });
+			const result = await plugin.tool["codex-remove"].execute({ index: 1, confirm: true });
 			expect(result).toContain("Removed");
 			expect(mockStorage.accounts).toHaveLength(1);
 		});
 
 		it("handles removal of last account", async () => {
 			mockStorage.accounts = [{ refreshToken: "r1", email: "user@example.com" }];
-			const result = await plugin.tool["codex-remove"].execute({ index: 1 });
+			const result = await plugin.tool["codex-remove"].execute({ index: 1, confirm: true });
 			expect(result).toContain("Removed");
 			expect(result).toContain("No accounts remaining");
+		});
+
+		it("refuses to remove without confirm=true (destructive-default guard)", async () => {
+			mockStorage.accounts = [
+				{ refreshToken: "r1", email: "user1@example.com" },
+				{ refreshToken: "r2", email: "user2@example.com" },
+			];
+			// No args at all: no account touched.
+			const noArgsResult = await plugin.tool["codex-remove"].execute();
+			expect(noArgsResult).toContain("confirm=true");
+			expect(mockStorage.accounts).toHaveLength(2);
+
+			// Explicit confirm=false: still no-op.
+			const falseConfirmResult = await plugin.tool["codex-remove"].execute({
+				index: 1,
+				confirm: false,
+			});
+			expect(falseConfirmResult).toContain("confirm=true");
+			expect(mockStorage.accounts).toHaveLength(2);
+
+			// Valid index but no confirm: still no-op.
+			const missingConfirmResult = await plugin.tool["codex-remove"].execute({ index: 1 });
+			expect(missingConfirmResult).toContain("confirm=true");
+			expect(mockStorage.accounts).toHaveLength(2);
+
+			// Finally, pass confirm=true and verify removal proceeds.
+			const confirmedResult = await plugin.tool["codex-remove"].execute({
+				index: 1,
+				confirm: true,
+			});
+			expect(confirmedResult).toContain("Removed");
+			expect(mockStorage.accounts).toHaveLength(1);
 		});
 	});
 
@@ -2284,7 +2316,7 @@ describe("OpenAIOAuthPlugin edge cases", () => {
 		const { OpenAIOAuthPlugin } = await import("../index.js");
 		const plugin = await OpenAIOAuthPlugin({ client: mockClient } as never) as unknown as PluginType;
 
-		const result = await plugin.tool["codex-remove"].execute({ index: 1 });
+		const result = await plugin.tool["codex-remove"].execute({ index: 1, confirm: true });
 		expect(result).toContain("failed to persist");
 	});
 
@@ -2304,7 +2336,7 @@ describe("OpenAIOAuthPlugin edge cases", () => {
 		const { OpenAIOAuthPlugin } = await import("../index.js");
 		const plugin = await OpenAIOAuthPlugin({ client: mockClient } as never) as unknown as PluginType;
 
-		await plugin.tool["codex-remove"].execute({ index: 1 });
+		await plugin.tool["codex-remove"].execute({ index: 1, confirm: true });
 		// After removing account at 0-based index 0, length is 2.
 		// activeIndex (2) >= length (2), so it resets to 0
 		expect(mockStorage.activeIndex).toBe(0);
@@ -2324,7 +2356,7 @@ describe("OpenAIOAuthPlugin edge cases", () => {
 		const { OpenAIOAuthPlugin } = await import("../index.js");
 		const plugin = await OpenAIOAuthPlugin({ client: mockClient } as never) as unknown as PluginType;
 
-		await plugin.tool["codex-remove"].execute({ index: 2 });
+		await plugin.tool["codex-remove"].execute({ index: 2, confirm: true });
 		expect(mockStorage.activeIndex).toBe(0);
 	});
 });

--- a/test/storage.test.ts
+++ b/test/storage.test.ts
@@ -153,7 +153,29 @@ describe("storage", () => {
     it("should fail export if file exists and force is false", async () => {
       await fs.writeFile(exportPath, "exists");
 
-      await expect(exportAccounts(exportPath, false)).rejects.toThrow(/already exists/);
+      await expect(exportAccounts(exportPath, false)).rejects.toThrow(StorageError);
+      await expect(exportAccounts(exportPath, false)).rejects.toThrow(/Refusing to overwrite/);
+    });
+
+    it("defaults to non-destructive export (force=false) and refuses to overwrite", async () => {
+      // Arrange: populate storage and a pre-existing export target.
+      const storage = {
+        version: 3,
+        activeIndex: 0,
+        accounts: [{ accountId: "test", refreshToken: "ref", addedAt: 1, lastUsed: 2 }],
+      };
+      await saveAccounts(storage);
+      await fs.writeFile(exportPath, "pre-existing");
+
+      // Act + assert: no `force` argument → must refuse.
+      await expect(exportAccounts(exportPath)).rejects.toThrow(StorageError);
+      // File contents preserved (not overwritten by a silent export).
+      expect(await fs.readFile(exportPath, "utf-8")).toBe("pre-existing");
+
+      // Explicit opt-in (force=true) is required to overwrite.
+      await exportAccounts(exportPath, true);
+      const overwritten = JSON.parse(await fs.readFile(exportPath, "utf-8"));
+      expect(overwritten.accounts[0].accountId).toBe("test");
     });
 
     it("should import accounts from a file and merge", async () => {
@@ -765,6 +787,73 @@ describe("storage", () => {
       const loaded = await loadAccounts();
       expect(loaded?.accounts).toHaveLength(1);
       expect(loaded?.accounts[0]?.accountId).toBe("existing");
+    });
+
+    it("defaults to a timestamped pre-import backup when no backupMode is supplied", async () => {
+      // Arrange: existing storage so there is something to back up.
+      await saveAccounts({
+        version: 3,
+        activeIndex: 0,
+        accounts: [
+          { accountId: "existing", refreshToken: "ref-existing", addedAt: 1, lastUsed: 1 },
+        ],
+      });
+
+      await fs.writeFile(
+        exportPath,
+        JSON.stringify({
+          version: 3,
+          activeIndex: 0,
+          accounts: [
+            { accountId: "imported", refreshToken: "ref-imported", addedAt: 2, lastUsed: 2 },
+          ],
+        }),
+      );
+
+      // Act: call with NO backupMode option — must default to a safe backup.
+      const result = await importAccounts(exportPath, {
+        preImportBackupPrefix: "codex-pre-import-backup-default",
+      });
+
+      // Assert: backup was created; path filename carries the prefix used above.
+      expect(result.backupStatus).toBe("created");
+      expect(result.backupPath).toBeDefined();
+      expect(result.backupPath).toMatch(/codex-pre-import-backup-default/);
+      // Backup file exists on disk and is readable JSON representing prior state.
+      expect(existsSync(result.backupPath!)).toBe(true);
+      const backupContent = JSON.parse(await fs.readFile(result.backupPath!, "utf-8"));
+      expect(backupContent.accounts[0].accountId).toBe("existing");
+
+      // And the import itself applied as expected.
+      const loaded = await loadAccounts();
+      expect(loaded?.accounts.map((a) => a.accountId)).toContain("imported");
+      expect(loaded?.accounts.map((a) => a.accountId)).toContain("existing");
+    });
+
+    it("honours backupMode: 'none' opt-out for callers that want the legacy behaviour", async () => {
+      await saveAccounts({
+        version: 3,
+        activeIndex: 0,
+        accounts: [
+          { accountId: "existing", refreshToken: "ref-existing", addedAt: 1, lastUsed: 1 },
+        ],
+      });
+
+      await fs.writeFile(
+        exportPath,
+        JSON.stringify({
+          version: 3,
+          activeIndex: 0,
+          accounts: [
+            { accountId: "imported", refreshToken: "ref-imported", addedAt: 2, lastUsed: 2 },
+          ],
+        }),
+      );
+
+      const result = await importAccounts(exportPath, { backupMode: "none" });
+
+      expect(result.backupStatus).toBe("skipped");
+      expect(result.backupPath).toBeUndefined();
     });
   });
 


### PR DESCRIPTION
## Summary

Phase-1 safety remediation from the repo audit at SHA `d92a8eed`. This PR fixes the single CRITICAL finding plus three destructive-default HIGHs flagged in `docs/audits/`. Forked directly from `main` (not from the audit-docs branch) so it is independently reviewable.

## Changes

- **CRITICAL fix — `lib/accounts.ts`**: Serialize `AccountManager.incrementAuthFailures` via a per-refresh-token promise chain. The method is now `async` and atomically increments the auth-failure counter, preventing lost updates when two org-variant accounts that share a refresh token observe an auth failure concurrently. Without serialization both callers could read the same stale value, both compute `+1`, and both write the same result — masking a hard-auth failure and causing the manager to keep hammering a dead token (stuck-login/loop-429). Closes audit ledger `47`. See `docs/audits/03-critical-issues.md` and `docs/audits/14-top20.md` item #1. Added `getAuthFailures` helper for tests/diagnostics. Updated the one production caller in `index.ts` to `await` the returned promise.

- **Data-safety default — `lib/storage.ts` `importAccounts`**: `backupMode` now defaults to `"timestamped"` (was `"none"`). A pre-import backup of the existing accounts file is always written before apply. Callers that need the prior destructive default must pass `{ backupMode: "none" }` explicitly. New enum value `"timestamped"` is added alongside the existing `"best-effort"` alias (kept for backward compatibility) and `"required"`. See `docs/audits/04-high-priority.md` and `docs/audits/14-top20.md` item #5.

- **Data-safety default — `lib/storage.ts` `exportAccounts`**: `force` now defaults to `false` (was `true`). When `force=false` and the target file exists, a `StorageError` is thrown with code `EEXIST` and a clear hint. Callers must opt in with `force=true` to overwrite. See `docs/audits/04-high-priority.md` and `docs/audits/14-top20.md` item #5.

- **UX guard — `index.ts` `codex-remove` tool**: The tool now requires an explicit `confirm: true` argument. When omitted or set to `false`, the tool is a no-op and returns a guidance message; no account is touched. Prevents silent loss of OAuth refresh-token material from a mistyped index in a scripted workflow. See `docs/audits/04-high-priority.md` (ledger `175`) and `docs/audits/14-top20.md` item #4.

## Tests

New tests added / existing tests updated to cover each change:

- `test/accounts.test.ts`
  - Race test: 100 concurrent `incrementAuthFailures` calls (alternating between two org-variant accounts that share a refresh token) arrive at exactly 100 with contiguous values 1..100 and no lost updates.
  - Per-token isolation test: 50 concurrent increments on token-A and 25 concurrent increments on token-B settle at exactly 50 and 25 respectively.
  - Pre-existing synchronous tests updated to `await` the new async method.

- `test/storage.test.ts`
  - `importAccounts` default-backup test: calling with no `backupMode` option creates a timestamped backup file on disk; the backup JSON contains the prior accounts state.
  - `importAccounts` opt-out test: passing `{ backupMode: "none" }` preserves the legacy no-backup behaviour.
  - `exportAccounts` non-destructive-default test: calling without `force` refuses to overwrite an existing file, throws `StorageError`, and preserves the original file contents; `force=true` restores overwrite behaviour. Existing `force=false` test updated to assert the new `StorageError` type and message.

- `test/index.test.ts`
  - `codex-remove` confirm-guard test: no-args, `confirm: false`, and `confirm` omitted all return guidance text containing `confirm=true` and leave accounts unchanged; `confirm: true` proceeds to remove the selected account. All other pre-existing `codex-remove` tests updated to pass `confirm: true`.

## Audit refs

- `docs/audits/03-critical-issues.md` — CRITICAL ledger `47`
- `docs/audits/04-high-priority.md` — `codex-remove` confirmation + destructive import/export defaults
- `docs/audits/14-top20.md` — items #1, #4, #5

## Verification

Full pipeline run locally on `fix/phase1-safety-defaults`:

- `npm run typecheck` → exit 0
- `npm run lint` → exit 0 (no new warnings)
- `npm test` → 2076/2076 passed, 64 test files
- `npm run build` → exit 0

## Risk

LOW. Every change is a defensive narrowing of existing behaviour; callers that need the prior behaviour can opt in explicitly via a single argument. No `as any` / `@ts-ignore` / `@ts-expect-error` introduced.

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---


<h3>Greptile Summary</h3>

this pr lands phase-1 safety remediations: serializes `incrementAuthFailures` through a per-token promise chain, flips `importAccounts` backup default from `\"none\"` to `\"timestamped\"`, flips `exportAccounts` `force` default from `true` to `false`, and gates `codex-remove` behind an explicit `confirm: true`. the serialization approach is correct for node.js's microtask model — all pending chain entries drain before any new macrotask can interleave a `clearAuthFailures` call.

- mock stubs for `incrementAuthFailures` in `test/index.test.ts` return a bare `number` instead of `Promise<number>` at lines 430, 3009, 3202, and 3317; while `await 1` works at runtime, the mocks don't faithfully represent the async contract and won't catch regressions where a caller chains `.then()` directly.

<h3>Confidence Score: 5/5</h3>

safe to merge; all remaining findings are P2 style suggestions that don't affect runtime correctness

the critical serialization fix is correct — node.js microtask semantics guarantee pending chain entries drain before any macrotask (e.g. a concurrent clearAuthFailures from a different request) can interleave. the destructive-default flips and confirm guard are clean defensive narrows. test coverage is thorough. the only P2 is sync mock stubs that coerce safely via `await` but misrepresent the async contract.

test/index.test.ts — manual AccountManager mock stubs at lines 430, 3009, 3202, 3317 should return Promise.resolve(1)

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| lib/accounts.ts | serializes `incrementAuthFailures` via per-token promise chain; cleanup logic correctly uses identity comparison to avoid over-eager deletion; `getAuthFailures` helper added for diagnostics |
| lib/storage.ts | safe default changes: `importAccounts` defaults to `"timestamped"` backup, `exportAccounts` defaults to `force=false`; `StorageError` used for the EEXIST case gives callers a typed signal |
| index.ts | adds `await` to `incrementAuthFailures` call; adds `confirm: true` guard to `codex-remove`; `codex-export` already passes `force ?? true` so not affected by the default flip |
| test/accounts.test.ts | existing tests updated to `await`; new race test with 100 concurrent increments on shared token and isolation test for separate tokens provide strong coverage of the serialization invariant |
| test/index.test.ts | confirm-guard tests are thorough; however several manual `AccountManager`-shape mocks still return a bare `number` from `incrementAuthFailures` instead of `Promise<number>` (lines 430, 3009, 3202, 3317) |
| test/storage.test.ts | new tests cover force=false default, EEXIST StorageError type, timestamped backup default, and backupMode:"none" opt-out; existing test at line 146 still calls `exportAccounts(exportPath)` with no `force`, which now uses the safe default — correct since exportPath doesn't exist at that point |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant R1 as "Request A (org-variant 1)"
    participant R2 as "Request B (org-variant 2)"
    participant Chain as "incrementAuthFailuresChain[token]"
    participant Map as "authFailuresByRefreshToken[token]"
    participant R3 as "Request C (success path)"

    R1->>Chain: incrementAuthFailures(acct1) — queues next1
    R2->>Chain: incrementAuthFailures(acct2) — queues next2 after next1
    Note over Chain: microtasks drain in order
    Chain->>Map: next1 resolves — read 0, write 1, return 1
    Chain->>Map: next2 resolves — read 1, write 2, return 2
    R1-->>R1: "failures=1 no lost update"
    R2-->>R2: "failures=2 no lost update"
    Note over R3: new macrotask — all chain microtasks already drained
    R3->>Map: clearAuthFailures — delete token entry
    Note over Map: counter reset cleanly
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `index.ts`, line 6282 ([link](https://github.com/ndycode/oc-codex-multi-auth/blob/e7c1c34b79c6a5e034929ef547fcd8c2bf3daf8b/index.ts#L6282)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **`codex-export` bypasses the new `force=false` safety default**

   `force ?? true` evaluates to `true` whenever the caller omits the flag, so `codex-export` still silently overwrites an existing file — the exact destructive default that `exportAccounts(path, force = false)` was changed to prevent. the production MCP entry point nullifies the safety fix for every user who doesn't explicitly pass `force=false`.

   

   also update the tool description on line 6258 from `"(default: true)"` to `"(default: false)"` to keep the docs in sync.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: index.ts
   Line: 6282

   Comment:
   **`codex-export` bypasses the new `force=false` safety default**

   `force ?? true` evaluates to `true` whenever the caller omits the flag, so `codex-export` still silently overwrites an existing file — the exact destructive default that `exportAccounts(path, force = false)` was changed to prevent. the production MCP entry point nullifies the safety fix for every user who doesn't explicitly pass `force=false`.

   

   also update the tool description on line 6258 from `"(default: true)"` to `"(default: false)"` to keep the docs in sync.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Foc-codex-multi-auth%22%20on%20the%20existing%20branch%20%22fix%2Fphase1-safety-defaults%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fphase1-safety-defaults%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20index.ts%0ALine%3A%206282%0A%0AComment%3A%0A**%60codex-export%60%20bypasses%20the%20new%20%60force%3Dfalse%60%20safety%20default**%0A%0A%60force%20%3F%3F%20true%60%20evaluates%20to%20%60true%60%20whenever%20the%20caller%20omits%20the%20flag%2C%20so%20%60codex-export%60%20still%20silently%20overwrites%20an%20existing%20file%20%E2%80%94%20the%20exact%20destructive%20default%20that%20%60exportAccounts%28path%2C%20force%20%3D%20false%29%60%20was%20changed%20to%20prevent.%20the%20production%20MCP%20entry%20point%20nullifies%20the%20safety%20fix%20for%20every%20user%20who%20doesn't%20explicitly%20pass%20%60force%3Dfalse%60.%0A%0A%60%60%60suggestion%0A%09%09%09%09%09await%20exportAccounts%28resolvedExportPath%2C%20force%20%3F%3F%20false%29%3B%0A%60%60%60%0A%0Aalso%20update%20the%20tool%20description%20on%20line%206258%20from%20%60%22%28default%3A%20true%29%22%60%20to%20%60%22%28default%3A%20false%29%22%60%20to%20keep%20the%20docs%20in%20sync.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Foc-codex-multi-auth%22%20on%20the%20existing%20branch%20%22fix%2Fphase1-safety-defaults%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fphase1-safety-defaults%22.%0A%0AFix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atest%2Findex.test.ts%3A430%0A**Sync%20mock%20stubs%20don't%20match%20the%20new%20async%20signature**%0A%0A%60incrementAuthFailures%60%20is%20now%20%60async%60%20and%20returns%20%60Promise%3Cnumber%3E%60%2C%20but%20these%20manual%20mock%20stubs%20return%20a%20bare%20%60number%60.%20%60await%201%60%20coerces%20fine%20in%20JS%20so%20tests%20pass%2C%20but%20if%20any%20code%20path%20ever%20calls%20%60.then%28%29%60%20directly%20on%20the%20return%20value%20%28e.g.%20a%20future%20refactor%2C%20or%20vitest's%20spy%20assertions%20on%20resolved%20values%29%20it'll%20throw%20%60TypeError%3A%20Cannot%20read%20properties%20of%20undefined%20%28reading%20'then'%29%60.%20same%20pattern%20repeats%20at%20lines%203009%2C%203202%2C%20and%203317.%0A%0A%60%60%60suggestion%0A%09%09%09incrementAuthFailures%28%29%20%7B%20return%20Promise.resolve%281%29%3B%20%7D%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: test/index.test.ts
Line: 430

Comment:
**Sync mock stubs don't match the new async signature**

`incrementAuthFailures` is now `async` and returns `Promise<number>`, but these manual mock stubs return a bare `number`. `await 1` coerces fine in JS so tests pass, but if any code path ever calls `.then()` directly on the return value (e.g. a future refactor, or vitest's spy assertions on resolved values) it'll throw `TypeError: Cannot read properties of undefined (reading 'then')`. same pattern repeats at lines 3009, 3202, and 3317.

```suggestion
			incrementAuthFailures() { return Promise.resolve(1); }
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(safety): serialize auth-failure incr..."](https://github.com/ndycode/oc-codex-multi-auth/commit/71cba800658f96fd516463661f9408fc8179a6f9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28724016)</sub>

<!-- /greptile_comment -->