### PR TITLE
ci: add quality gates matrix (typecheck/lint/test/build + prod audit)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 # Cancel superseded runs on the same ref to save CI minutes.
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,75 @@
+name: CI
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  push:
+    branches: [main]
+
+# Cancel superseded runs on the same ref to save CI minutes.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  quality:
+    name: Quality (Node ${{ matrix.node }} / ${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        node: ['18', '20', '22']
+        os: [ubuntu-latest]
+        include:
+          - node: '20'
+            os: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Setup Node ${{ matrix.node }}
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: ${{ matrix.node }}
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Test
+        run: npm test
+
+      - name: Build
+        run: npm run build
+
+  audit-prod:
+    name: Production dependency audit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Setup Node 20
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '20'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Audit production dependencies (high+)
+        run: npm run audit:prod


### PR DESCRIPTION
## Summary
Adds `ci.yml` workflow gating PRs on typecheck/lint/test/build across Node 18/20/22 + Windows cross-check. Audit top-20 #3.

## Changes
- **`.github/workflows/ci.yml`** (new): matrix job runs `npm ci && npm run typecheck && npm run lint && npm test && npm run build` on Node 18/20/22 ubuntu + Node 20 windows. Separate job runs `npm run audit:prod` for dependency advisory gating.
- Concurrency group cancels superseded runs on same branch.
- Preserves existing `.github/workflows/pr-quality.yml` anti-slop check unchanged.
- Third-party actions pinned to full commit SHA (matches repo convention in `pr-quality.yml`).

## Rationale
Prior to this PR, only anti-slop runs on PR — no typecheck, no tests, no build. Regressions reach main. This gate closes that loop (audit: top-20 #3, Phase-3 §3.1 hoisted to Phase 1 because it enables all future PRs to run with confidence).

## Audit refs
- docs/audits/14-top20.md #3
- docs/audits/11-dx-cli-docs.md
- docs/audits/13-phased-roadmap.md §3.1

## Verification
- Local `npm run typecheck / lint / test / build` all pass (2070 tests green).
- Windows host used for local validation.
- Post-merge, the first PR to land will exercise the matrix end-to-end.

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

adds `ci.yml` introducing a matrix quality gate (typecheck/lint/test/build on node 18/20/22 ubuntu + node 20 windows) and a separate `audit-prod` job. the previous `cancel-in-progress` concurrency concern is correctly resolved — cancellation is scoped to pr events only via `${{ github.event_name == 'pull_request' }}`, so pushes to main are not affected. `copy-oauth-success.js` already handles windows path normalization explicitly, so the windows build leg is safe.

<h3>Confidence Score: 5/5</h3>

safe to merge — no blocking issues, concurrency scoping is correct, windows path handling is verified.

all findings are p2. the prior p1 concurrency concern is already fixed in this revision. action shas are pinned, permissions are minimal, and the build script is windows-safe.

no files require special attention

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/ci.yml | new ci workflow gating prs on typecheck/lint/test/build across node 18/20/22 ubuntu + node 20 windows, with a separate audit-prod job; concurrency correctly scoped to pr-only cancellation; no blocking issues found |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    PR[PR / push to main] --> CG{concurrency group\nci-CI-ref}
    CG -- PR: cancel-in-progress=true --> Q
    CG -- push to main: cancel-in-progress=false --> Q

    Q[quality matrix]
    Q --> N18[ubuntu / node 18\ntypecheck → lint → test → build]
    Q --> N20U[ubuntu / node 20\ntypecheck → lint → test → build]
    Q --> N22[ubuntu / node 22\ntypecheck → lint → test → build]
    Q --> N20W[windows / node 20\ntypecheck → lint → test → build]

    PR --> A[audit-prod\nubuntu / node 20]
    A --> AUD[npm run audit:prod\nhigh+ vuln gate]
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Foc-codex-multi-auth%22%20on%20the%20existing%20branch%20%22ci%2Fphase1-quality-gates%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22ci%2Fphase1-quality-gates%22.%0A%0AFix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Fci.yml%3A51%0A**missing%20vitest%20coverage%20step**%0A%0A%60npm%20test%60%20runs%20%60vitest%20run%60%20without%20coverage%2C%20so%20no%20coverage%20data%20is%20collected%20or%20surfaced%20in%20ci.%20consider%20adding%20a%20coverage%20step%20%28or%20replacing%20the%20test%20step%29%20so%20regressions%20in%20coverage%20are%20visible%20alongside%20the%202070%20tests%20passing.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20-%20name%3A%20Test%0A%20%20%20%20%20%20%20%20run%3A%20npm%20run%20test%3Acoverage%0A%60%60%60%0A%0Aif%20you'd%20rather%20keep%20coverage%20optional%2C%20add%20it%20as%20a%20separate%20step%20with%20%60continue-on-error%3A%20true%60%20so%20it%20never%20blocks%20the%20gate.%0A%0A**Context%20Used%3A**%20speak%20in%20lowercase%2C%20concise%20sentences.%20act%20like%20th...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3Dinstruction-0%29%29%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: .github/workflows/ci.yml
Line: 51

Comment:
**missing vitest coverage step**

`npm test` runs `vitest run` without coverage, so no coverage data is collected or surfaced in ci. consider adding a coverage step (or replacing the test step) so regressions in coverage are visible alongside the 2070 tests passing.

```suggestion
      - name: Test
        run: npm run test:coverage
```

if you'd rather keep coverage optional, add it as a separate step with `continue-on-error: true` so it never blocks the gate.

**Context Used:** speak in lowercase, concise sentences. act like th... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["ci: only cancel in-progress on PR events..."](https://github.com/ndycode/oc-codex-multi-auth/commit/c55d13dc308298513145251426881ddb5f14b43a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28723915)</sub>

<!-- /greptile_comment -->