### PR TITLE
fix(reliability): shutdown flush + forward-compat schema guard

### DIFF
--- a/lib/accounts.ts
+++ b/lib/accounts.ts
@@ -1037,6 +1037,13 @@ export class AccountManager {
 	private ensureShutdownFlushRegistered(): void {
 		if (this.shutdownHandler) return;
 		const handler = async (): Promise<void> => {
+			// One-shot: clear the slot first so that if `runCleanup()` fires
+			// externally (e.g. tests reusing a manager across cycles, or any
+			// other caller that drains the global cleanup queue), a subsequent
+			// `saveToDiskDebounced()` can re-register a fresh handler. Without
+			// this the guard above returns early and the next pending save
+			// goes unprotected on shutdown.
+			this.shutdownHandler = null;
 			let timeoutTimer: ReturnType<typeof setTimeout> | null = null;
 			try {
 				await Promise.race([

--- a/lib/accounts.ts
+++ b/lib/accounts.ts
@@ -21,6 +21,13 @@ import {
 } from "./rotation.js";
 import { isRecord, nowMs } from "./utils.js";
 import { decodeJWT } from "./auth/auth.js";
+import { registerCleanup, unregisterCleanup } from "./shutdown.js";
+
+/**
+ * Upper bound the shutdown handler will wait for `flushPendingSave` so that a
+ * jammed save cannot stall SIGINT/SIGTERM indefinitely.
+ */
+const SHUTDOWN_FLUSH_TIMEOUT_MS = 5_000;
 
 export {
 	extractAccountId,
@@ -222,6 +229,7 @@ export class AccountManager {
 	 * audit finding `docs/audits/03-critical-issues.md` (ledger id `47`).
 	 */
 	private incrementAuthFailuresChain: Map<string, Promise<number>> = new Map();
+	private shutdownHandler: (() => Promise<void>) | null = null;
 
 	static async loadFromDisk(authFallback?: OAuthAuthDetails): Promise<AccountManager> {
 		const stored = await loadAccounts();
@@ -985,6 +993,7 @@ export class AccountManager {
 	}
 
 	saveToDiskDebounced(delayMs = 500): void {
+		this.ensureShutdownFlushRegistered();
 		if (this.saveDebounceTimer) {
 			clearTimeout(this.saveDebounceTimer);
 		}
@@ -1016,6 +1025,53 @@ export class AccountManager {
 		if (this.pendingSave) {
 			await this.pendingSave;
 		}
+	}
+
+	/**
+	 * Registers a process-shutdown cleanup that awaits any pending debounced
+	 * save. Without this, a rotation queued inside the 500ms debounce window
+	 * would be lost when SIGINT/SIGTERM fires before the timer resolves.
+	 * Registration is lazy (only when `saveToDiskDebounced` is first invoked)
+	 * so idle managers do not leak handlers into the shutdown queue.
+	 */
+	private ensureShutdownFlushRegistered(): void {
+		if (this.shutdownHandler) return;
+		const handler = async (): Promise<void> => {
+			let timeoutTimer: ReturnType<typeof setTimeout> | null = null;
+			try {
+				await Promise.race([
+					this.flushPendingSave(),
+					new Promise<void>((_resolve, reject) => {
+						timeoutTimer = setTimeout(() => {
+							reject(
+								new Error(
+									`flushPendingSave timed out after ${SHUTDOWN_FLUSH_TIMEOUT_MS}ms`,
+								),
+							);
+						}, SHUTDOWN_FLUSH_TIMEOUT_MS);
+					}),
+				]);
+			} catch (error) {
+				log.warn("Shutdown flush failed", {
+					error: error instanceof Error ? error.message : String(error),
+				});
+			} finally {
+				if (timeoutTimer) clearTimeout(timeoutTimer);
+			}
+		};
+		this.shutdownHandler = handler;
+		registerCleanup(handler);
+	}
+
+	/**
+	 * Removes this manager's shutdown cleanup registration. Call this when
+	 * replacing an `AccountManager` instance (e.g., on cache invalidation)
+	 * to avoid unbounded growth of the global cleanup queue.
+	 */
+	disposeShutdownHandler(): void {
+		if (!this.shutdownHandler) return;
+		unregisterCleanup(this.shutdownHandler);
+		this.shutdownHandler = null;
 	}
 }
 

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -345,7 +345,7 @@ async function migrateStorageFileIfNeeded(
   try {
     const legacyContent = await fs.readFile(legacyPath, "utf-8");
     const legacyData = JSON.parse(legacyContent) as unknown;
-    const normalized = normalizeAccountStorage(legacyData);
+    const normalized = normalizeAccountStorage(legacyData, legacyPath);
     if (!normalized) return null;
 
     await persist(normalized);
@@ -368,6 +368,10 @@ async function migrateStorageFileIfNeeded(
     });
     return normalized;
   } catch (error) {
+    // Forward-compat failures should not be masked as migration warnings.
+    if (error instanceof StorageError && error.code === "UNSUPPORTED_SCHEMA_VERSION") {
+      throw error;
+    }
     log.warn(`Failed to migrate legacy ${label}`, {
       from: legacyPath,
       to: nextPath,
@@ -628,17 +632,46 @@ function findAccountIndexByIdentityKeys(
  * Normalizes and validates account storage data, migrating from v1 to v3 if needed.
  * Handles deduplication, index clamping, and per-family active index mapping.
  * @param data - Raw storage data (unknown format)
+ * @param sourcePath - Optional origin path used for error diagnostics
  * @returns Normalized AccountStorageV3 or null if invalid
+ * @throws StorageError (code `UNSUPPORTED_SCHEMA_VERSION`) when `data.version`
+ *   is a finite number greater than the newest format this plugin understands.
+ *   Throwing prevents a downgraded plugin from silently discarding future
+ *   schemas that still contain valid credentials.
  */
-export function normalizeAccountStorage(data: unknown): AccountStorageV3 | null {
+export function normalizeAccountStorage(
+  data: unknown,
+  sourcePath?: string,
+): AccountStorageV3 | null {
   if (!isRecord(data)) {
     log.warn("Invalid storage format, ignoring");
     return null;
   }
 
+  const rawVersion = (data as { version?: unknown }).version;
+
+  // Forward-compat guard: a finite version above the newest supported schema
+  // signals a file written by a newer plugin build. Returning null here would
+  // make the caller treat the data as corrupt and overwrite it with an empty
+  // or downgraded payload, permanently destroying the user's accounts.
+  if (typeof rawVersion === "number" && Number.isFinite(rawVersion) && rawVersion > 3) {
+    const resolvedPath = sourcePath ?? "<unknown>";
+    const hint =
+      `The storage file at ${resolvedPath} was written by a newer version ` +
+      `of this plugin (schema v${rawVersion}). Upgrade the plugin to a build ` +
+      `that understands schema v${rawVersion}, or back up and remove the ` +
+      `file to start fresh.`;
+    throw new StorageError(
+      `Unsupported account storage schema version ${rawVersion}; this plugin supports up to version 3.`,
+      "UNSUPPORTED_SCHEMA_VERSION",
+      resolvedPath,
+      hint,
+    );
+  }
+
   if (data.version !== 1 && data.version !== 3) {
     log.warn("Unknown storage version, ignoring", {
-      version: (data as { version?: unknown }).version,
+      version: rawVersion,
     });
     return null;
   }
@@ -719,6 +752,10 @@ export function normalizeAccountStorage(data: unknown): AccountStorageV3 | null 
  * Loads OAuth accounts from disk storage.
  * Automatically migrates v1 storage to v3 format if needed.
  * @returns AccountStorageV3 if file exists and is valid, null otherwise
+ * @throws StorageError (code `UNSUPPORTED_SCHEMA_VERSION`) when the on-disk
+ *   `version` field is greater than the newest format this plugin understands.
+ *   Surfacing the error stops a downgraded plugin from overwriting the user's
+ *   future-schema credentials with a stale or empty payload.
  */
 export async function loadAccounts(): Promise<AccountStorageV3 | null> {
   return withStorageLock(async () => loadAccountsInternal(saveAccountsUnlocked));
@@ -787,7 +824,7 @@ async function loadGlobalAccountsFallback(): Promise<AccountStorageV3 | null> {
       });
     }
 
-    const normalized = normalizeAccountStorage(data);
+    const normalized = normalizeAccountStorage(data, globalStoragePath);
     if (!normalized) return null;
 
     log.info("Loaded global account storage as project fallback", {
@@ -797,6 +834,11 @@ async function loadGlobalAccountsFallback(): Promise<AccountStorageV3 | null> {
     });
     return normalized;
   } catch (error) {
+    // Propagate forward-compat failures so the caller can surface them to the
+    // user instead of silently falling back to an empty global pool.
+    if (error instanceof StorageError && error.code === "UNSUPPORTED_SCHEMA_VERSION") {
+      throw error;
+    }
     const code = (error as NodeJS.ErrnoException).code;
     if (code !== "ENOENT") {
       log.warn("Failed to load global fallback account storage", {
@@ -826,7 +868,7 @@ async function loadAccountsInternal(
       log.warn("Account storage schema validation warnings", { errors: schemaErrors.slice(0, 5) });
     }
 
-    const normalized = normalizeAccountStorage(data);
+    const normalized = normalizeAccountStorage(data, path);
 
     const storedVersion = isRecord(data) ? (data as { version?: unknown }).version : undefined;
     if (normalized && storedVersion !== normalized.version) {
@@ -842,6 +884,12 @@ async function loadAccountsInternal(
 
     return normalized;
   } catch (error) {
+    // Forward-compat failures must reach the caller instead of being silently
+    // downgraded to an empty load, which would clobber the user's future-format
+    // credentials on the next save.
+    if (error instanceof StorageError && error.code === "UNSUPPORTED_SCHEMA_VERSION") {
+      throw error;
+    }
     const code = (error as NodeJS.ErrnoException).code;
     if (code === "ENOENT") {
       const migrated = persistMigration
@@ -1256,7 +1304,9 @@ async function readAndNormalizeImportFile(filePath: string): Promise<{
 		throw new Error(`Invalid JSON in import file: ${resolvedPath}`);
 	}
 
-	const normalized = normalizeAccountStorage(imported);
+	// Pass the resolved path so an UNSUPPORTED_SCHEMA_VERSION error includes
+	// the actual import file in its diagnostics.
+	const normalized = normalizeAccountStorage(imported, resolvedPath);
 	if (!normalized) {
 		throw new Error("Invalid account storage format");
 	}

--- a/test/accounts.test.ts
+++ b/test/accounts.test.ts
@@ -1792,6 +1792,48 @@ describe("AccountManager", () => {
     });
   });
 
+  describe("shutdown cleanup registration", () => {
+    it("registers a cleanup handler the first time saveToDiskDebounced runs", async () => {
+      const { getCleanupCount, runCleanup } = await import("../lib/shutdown.js");
+      await runCleanup();
+
+      const now = Date.now();
+      const manager = new AccountManager(undefined, {
+        version: 3 as const,
+        activeIndex: 0,
+        accounts: [{ refreshToken: "token-shutdown", addedAt: now, lastUsed: now }],
+      });
+
+      expect(getCleanupCount()).toBe(0);
+
+      manager.saveToDiskDebounced(10_000);
+      expect(getCleanupCount()).toBe(1);
+
+      // Repeated calls must not accumulate duplicate registrations.
+      manager.saveToDiskDebounced(10_000);
+      manager.saveToDiskDebounced(10_000);
+      expect(getCleanupCount()).toBe(1);
+
+      manager.disposeShutdownHandler();
+      expect(getCleanupCount()).toBe(0);
+    });
+
+    it("disposeShutdownHandler is a no-op when nothing was registered", async () => {
+      const { getCleanupCount, runCleanup } = await import("../lib/shutdown.js");
+      await runCleanup();
+
+      const now = Date.now();
+      const manager = new AccountManager(undefined, {
+        version: 3 as const,
+        activeIndex: 0,
+        accounts: [{ refreshToken: "token-idle", addedAt: now, lastUsed: now }],
+      });
+
+      expect(() => manager.disposeShutdownHandler()).not.toThrow();
+      expect(getCleanupCount()).toBe(0);
+    });
+  });
+
   describe("health and token tracking methods", () => {
     beforeEach(() => {
       resetTrackers();

--- a/test/accounts.test.ts
+++ b/test/accounts.test.ts
@@ -1398,6 +1398,54 @@ describe("AccountManager", () => {
 
       expect(mockSaveAccounts).toHaveBeenCalledTimes(2);
     });
+
+    it("re-registers shutdown handler after external runCleanup cycle", async () => {
+      // Regression for Greptile P2: before the fix, the handler installed by
+      // `ensureShutdownFlushRegistered()` left `this.shutdownHandler` set
+      // after `runCleanup()` drained it externally, so the early-return
+      // guard prevented re-registration and the next pending save went
+      // unprotected against shutdown.
+      const { saveAccounts } = await import("../lib/storage.js");
+      const { runCleanup, getCleanupCount } = await import("../lib/shutdown.js");
+      const mockSaveAccounts = vi.mocked(saveAccounts);
+      mockSaveAccounts.mockClear();
+      mockSaveAccounts.mockResolvedValue();
+
+      // Drain any handlers left behind by prior tests so the call-count
+      // assertions below reflect only this test.
+      await runCleanup();
+
+      const now = Date.now();
+      const stored = {
+        version: 3 as const,
+        activeIndex: 0,
+        accounts: [
+          { refreshToken: "token-1", addedAt: now, lastUsed: now },
+        ],
+      };
+
+      const manager = new AccountManager(undefined, stored);
+
+      // First cycle: schedule a debounced save then drain the cleanup
+      // queue externally (same pathway `beforeExit` uses). The handler
+      // must flush the pending save and release the `shutdownHandler`
+      // slot so the next `saveToDiskDebounced()` can re-register.
+      manager.saveToDiskDebounced(100);
+      expect(getCleanupCount()).toBe(1);
+      await runCleanup();
+      expect(mockSaveAccounts).toHaveBeenCalledTimes(1);
+      expect(getCleanupCount()).toBe(0);
+
+      // Second cycle: a fresh debounced save on the same manager must
+      // re-register, otherwise `runCleanup()` has nothing to drain and
+      // the save is silently lost under fake timers.
+      mockSaveAccounts.mockClear();
+      manager.saveToDiskDebounced(100);
+      expect(getCleanupCount()).toBe(1);
+      await runCleanup();
+      expect(mockSaveAccounts).toHaveBeenCalledTimes(1);
+      expect(getCleanupCount()).toBe(0);
+    });
   });
 
   describe("constructor edge cases", () => {

--- a/test/shutdown.test.ts
+++ b/test/shutdown.test.ts
@@ -5,6 +5,15 @@ import {
 	runCleanup,
 	getCleanupCount,
 } from "../lib/shutdown.js";
+import { AccountManager } from "../lib/accounts.js";
+
+vi.mock("../lib/storage.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../lib/storage.js")>();
+	return {
+		...actual,
+		saveAccounts: vi.fn().mockResolvedValue(undefined),
+	};
+});
 
 describe("Graceful shutdown", () => {
 	beforeEach(async () => {
@@ -172,6 +181,104 @@ describe("Graceful shutdown", () => {
 			expect(processOnceSpy.mock.calls.length).toBe(firstCallCount);
 
 			processOnceSpy.mockRestore();
+		});
+	});
+
+	describe("AccountManager integration (Phase 1 reliability)", () => {
+		beforeEach(async () => {
+			await runCleanup();
+			const { saveAccounts } = await import("../lib/storage.js");
+			vi.mocked(saveAccounts).mockClear();
+			vi.mocked(saveAccounts).mockResolvedValue();
+		});
+
+		it("shutdown flushes pending AccountManager save before exit", async () => {
+			const { saveAccounts } = await import("../lib/storage.js");
+			const mockSaveAccounts = vi.mocked(saveAccounts);
+			const now = Date.now();
+			const manager = new AccountManager(undefined, {
+				version: 3,
+				activeIndex: 0,
+				accounts: [{ refreshToken: "t1", addedAt: now, lastUsed: now }],
+			});
+
+			// Schedule a save well beyond the window of any realistic test run;
+			// if the shutdown handler is wired up, it must flush immediately.
+			manager.saveToDiskDebounced(10_000);
+			expect(mockSaveAccounts).not.toHaveBeenCalled();
+			expect(getCleanupCount()).toBeGreaterThan(0);
+
+			await runCleanup();
+
+			expect(mockSaveAccounts).toHaveBeenCalledTimes(1);
+			expect(getCleanupCount()).toBe(0);
+
+			manager.disposeShutdownHandler();
+		});
+
+		it("is a no-op when no debounced save is pending", async () => {
+			const { saveAccounts } = await import("../lib/storage.js");
+			const mockSaveAccounts = vi.mocked(saveAccounts);
+			const now = Date.now();
+			const manager = new AccountManager(undefined, {
+				version: 3,
+				activeIndex: 0,
+				accounts: [{ refreshToken: "t1", addedAt: now, lastUsed: now }],
+			});
+
+			manager.saveToDiskDebounced(10_000);
+			await manager.flushPendingSave();
+			mockSaveAccounts.mockClear();
+
+			await runCleanup();
+
+			expect(mockSaveAccounts).not.toHaveBeenCalled();
+			manager.disposeShutdownHandler();
+		});
+
+		it("disposeShutdownHandler removes the cleanup registration", async () => {
+			const { saveAccounts } = await import("../lib/storage.js");
+			const mockSaveAccounts = vi.mocked(saveAccounts);
+			const now = Date.now();
+			const manager = new AccountManager(undefined, {
+				version: 3,
+				activeIndex: 0,
+				accounts: [{ refreshToken: "t1", addedAt: now, lastUsed: now }],
+			});
+
+			manager.saveToDiskDebounced(10_000);
+			const countWithHandler = getCleanupCount();
+			expect(countWithHandler).toBeGreaterThan(0);
+
+			manager.disposeShutdownHandler();
+			expect(getCleanupCount()).toBe(countWithHandler - 1);
+
+			await runCleanup();
+			expect(mockSaveAccounts).not.toHaveBeenCalled();
+		});
+
+		it("survives a flushPendingSave rejection without blocking other cleanup", async () => {
+			const { saveAccounts } = await import("../lib/storage.js");
+			const mockSaveAccounts = vi.mocked(saveAccounts);
+			mockSaveAccounts.mockRejectedValueOnce(new Error("disk full"));
+
+			const now = Date.now();
+			const manager = new AccountManager(undefined, {
+				version: 3,
+				activeIndex: 0,
+				accounts: [{ refreshToken: "t1", addedAt: now, lastUsed: now }],
+			});
+			const secondCleanup = vi.fn();
+			registerCleanup(secondCleanup);
+
+			manager.saveToDiskDebounced(10_000);
+
+			await runCleanup();
+
+			expect(mockSaveAccounts).toHaveBeenCalledTimes(1);
+			expect(secondCleanup).toHaveBeenCalledTimes(1);
+
+			manager.disposeShutdownHandler();
 		});
 	});
 });

--- a/test/storage-async.test.ts
+++ b/test/storage-async.test.ts
@@ -10,6 +10,7 @@ import {
   deduplicateAccounts,
   deduplicateAccountsByEmail,
   getStoragePath,
+  StorageError,
   type AccountStorageV3,
 } from "../lib/storage.js";
 
@@ -37,9 +38,20 @@ describe("Storage Module - Async Operations", () => {
       expect(normalizeAccountStorage([])).toBeNull();
     });
 
-    it("returns null for unknown version", () => {
+    it("returns null for legacy/unrecognized versions below the forward-compat bound", () => {
+      // V2 is a known unsupported legacy format whose migration lives elsewhere,
+      // and non-numeric markers should still be tolerated as corrupt input.
       expect(normalizeAccountStorage({ version: 2, accounts: [], activeIndex: 0 })).toBeNull();
-      expect(normalizeAccountStorage({ version: 99, accounts: [], activeIndex: 0 })).toBeNull();
+      expect(normalizeAccountStorage({ version: "99", accounts: [], activeIndex: 0 })).toBeNull();
+    });
+
+    it("throws UNSUPPORTED_SCHEMA_VERSION for future numeric versions", () => {
+      // Silently returning null for a future schema would let a downgraded
+      // plugin wipe the user's real credentials on the next save, so the
+      // guard has to surface the failure instead.
+      expect(() =>
+        normalizeAccountStorage({ version: 99, accounts: [], activeIndex: 0 }),
+      ).toThrowError(StorageError);
     });
 
     it("returns null for invalid accounts array", () => {

--- a/test/storage.test.ts
+++ b/test/storage.test.ts
@@ -2375,4 +2375,95 @@ describe("storage", () => {
       unlinkSpy.mockRestore();
     });
   });
+
+  describe("forward-compat schema guard", () => {
+    const testWorkDir = join(tmpdir(), "codex-fwdcompat-test-" + Math.random().toString(36).slice(2));
+    let testStoragePath: string;
+
+    beforeEach(async () => {
+      await fs.mkdir(testWorkDir, { recursive: true });
+      testStoragePath = join(testWorkDir, "accounts.json");
+      setStoragePathDirect(testStoragePath);
+    });
+
+    afterEach(async () => {
+      setStoragePathDirect(null);
+      await fs.rm(testWorkDir, { recursive: true, force: true });
+    });
+
+    it("normalizeAccountStorage throws StorageError for version 4", () => {
+      expect(() =>
+        normalizeAccountStorage({ version: 4, accounts: [] }, "/tmp/future.json"),
+      ).toThrowError(StorageError);
+    });
+
+    it("normalizeAccountStorage StorageError carries UNSUPPORTED_SCHEMA_VERSION code and path", () => {
+      try {
+        normalizeAccountStorage({ version: 9, accounts: [] }, "/tmp/future-9.json");
+        throw new Error("expected normalizeAccountStorage to throw");
+      } catch (error) {
+        expect(error).toBeInstanceOf(StorageError);
+        const storageError = error as StorageError;
+        expect(storageError.code).toBe("UNSUPPORTED_SCHEMA_VERSION");
+        expect(storageError.path).toBe("/tmp/future-9.json");
+        expect(storageError.message).toContain("9");
+        expect(storageError.hint).toContain("v9");
+      }
+    });
+
+    it("normalizeAccountStorage uses '<unknown>' path when caller omits sourcePath", () => {
+      try {
+        normalizeAccountStorage({ version: 4, accounts: [] });
+        throw new Error("expected normalizeAccountStorage to throw");
+      } catch (error) {
+        expect(error).toBeInstanceOf(StorageError);
+        expect((error as StorageError).path).toBe("<unknown>");
+      }
+    });
+
+    it("normalizeAccountStorage still returns null for non-numeric future marker", () => {
+      expect(
+        normalizeAccountStorage({ version: "4", accounts: [] }, "/tmp/garbage.json"),
+      ).toBeNull();
+    });
+
+    it("normalizeAccountStorage does not throw for legacy version 2 (still returns null)", () => {
+      // V2 is a known unsupported legacy format; its handling is a separate
+      // migration concern and must not regress into the forward-compat path.
+      expect(
+        normalizeAccountStorage({ version: 2, accounts: [] }, "/tmp/v2.json"),
+      ).toBeNull();
+    });
+
+    it("loadAccounts throws StorageError with UNSUPPORTED_SCHEMA_VERSION on schemaVersion > 3", async () => {
+      const futureStorage = {
+        version: 4,
+        activeIndex: 0,
+        accounts: [{ refreshToken: "t1", addedAt: Date.now(), lastUsed: Date.now() }],
+      };
+      await fs.writeFile(testStoragePath, JSON.stringify(futureStorage), "utf-8");
+
+      await expect(loadAccounts()).rejects.toBeInstanceOf(StorageError);
+      await expect(loadAccounts()).rejects.toMatchObject({
+        code: "UNSUPPORTED_SCHEMA_VERSION",
+        path: testStoragePath,
+      });
+    });
+
+    it("loadAccounts leaves the future-schema file untouched when it throws", async () => {
+      const originalContent = JSON.stringify({
+        version: 5,
+        activeIndex: 0,
+        accounts: [{ refreshToken: "future-token", addedAt: 1, lastUsed: 1 }],
+      });
+      await fs.writeFile(testStoragePath, originalContent, "utf-8");
+
+      await expect(loadAccounts()).rejects.toBeInstanceOf(StorageError);
+
+      // The user's future-schema credentials must still be present on disk
+      // after the guard fires; silent discard was the bug being fixed.
+      const onDisk = await fs.readFile(testStoragePath, "utf-8");
+      expect(onDisk).toBe(originalContent);
+    });
+  });
 });


### PR DESCRIPTION
## Summary
Phase-1 reliability fixes from audit d92a8eed.

## Changes
- **Shutdown flush**: `lib/accounts.ts` now registers a lazy process-cleanup handler on first `saveToDiskDebounced` call; `runCleanup` (SIGINT/SIGTERM/beforeExit) awaits `flushPendingSave()` with a 5s timeout, preventing loss of the last rotation scheduled inside the 500ms debounce window (audit ledger `95`, `130`; top-20 #2).
- **Forward-compat guard**: `lib/storage.ts` throws `StorageError` with code `UNSUPPORTED_SCHEMA_VERSION` when `version > 3` instead of silently returning `null` and discarding user data on the next save. All load/import/migrate paths that see the future schema either propagate the error (primary load + import) or re-throw (legacy migration, global fallback) so the user sees a real failure instead of silent data loss (audit ledger `200`; top-20 #7).

## Tests
- `test/shutdown.test.ts`: integration covering lazy cleanup registration, flush on `runCleanup`, no-op when idle, `disposeShutdownHandler`, and cleanup continues past a rejected flush.
- `test/accounts.test.ts`: unit coverage that `saveToDiskDebounced` registers exactly one handler, repeated calls do not accumulate, and `disposeShutdownHandler` removes it cleanly.
- `test/storage.test.ts`: forward-compat suite — `normalizeAccountStorage(v>3)` throws `StorageError` with correct `code`/`path`/`hint`, legacy v2 still returns null, v4 on disk throws on `loadAccounts` without mutating the file.
- `test/storage-async.test.ts`: updated the existing v99 regression to assert the new throw semantics.

## Audit refs
- docs/audits/14-top20.md items #2, #7
- docs/audits/13-phased-roadmap.md Phase 1 §1.2, §1.6

## Verification
- typecheck / lint / test (2084 passing) / build all pass locally.

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

this pr adds two reliability fixes: a lazy shutdown flush handler on `AccountManager` that drains the 500 ms debounce window before SIGINT/SIGTERM/beforeExit, and a forward-compat schema guard in `normalizeAccountStorage` that throws `StorageError(UNSUPPORTED_SCHEMA_VERSION)` instead of silently returning `null` for `version > 3`.

- the `Promise.race` timeout path in `ensureShutdownFlushRegistered` leaves `flushPendingSave()` running as an unowned promise after the 5 s guard fires; if the orphaned flush subsequently rejects (slow windows file lock → eventual write failure), node.js 15+ treats it as an unhandled rejection and terminates the process with a non-zero exit code — the one-line fix is `const flushPromise = this.flushPendingSave(); flushPromise.catch(() => {})`.

<h3>Confidence Score: 4/5</h3>

safe to merge after fixing the orphaned flushPendingSave rejection in the timeout path

storage.ts forward-compat guard and AccountManager re-registration are both correct and well-tested; the single P1 is a new unhandled-rejection risk introduced by the Promise.race timeout wiring in ensureShutdownFlushRegistered — one line to fix, but it can cause a process crash with non-zero exit on windows when disk writes are slow

lib/accounts.ts lines 1049-1060 (Promise.race timeout path)

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/accounts.ts | adds lazy shutdown flush registration via ensureShutdownFlushRegistered + disposeShutdownHandler; one-shot self-clear pattern is correct but the Promise.race timeout path leaves flushPendingSave() orphaned and unhandled on rejection (P1) |
| lib/storage.ts | forward-compat guard in normalizeAccountStorage throws StorageError(UNSUPPORTED_SCHEMA_VERSION) for version > 3; all load/import/migrate callers correctly propagate or re-throw instead of swallowing; no issues found |
| test/shutdown.test.ts | good integration coverage for lazy registration, flush-on-runCleanup, no-op idle, dispose, and rejection survival; missing a case that advances fake timers past SHUTDOWN_FLUSH_TIMEOUT_MS to pin the timeout branch |
| test/accounts.test.ts | unit coverage for exactly-one handler registration, no-accumulation on repeated calls, dispose clean-up, and re-registration after external runCleanup cycle; solid |
| test/storage.test.ts | forward-compat suite covers v4/v9 throws, UNSUPPORTED_SCHEMA_VERSION code+path+hint, legacy v2 null return, loadAccounts re-throw, and file-untouched assertion; comprehensive |
| test/storage-async.test.ts | updates existing v99 regression to assert the new throw semantics instead of silent null return; correct |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant P as Process (SIGINT/beforeExit)
    participant RC as runCleanup()
    participant AM as AccountManager handler
    participant FP as flushPendingSave()
    participant TO as 5s Timeout
    participant SA as saveAccounts()

    P->>RC: signal / beforeExit
    RC->>AM: await handler()
    AM->>AM: this.shutdownHandler = null (one-shot clear)
    AM->>FP: Promise.race([flushPendingSave(), timeout])
    AM->>TO: setTimeout(5000, reject)

    alt flush completes within 5s
        FP->>SA: saveToDisk() → saveAccounts()
        SA-->>FP: resolve
        FP-->>AM: resolve ✓
        AM->>TO: clearTimeout ✓
    else timeout fires first (P1 risk)
        TO-->>AM: reject (timeout error)
        AM->>AM: catch → log.warn
        Note over FP,SA: flushPendingSave() still running, unhandled
        FP->>SA: saveToDisk() → saveAccounts()
        SA-->>FP: reject (StorageError)
        FP--xAM: unhandled rejection → process crash (Node 15+)
    end

    RC-->>P: cleanup complete
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Foc-codex-multi-auth%22%20on%20the%20existing%20branch%20%22fix%2Fphase1-reliability%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fphase1-reliability%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Alib%2Faccounts.ts%3A1049-1060%0A**Orphaned%20%60flushPendingSave%60%20rejection%20after%20timeout%20can%20crash%20the%20process**%0A%0Awhen%20the%205%20s%20timeout%20wins%20the%20race%2C%20%60flushPendingSave%28%29%60%20runs%20as%20a%20detached%2C%20unhandled%20promise.%20if%20it%20subsequently%20rejects%20%28e.g.%20%60StorageError%60%20from%20a%20slow%20windows-locked%20file%20write%20that%20finally%20fails%20after%20the%20timeout%29%2C%20node.js%2015%2B%20emits%20%60unhandledRejection%60%20and%20by%20default%20terminates%20the%20process%20with%20a%20non-zero%20exit%20code%20%E2%80%94%20turning%20a%20graceful%20shutdown%20into%20a%20crash%2C%20especially%20in%20the%20%60beforeExit%60%20path%20where%20%60process.exit%28%29%60%20is%20never%20called.%0A%0Afix%3A%20attach%20a%20no-op%20%60.catch%28%29%60%20to%20the%20flush%20promise%20before%20the%20race%20so%20the%20rejection%20is%20always%20owned%2C%20regardless%20of%20which%20branch%20wins%3A%0A%0A%60%60%60ts%0Aconst%20flushPromise%20%3D%20this.flushPendingSave%28%29%3B%0A%2F%2F%20prevent%20unhandled%20rejection%20if%20timeout%20wins%20and%20the%20flush%20later%20rejects%0AflushPromise.catch%28%28err%29%20%3D%3E%20%7B%0A%20%20%20%20log.warn%28%22Flush%20completed%20with%20error%20after%20timeout%22%2C%20%7B%0A%20%20%20%20%20%20%20%20error%3A%20err%20instanceof%20Error%20%3F%20err.message%20%3A%20String%28err%29%2C%0A%20%20%20%20%7D%29%3B%0A%7D%29%3B%0Atry%20%7B%0A%20%20%20%20await%20Promise.race%28%5B%0A%20%20%20%20%20%20%20%20flushPromise%2C%0A%20%20%20%20%20%20%20%20new%20Promise%3Cvoid%3E%28%28_resolve%2C%20reject%29%20%3D%3E%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20timeoutTimer%20%3D%20setTimeout%28%28%29%20%3D%3E%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20reject%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20new%20Error%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%60flushPendingSave%20timed%20out%20after%20%24%7BSHUTDOWN_FLUSH_TIMEOUT_MS%7Dms%60%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%2C%20SHUTDOWN_FLUSH_TIMEOUT_MS%29%3B%0A%20%20%20%20%20%20%20%20%7D%29%2C%0A%20%20%20%20%5D%29%3B%0A%7D%20catch%20%28error%29%20%7B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Atest%2Fshutdown.test.ts%3A260-282%0A**Missing%20vitest%20coverage%20for%20the%205%20s%20timeout%20path**%0A%0Athe%20test%20suite%20covers%20direct%20rejection%20from%20%60saveAccounts%60%20but%20there%20is%20no%20case%20that%20actually%20trips%20the%20%60SHUTDOWN_FLUSH_TIMEOUT_MS%60%20guard.%20the%20timeout%20branch%20is%20the%20exact%20path%20where%20the%20unhandled-rejection%20risk%20described%20above%20lives.%20a%20test%20using%20%60vi.useFakeTimers%28%29%60%20that%20stalls%20the%20flush%20and%20advances%20time%20past%205%20000%20ms%20would%20pin%20the%20timeout%20behavior%2C%20guard%20the%20log-warning%20branch%2C%20and%20catch%20any%20regression%20in%20the%20%60Promise.race%60%20wiring.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: lib/accounts.ts
Line: 1049-1060

Comment:
**Orphaned `flushPendingSave` rejection after timeout can crash the process**

when the 5 s timeout wins the race, `flushPendingSave()` runs as a detached, unhandled promise. if it subsequently rejects (e.g. `StorageError` from a slow windows-locked file write that finally fails after the timeout), node.js 15+ emits `unhandledRejection` and by default terminates the process with a non-zero exit code — turning a graceful shutdown into a crash, especially in the `beforeExit` path where `process.exit()` is never called.

fix: attach a no-op `.catch()` to the flush promise before the race so the rejection is always owned, regardless of which branch wins:

```ts
const flushPromise = this.flushPendingSave();
// prevent unhandled rejection if timeout wins and the flush later rejects
flushPromise.catch((err) => {
    log.warn("Flush completed with error after timeout", {
        error: err instanceof Error ? err.message : String(err),
    });
});
try {
    await Promise.race([
        flushPromise,
        new Promise<void>((_resolve, reject) => {
            timeoutTimer = setTimeout(() => {
                reject(
                    new Error(
                        `flushPendingSave timed out after ${SHUTDOWN_FLUSH_TIMEOUT_MS}ms`,
                    ),
                );
            }, SHUTDOWN_FLUSH_TIMEOUT_MS);
        }),
    ]);
} catch (error) {
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: test/shutdown.test.ts
Line: 260-282

Comment:
**Missing vitest coverage for the 5 s timeout path**

the test suite covers direct rejection from `saveAccounts` but there is no case that actually trips the `SHUTDOWN_FLUSH_TIMEOUT_MS` guard. the timeout branch is the exact path where the unhandled-rejection risk described above lives. a test using `vi.useFakeTimers()` that stalls the flush and advances time past 5 000 ms would pin the timeout behavior, guard the log-warning branch, and catch any regression in the `Promise.race` wiring.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(accounts): clear shutdownHandler so ..."](https://github.com/ndycode/oc-codex-multi-auth/commit/a86c34bc3a741ded6e50db0933a8dbefaee42fc4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28724004)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->