### PR TITLE
fix(security): strict nullish merge + loopback URI + CLI zod + token redaction

### DIFF
--- a/lib/accounts.ts
+++ b/lib/accounts.ts
@@ -19,9 +19,10 @@ import {
 	type AccountWithMetrics,
 	type HybridSelectionOptions,
 } from "./rotation.js";
-import { isRecord, nowMs } from "./utils.js";
+import { nowMs } from "./utils.js";
 import { decodeJWT } from "./auth/auth.js";
 import { registerCleanup, unregisterCleanup } from "./shutdown.js";
+import { CodexCliAccountsSchema } from "./schemas.js";
 
 /**
  * Upper bound the shutdown handler will wait for `flushPendingSave` so that a
@@ -115,30 +116,43 @@ async function getCodexCliTokenCache(): Promise<Map<string, CodexCliTokenCacheEn
 
 	try {
 		const raw = await fs.readFile(CODEX_CLI_ACCOUNTS_PATH, "utf-8");
-		const parsed = JSON.parse(raw) as unknown;
-		if (!isRecord(parsed) || !Array.isArray(parsed.accounts)) {
+		const rawParsed = JSON.parse(raw) as unknown;
+
+		// Cross-process trust boundary: the Codex CLI accounts file is produced
+		// by a separate process on disk and may be stale, truncated, tampered
+		// with, or produced by a version whose shape we do not recognise. We
+		// MUST validate through the Zod schema before reading any field; a
+		// parse failure is a warn+skip, never a throw (audit top-20 #11).
+		const validation = CodexCliAccountsSchema.safeParse(rawParsed);
+		if (!validation.success) {
+			log.warn("Codex CLI accounts cache failed validation; ignoring", {
+				issues: validation.error.issues.length,
+				firstPath: validation.error.issues[0]?.path.join(".") ?? "(root)",
+			});
 			codexCliTokenCache = null;
 			return null;
 		}
 
-		const next = new Map<string, CodexCliTokenCacheEntry>();
-		for (const entry of parsed.accounts) {
-			if (!isRecord(entry)) continue;
+		const validated = validation.data;
+		const entries = Array.isArray(validated.accounts) ? validated.accounts : [];
 
+		const next = new Map<string, CodexCliTokenCacheEntry>();
+		for (const entry of entries) {
 			const email = sanitizeEmail(typeof entry.email === "string" ? entry.email : undefined);
 			if (!email) continue;
 
 			const accountId =
-				typeof entry.accountId === "string" && entry.accountId.trim() ? entry.accountId.trim() : undefined;
+				typeof entry.accountId === "string" && entry.accountId.trim()
+					? entry.accountId.trim()
+					: undefined;
 
-			const auth = entry.auth;
-			const tokens = isRecord(auth) ? auth.tokens : undefined;
+			const tokens = entry.auth?.tokens;
 			const accessToken =
-				isRecord(tokens) && typeof tokens.access_token === "string" && tokens.access_token.trim()
+				typeof tokens?.access_token === "string" && tokens.access_token.trim()
 					? tokens.access_token.trim()
 					: undefined;
 			const refreshToken =
-				isRecord(tokens) && typeof tokens.refresh_token === "string" && tokens.refresh_token.trim()
+				typeof tokens?.refresh_token === "string" && tokens.refresh_token.trim()
 					? tokens.refresh_token.trim()
 					: undefined;
 

--- a/lib/auth/auth.ts
+++ b/lib/auth/auth.ts
@@ -2,14 +2,21 @@ import { generatePKCE } from "@openauthjs/openauth/pkce";
 import { randomBytes } from "node:crypto";
 import type { PKCEPair, AuthorizationFlow, TokenResult, ParsedAuthInput, JWTPayload } from "../types.js";
 import { logError } from "../logger.js";
-import { OAUTH_CALLBACK_PATH, OAUTH_CALLBACK_PORT } from "../runtime-contracts.js";
+import {
+	OAUTH_CALLBACK_LOOPBACK_HOST,
+	OAUTH_CALLBACK_PATH,
+	OAUTH_CALLBACK_PORT,
+} from "../runtime-contracts.js";
 import { safeParseOAuthTokenResponse } from "../schemas.js";
 
 // OAuth constants (from openai/codex)
 export const CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann";
 export const AUTHORIZE_URL = "https://auth.openai.com/oauth/authorize";
 export const TOKEN_URL = "https://auth.openai.com/oauth/token";
-export const REDIRECT_URI = `http://localhost:${OAUTH_CALLBACK_PORT}${OAUTH_CALLBACK_PATH}`;
+// RFC 8252 §7.3: the redirect URI MUST use the exact loopback IP literal that
+// the callback server binds to. Using `localhost` here would resolve via DNS
+// and could be hijacked or mismatch the bind host on dual-stack systems.
+export const REDIRECT_URI = `http://${OAUTH_CALLBACK_LOOPBACK_HOST}:${OAUTH_CALLBACK_PORT}${OAUTH_CALLBACK_PATH}`;
 export const SCOPE = "openid profile email offline_access";
 
 /**

--- a/lib/auth/login-runner.ts
+++ b/lib/auth/login-runner.ts
@@ -10,6 +10,125 @@ import { MODEL_FAMILIES, type ModelFamily } from "../prompts/codex.js";
 import { withAccountStorageTransaction } from "../storage.js";
 import type { AccountIdSource, TokenResult } from "../types.js";
 
+/**
+ * Fields that identify the two account records participating in a merge.
+ * Kept permissive so callers can pass stored account records of any concrete
+ * shape without coupling this helper to the full V3 schema.
+ */
+type MergeableAccountRecord = {
+	refreshToken?: string;
+	accessToken?: string;
+	expiresAt?: number;
+	lastUsed?: number;
+	addedAt?: number;
+	enabled?: boolean;
+	accountId?: string;
+	organizationId?: string;
+	accountIdSource?: AccountIdSource;
+	accountLabel?: string;
+	email?: string;
+	lastSwitchReason?: string;
+	rateLimitResetTimes?: Record<string, number | undefined>;
+	coolingDownUntil?: number;
+	cooldownReason?: string;
+};
+
+/**
+ * Pure merge function that combines two stored account records. `target` wins
+ * for stable identity fields; token fields prefer the newer record (by
+ * lastUsed/addedAt) but use nullish-coalescing so an explicitly empty newer
+ * token does NOT silently fall back to the older value. Empty-string tokens
+ * are treated as intentional clears — never resurrected from the older record.
+ *
+ * Exposed for targeted regression tests around the credential-merge semantics.
+ */
+export function mergeStoredAccountPair<T extends MergeableAccountRecord>(
+	target: T,
+	source: T,
+): T {
+	const targetLastUsed = target.lastUsed ?? 0;
+	const sourceLastUsed = source.lastUsed ?? 0;
+	const targetAddedAt = target.addedAt ?? 0;
+	const sourceAddedAt = source.addedAt ?? 0;
+	const sourceIsNewer =
+		sourceLastUsed > targetLastUsed ||
+		(sourceLastUsed === targetLastUsed && sourceAddedAt > targetAddedAt);
+	const newer = sourceIsNewer ? source : target;
+	const older = sourceIsNewer ? target : source;
+
+	const mergedRateLimitResetTimes: Record<string, number> = {};
+	const rateLimitResetKeys = new Set([
+		...Object.keys(older.rateLimitResetTimes ?? {}),
+		...Object.keys(newer.rateLimitResetTimes ?? {}),
+	]);
+	for (const key of rateLimitResetKeys) {
+		const olderRaw = older.rateLimitResetTimes?.[key];
+		const newerRaw = newer.rateLimitResetTimes?.[key];
+		const olderValue =
+			typeof olderRaw === "number" && Number.isFinite(olderRaw) ? olderRaw : 0;
+		const newerValue =
+			typeof newerRaw === "number" && Number.isFinite(newerRaw) ? newerRaw : 0;
+		const resolved = Math.max(olderValue, newerValue);
+		if (resolved > 0) {
+			mergedRateLimitResetTimes[key] = resolved;
+		}
+	}
+
+	const mergedEnabled =
+		target.enabled === false || source.enabled === false
+			? false
+			: target.enabled ?? source.enabled;
+
+	const targetCoolingDownUntil =
+		typeof target.coolingDownUntil === "number" && Number.isFinite(target.coolingDownUntil)
+			? target.coolingDownUntil
+			: 0;
+	const sourceCoolingDownUntil =
+		typeof source.coolingDownUntil === "number" && Number.isFinite(source.coolingDownUntil)
+			? source.coolingDownUntil
+			: 0;
+	const mergedCoolingDownUntilValue = Math.max(
+		targetCoolingDownUntil,
+		sourceCoolingDownUntil,
+	);
+	const mergedCoolingDownUntil =
+		mergedCoolingDownUntilValue > 0 ? mergedCoolingDownUntilValue : undefined;
+	const mergedCooldownReason = (() => {
+		if (mergedCoolingDownUntilValue <= 0) {
+			return target.cooldownReason ?? source.cooldownReason;
+		}
+		if (sourceCoolingDownUntil > targetCoolingDownUntil) {
+			return source.cooldownReason ?? target.cooldownReason;
+		}
+		if (targetCoolingDownUntil > sourceCoolingDownUntil) {
+			return target.cooldownReason ?? source.cooldownReason;
+		}
+		return source.cooldownReason ?? target.cooldownReason;
+	})();
+
+	return {
+		...target,
+		accountId: target.accountId ?? source.accountId,
+		organizationId: target.organizationId ?? source.organizationId,
+		accountIdSource: target.accountIdSource ?? source.accountIdSource,
+		accountLabel: target.accountLabel ?? source.accountLabel,
+		email: target.email ?? source.email,
+		// CRITICAL: use `??` (nullish-coalescing), not `||`. An explicit empty-string
+		// token on `newer` represents a cleared credential — must NOT silently
+		// fall back to the older (potentially stale) token.
+		refreshToken: newer.refreshToken ?? older.refreshToken,
+		accessToken: newer.accessToken ?? older.accessToken,
+		expiresAt: newer.expiresAt ?? older.expiresAt,
+		enabled: mergedEnabled,
+		addedAt: Math.max(target.addedAt ?? 0, source.addedAt ?? 0),
+		lastUsed: Math.max(target.lastUsed ?? 0, source.lastUsed ?? 0),
+		lastSwitchReason: target.lastSwitchReason ?? source.lastSwitchReason,
+		rateLimitResetTimes: mergedRateLimitResetTimes,
+		coolingDownUntil: mergedCoolingDownUntil,
+		cooldownReason: mergedCooldownReason,
+	};
+}
+
 type TokenSuccess = Extract<TokenResult, { type: "success" }>;
 
 export type TokenSuccessWithAccount = TokenSuccess & {
@@ -272,80 +391,7 @@ export async function persistAccountPool(
 			const target = accounts[targetIndex];
 			const source = accounts[sourceIndex];
 			if (!target || !source) return;
-			const targetLastUsed = target.lastUsed ?? 0;
-			const sourceLastUsed = source.lastUsed ?? 0;
-			const targetAddedAt = target.addedAt ?? 0;
-			const sourceAddedAt = source.addedAt ?? 0;
-			const sourceIsNewer =
-				sourceLastUsed > targetLastUsed ||
-				(sourceLastUsed === targetLastUsed && sourceAddedAt > targetAddedAt);
-			const newer = sourceIsNewer ? source : target;
-			const older = sourceIsNewer ? target : source;
-			const mergedRateLimitResetTimes: Record<string, number> = {};
-			const rateLimitResetKeys = new Set([
-				...Object.keys(older.rateLimitResetTimes ?? {}),
-				...Object.keys(newer.rateLimitResetTimes ?? {}),
-			]);
-			for (const key of rateLimitResetKeys) {
-				const olderRaw = older.rateLimitResetTimes?.[key];
-				const newerRaw = newer.rateLimitResetTimes?.[key];
-				const olderValue =
-					typeof olderRaw === "number" && Number.isFinite(olderRaw) ? olderRaw : 0;
-				const newerValue =
-					typeof newerRaw === "number" && Number.isFinite(newerRaw) ? newerRaw : 0;
-				const resolved = Math.max(olderValue, newerValue);
-				if (resolved > 0) {
-					mergedRateLimitResetTimes[key] = resolved;
-				}
-			}
-			const mergedEnabled =
-				target.enabled === false || source.enabled === false
-					? false
-					: target.enabled ?? source.enabled;
-			const targetCoolingDownUntil =
-				typeof target.coolingDownUntil === "number" && Number.isFinite(target.coolingDownUntil)
-					? target.coolingDownUntil
-					: 0;
-			const sourceCoolingDownUntil =
-				typeof source.coolingDownUntil === "number" && Number.isFinite(source.coolingDownUntil)
-					? source.coolingDownUntil
-					: 0;
-			const mergedCoolingDownUntilValue = Math.max(
-				targetCoolingDownUntil,
-				sourceCoolingDownUntil,
-			);
-			const mergedCoolingDownUntil =
-				mergedCoolingDownUntilValue > 0 ? mergedCoolingDownUntilValue : undefined;
-			const mergedCooldownReason = (() => {
-				if (mergedCoolingDownUntilValue <= 0) {
-					return target.cooldownReason ?? source.cooldownReason;
-				}
-				if (sourceCoolingDownUntil > targetCoolingDownUntil) {
-					return source.cooldownReason ?? target.cooldownReason;
-				}
-				if (targetCoolingDownUntil > sourceCoolingDownUntil) {
-					return target.cooldownReason ?? source.cooldownReason;
-				}
-				return source.cooldownReason ?? target.cooldownReason;
-			})();
-			accounts[targetIndex] = {
-				...target,
-				accountId: target.accountId ?? source.accountId,
-				organizationId: target.organizationId ?? source.organizationId,
-				accountIdSource: target.accountIdSource ?? source.accountIdSource,
-				accountLabel: target.accountLabel ?? source.accountLabel,
-				email: target.email ?? source.email,
-				refreshToken: newer.refreshToken || older.refreshToken,
-				accessToken: newer.accessToken || older.accessToken,
-				expiresAt: newer.expiresAt ?? older.expiresAt,
-				enabled: mergedEnabled,
-				addedAt: Math.max(target.addedAt ?? 0, source.addedAt ?? 0),
-				lastUsed: Math.max(target.lastUsed ?? 0, source.lastUsed ?? 0),
-				lastSwitchReason: target.lastSwitchReason ?? source.lastSwitchReason,
-				rateLimitResetTimes: mergedRateLimitResetTimes,
-				coolingDownUntil: mergedCoolingDownUntil,
-				cooldownReason: mergedCooldownReason,
-			};
+			accounts[targetIndex] = mergeStoredAccountPair(target, source);
 		};
 
 		const normalizeStoredAccountId = (

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -26,11 +26,39 @@ const LOG_LEVEL_PRIORITY: Record<LogLevel, number> = {
 	error: 3,
 };
 
-const TOKEN_PATTERNS = [
+/**
+ * Regexes for detecting secret-shaped strings inside free-form log text
+ * (response bodies, error messages, stack traces). Each entry is tried in
+ * order and matches are replaced via `maskToken`.
+ *
+ * Structured objects route through `SENSITIVE_KEYS` instead; these patterns
+ * are the catch-net for strings that were never decomposed into keyed fields,
+ * e.g. a raw JSON response body logged as a single string.
+ */
+const TOKEN_PATTERNS: Array<RegExp | { pattern: RegExp; group: number }> = [
+	// JWTs (id_token, OpenAI access_token on modern flows).
 	/eyJ[A-Za-z0-9_-]+\.eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/g,
+	// Long lower-case hex (SHA-1/SHA-256 tokens, some API keys).
 	/[a-f0-9]{40,}/gi,
+	// Platform API keys.
 	/sk-[A-Za-z0-9]{20,}/g,
+	// Authorization headers — catches bearer + any scheme.
 	/Bearer\s+\S+/gi,
+	// Opaque OpenAI refresh / access / id tokens embedded in JSON-ish strings.
+	// Matches patterns like "refresh_token":"abc...", refresh_token: 'abc...',
+	// and refresh_token=abc... Captures the VALUE via group 1 so the key and
+	// the surrounding quotes survive the replacement. Audit top-20 #15.
+	{
+		pattern:
+			/(["']?)(?:refresh_token|access_token|id_token)\1?\s*[:=]\s*["']([^"'\s]+)["']/gi,
+		group: 2,
+	},
+	// Bare token=... / access_token=... in URL-encoded strings or query logs.
+	{
+		pattern:
+			/\b(?:refresh_token|access_token|id_token)\s*=\s*([A-Za-z0-9._\-~+/=]{8,})/gi,
+		group: 1,
+	},
 ];
 
 const EMAIL_PATTERN = /[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/g;
@@ -74,10 +102,23 @@ function maskEmail(email: string): string {
 
 function maskString(value: string): string {
 	let result = value;
-	// Mask emails first (before token patterns might match parts of them)
+	// Mask emails first (before token patterns might match parts of them).
 	result = result.replace(EMAIL_PATTERN, (match) => maskEmail(match));
-	for (const pattern of TOKEN_PATTERNS) {
-		result = result.replace(pattern, (match) => maskToken(match));
+	for (const entry of TOKEN_PATTERNS) {
+		if (entry instanceof RegExp) {
+			result = result.replace(entry, (match) => maskToken(match));
+		} else {
+			const { pattern, group } = entry;
+			result = result.replace(pattern, (match: string, ...captures: unknown[]) => {
+				// captures holds (in order): ...groups, offset, fullString
+				// We only care about the captured value at index `group - 1`.
+				const captured = captures[group - 1];
+				if (typeof captured !== "string" || captured.length === 0) {
+					return maskToken(match);
+				}
+				return match.replace(captured, maskToken(captured));
+			});
+		}
 	}
 	return result;
 }
@@ -396,3 +437,14 @@ export function getRequestId(): number {
 }
 
 export { formatDuration, maskEmail };
+
+/**
+ * Test-only exports. Internal helpers surfaced here so their redaction
+ * invariants can be unit-tested directly rather than through the
+ * side-effect-heavy logDebug/logRequest code paths. Do NOT import from this
+ * namespace outside of tests.
+ */
+export const __testOnly = {
+	maskString,
+	sanitizeValue,
+};

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -116,7 +116,19 @@ function maskString(value: string): string {
 				if (typeof captured !== "string" || captured.length === 0) {
 					return maskToken(match);
 				}
-				return match.replace(captured, maskToken(captured));
+				// Use lastIndexOf: the captured value always sits at the end of
+				// the match, but String.prototype.replace(string, string) only
+				// replaces the FIRST occurrence. If the captured value happens
+				// to be a substring of the preceding key name (e.g. captured
+				// "access" inside '"access_token":"access"'), a first-occurrence
+				// replace would corrupt the key and leak the real value. Slicing
+				// around lastIndexOf guarantees we rewrite the value only.
+				const lastIdx = match.lastIndexOf(captured);
+				return (
+					match.slice(0, lastIdx) +
+					maskToken(captured) +
+					match.slice(lastIdx + captured.length)
+				);
 			});
 		}
 	}

--- a/lib/schemas.ts
+++ b/lib/schemas.ts
@@ -196,6 +196,62 @@ export const AnyAccountStorageSchema = z.discriminatedUnion("version", [
 export type AnyAccountStorageFromSchema = z.infer<typeof AnyAccountStorageSchema>;
 
 // ============================================================================
+// Codex CLI Cross-Process Account File Schema
+// ============================================================================
+
+/**
+ * Schema for a single Codex CLI account entry.
+ *
+ * This file is produced by a separate process (the Codex CLI) and lives on
+ * disk at a known path. It is a cross-trust-boundary input: the file could be
+ * stale, truncated, tampered with, or produced by a mismatched Codex CLI
+ * version. All fields are therefore `optional` at the schema level — we
+ * extract only the fields we need and let `catchall(z.unknown())` preserve
+ * any extra fields without rejection.
+ *
+ * Security note (audit top-20 #11): never trust field shapes via ad-hoc
+ * property checks before validating through this schema. The wrapper
+ * `CodexCliAccountsSchema` must be applied at the JSON-parse boundary.
+ */
+export const CodexCliAccountEntrySchema = z
+	.object({
+		email: z.string().optional(),
+		accountId: z.string().optional(),
+		auth: z
+			.object({
+				tokens: z
+					.object({
+						access_token: z.string().optional(),
+						refresh_token: z.string().optional(),
+						id_token: z.string().optional(),
+					})
+					.catchall(z.unknown())
+					.optional(),
+			})
+			.catchall(z.unknown())
+			.optional(),
+	})
+	.catchall(z.unknown());
+
+export type CodexCliAccountEntryFromSchema = z.infer<typeof CodexCliAccountEntrySchema>;
+
+/**
+ * Schema for the full Codex CLI accounts file.
+ *
+ * Applied at the JSON-parse boundary in `lib/accounts.ts:getCodexCliTokenCache`.
+ * A validation failure causes the loader to warn+skip (treat cache as empty)
+ * rather than throwing — a malformed or attacker-controlled Codex CLI file
+ * must never take down the host plugin.
+ */
+export const CodexCliAccountsSchema = z
+	.object({
+		accounts: z.array(CodexCliAccountEntrySchema).optional(),
+	})
+	.catchall(z.unknown());
+
+export type CodexCliAccountsFromSchema = z.infer<typeof CodexCliAccountsSchema>;
+
+// ============================================================================
 // Token Result Schemas
 // ============================================================================
 

--- a/test/hydrate-codex-cli.test.ts
+++ b/test/hydrate-codex-cli.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from "vitest";
+import {
+	CodexCliAccountsSchema,
+	CodexCliAccountEntrySchema,
+} from "../lib/schemas.js";
+
+/**
+ * Audit top-20 #11: Codex CLI accounts file is a cross-process input written
+ * by a separate process. The plugin previously validated it with ad-hoc
+ * isRecord/typeof checks; anything outside those specific fields was trusted
+ * implicitly. These tests pin the Zod schema to:
+ *   1. accept the well-formed shape produced by the real Codex CLI,
+ *   2. reject a handful of attacker-shaped / version-drift variants in a way
+ *      the plugin can detect via `safeParse().success === false`,
+ *   3. never throw — validation must return a typed result, not crash.
+ */
+describe("CodexCliAccountsSchema", () => {
+	it("accepts a realistic well-formed accounts file", () => {
+		const valid = {
+			accounts: [
+				{
+					email: "user@example.com",
+					accountId: "acct_abc123",
+					auth: {
+						tokens: {
+							access_token: "access-value",
+							refresh_token: "refresh-value",
+							id_token: "id-value",
+						},
+					},
+				},
+			],
+		};
+
+		const result = CodexCliAccountsSchema.safeParse(valid);
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.accounts?.[0]?.email).toBe("user@example.com");
+			expect(result.data.accounts?.[0]?.auth?.tokens?.refresh_token).toBe(
+				"refresh-value",
+			);
+		}
+	});
+
+	it("accepts a file with unknown top-level keys (forward-compat via catchall)", () => {
+		const valid = {
+			accounts: [{ email: "user@example.com" }],
+			schemaVersion: 99,
+			generatedBy: "codex-cli-vNext",
+			// Future-added field the plugin does not know about must not break parsing.
+			unknownExtension: { some: "future-shape" },
+		};
+
+		const result = CodexCliAccountsSchema.safeParse(valid);
+		expect(result.success).toBe(true);
+	});
+
+	it("accepts an empty accounts file (loader treats as no accounts)", () => {
+		const result = CodexCliAccountsSchema.safeParse({ accounts: [] });
+		expect(result.success).toBe(true);
+	});
+
+	it("accepts a file with the accounts key omitted", () => {
+		// Older Codex CLI builds may ship a file with only `accounts` absent.
+		// Schema must accept it; the loader will then treat the cache as empty.
+		const result = CodexCliAccountsSchema.safeParse({});
+		expect(result.success).toBe(true);
+	});
+
+	it("rejects a file whose accounts key is not an array (attacker payload)", () => {
+		const attacker = {
+			accounts: { email: "user@example.com" }, // not an array
+		};
+		const result = CodexCliAccountsSchema.safeParse(attacker);
+		expect(result.success).toBe(false);
+	});
+
+	it("rejects non-object root (defensive against raw strings / numbers)", () => {
+		expect(CodexCliAccountsSchema.safeParse("not an object").success).toBe(false);
+		expect(CodexCliAccountsSchema.safeParse(123).success).toBe(false);
+		expect(CodexCliAccountsSchema.safeParse(null).success).toBe(false);
+	});
+
+	it("rejects an account entry whose email is not a string", () => {
+		const attacker = {
+			accounts: [{ email: { $ne: null } }],
+		};
+		const result = CodexCliAccountsSchema.safeParse(attacker);
+		expect(result.success).toBe(false);
+	});
+
+	it("rejects an account entry whose tokens block has non-string token fields", () => {
+		const attacker = {
+			accounts: [
+				{
+					email: "user@example.com",
+					auth: {
+						tokens: {
+							access_token: ["payload", "injection"],
+						},
+					},
+				},
+			],
+		};
+		const result = CodexCliAccountsSchema.safeParse(attacker);
+		expect(result.success).toBe(false);
+	});
+
+	it("does not throw on parse failure — safeParse returns typed result", () => {
+		// Direct parse-throwing APIs exist on Zod, but the production code must
+		// only ever use safeParse. Verify the schema yields a typed failure for
+		// a grossly malformed input rather than raising an exception.
+		expect(() => CodexCliAccountsSchema.safeParse(undefined)).not.toThrow();
+		expect(CodexCliAccountsSchema.safeParse(undefined).success).toBe(false);
+	});
+
+	it("CodexCliAccountEntrySchema accepts entries with only optional fields present", () => {
+		// Real files in the wild often omit accountId and even the auth block
+		// for partially-onboarded accounts. Loader treats these as skip-worthy
+		// but the schema MUST still accept them — throwing here would take
+		// down the whole cache load.
+		expect(
+			CodexCliAccountEntrySchema.safeParse({ email: "user@example.com" }).success,
+		).toBe(true);
+		expect(CodexCliAccountEntrySchema.safeParse({}).success).toBe(true);
+	});
+});

--- a/test/logger.test.ts
+++ b/test/logger.test.ts
@@ -895,4 +895,50 @@ describe('Logger Module', () => {
 			expect(id1).toBe(id2);
 		});
 	});
+
+	// Audit top-20 #15: OpenAI opaque refresh/access/id tokens embedded in
+	// logged JSON response bodies were leaking because the hex-40, JWT, and
+	// sk- regexes did not catch them. Extended TOKEN_PATTERNS catches them
+	// via keyed extraction.
+	describe('maskString redacts OpenAI opaque tokens in free-form JSON', () => {
+		it('redacts refresh_token values in JSON strings', async () => {
+			const { __testOnly } = await import('../lib/logger.js');
+			const input = '{"refresh_token":"abcdefghij-opaque-token-12345"}';
+			const out = __testOnly.maskString(input);
+			expect(out).not.toContain('abcdefghij-opaque-token-12345');
+			// Key name preserved; only the value is masked.
+			expect(out).toContain('refresh_token');
+		});
+
+		it('redacts access_token values in JSON strings', async () => {
+			const { __testOnly } = await import('../lib/logger.js');
+			const input = '{"access_token": "opaque-access-ABCDEFGH123456"}';
+			const out = __testOnly.maskString(input);
+			expect(out).not.toContain('opaque-access-ABCDEFGH123456');
+			expect(out).toContain('access_token');
+		});
+
+		it('redacts id_token values in JSON strings', async () => {
+			const { __testOnly } = await import('../lib/logger.js');
+			const input = '{"id_token":"some-opaque-id-token-value-1234"}';
+			const out = __testOnly.maskString(input);
+			expect(out).not.toContain('some-opaque-id-token-value-1234');
+		});
+
+		it('redacts refresh_token in query-string / URL-encoded form', async () => {
+			const { __testOnly } = await import('../lib/logger.js');
+			const input = 'POST /token refresh_token=raw-opaque-token-XYZ789';
+			const out = __testOnly.maskString(input);
+			expect(out).not.toContain('raw-opaque-token-XYZ789');
+		});
+
+		it('preserves non-token JSON structure while redacting only the token value', async () => {
+			const { __testOnly } = await import('../lib/logger.js');
+			const input = '{"token_type":"Bearer","expires_in":3600,"refresh_token":"aaaa-bbbb-cccc-dddd-eeee"}';
+			const out = __testOnly.maskString(input);
+			expect(out).toContain('token_type');
+			expect(out).toContain('expires_in');
+			expect(out).not.toContain('aaaa-bbbb-cccc-dddd-eeee');
+		});
+	});
 });

--- a/test/logger.test.ts
+++ b/test/logger.test.ts
@@ -940,5 +940,44 @@ describe('Logger Module', () => {
 			expect(out).toContain('expires_in');
 			expect(out).not.toContain('aaaa-bbbb-cccc-dddd-eeee');
 		});
+
+		// Regression: Greptile PR #112 review (P2). String.replace(string, ...)
+		// only swaps the FIRST occurrence. When the token VALUE is a substring
+		// of the preceding KEY NAME (e.g. value "access" inside key
+		// "access_token"), the old impl masked the key and leaked the value.
+		// Fix uses lastIndexOf so the trailing value always wins.
+		it('redacts token value even when value is substring of key name (access)', async () => {
+			const { __testOnly } = await import('../lib/logger.js');
+			const input = '{"access_token":"access"}';
+			const out = __testOnly.maskString(input);
+			// Key must survive intact.
+			expect(out).toContain('access_token');
+			// Raw leaked value must not appear next to the key.
+			expect(out).not.toMatch(/"access_token":\s*"access"/);
+			// Masked placeholder replaces the value (short tokens become ***MASKED***).
+			expect(out).toBe('{"access_token":"***MASKED***"}');
+		});
+
+		it('redacts token value even when value is substring of key name (refresh)', async () => {
+			const { __testOnly } = await import('../lib/logger.js');
+			const input = '{"refresh_token":"refresh"}';
+			const out = __testOnly.maskString(input);
+			expect(out).toContain('refresh_token');
+			expect(out).not.toMatch(/"refresh_token":\s*"refresh"/);
+			expect(out).toBe('{"refresh_token":"***MASKED***"}');
+		});
+
+		it('redacts long token value when value is substring of key name', async () => {
+			const { __testOnly } = await import('../lib/logger.js');
+			// Long value (>12 chars) so maskToken keeps head/tail, and value
+			// contains the key fragment "access_token" inside it — worst case.
+			const longValue = 'access_token-payload-xyz987654321';
+			const input = `{"access_token":"${longValue}"}`;
+			const out = __testOnly.maskString(input);
+			expect(out).toContain('access_token":"');
+			expect(out).not.toContain(longValue);
+			// Masked head + ellipsis + tail pattern (from maskToken long branch).
+			expect(out).toMatch(/"access_token":"access...4321"/);
+		});
 	});
 });

--- a/test/login-runner.test.ts
+++ b/test/login-runner.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
 	applyAccountSelectionFallbacks,
+	mergeStoredAccountPair,
 	persistAccountPool,
 	persistResolvedAccountSelection,
 	resolveAccountSelection,
@@ -245,5 +246,97 @@ describe("login-runner selection finalization", () => {
 		expect(wrapped.message).not.toContain("token-file");
 		expect(wrapped.message).not.toContain("acct-123");
 		expect(persistSelections).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe("mergeStoredAccountPair (credential merge semantics)", () => {
+	// Audit top-20 #10: `||` allowed an intentionally cleared (empty-string)
+	// token on the newer record to fall back to the older record's stale token,
+	// effectively resurrecting credentials the caller had already cleared.
+	it("does not resurrect an older token when the newer record has an explicit empty-string token", () => {
+		const base = {
+			addedAt: 1_000,
+			lastUsed: 1_000,
+			rateLimitResetTimes: {},
+		};
+		const older = {
+			...base,
+			refreshToken: "older-refresh",
+			accessToken: "older-access",
+			expiresAt: 2_000,
+		};
+		const newer = {
+			...base,
+			lastUsed: 2_000,
+			refreshToken: "",
+			accessToken: "",
+			expiresAt: 3_000,
+		};
+
+		const merged = mergeStoredAccountPair(older, newer);
+
+		// Newer wins on recency. Empty strings are NOT null/undefined, so
+		// nullish-coalescing keeps them — the stale older token stays buried.
+		expect(merged.refreshToken).toBe("");
+		expect(merged.accessToken).toBe("");
+		expect(merged.expiresAt).toBe(3_000);
+	});
+
+	it("falls back to the older token when the newer token is genuinely absent (undefined)", () => {
+		const older = {
+			addedAt: 1_000,
+			lastUsed: 1_000,
+			rateLimitResetTimes: {},
+			refreshToken: "older-refresh",
+			accessToken: "older-access",
+			expiresAt: 2_000,
+		};
+		const newer = {
+			addedAt: 2_000,
+			lastUsed: 2_000,
+			rateLimitResetTimes: {},
+			// tokens undefined (not empty string)
+		};
+
+		const merged = mergeStoredAccountPair(older, newer);
+
+		expect(merged.refreshToken).toBe("older-refresh");
+		expect(merged.accessToken).toBe("older-access");
+		expect(merged.expiresAt).toBe(2_000);
+	});
+
+	it("prefers the newer record's token over the older record's token when both are non-empty", () => {
+		const older = {
+			addedAt: 1_000,
+			lastUsed: 1_000,
+			rateLimitResetTimes: {},
+			refreshToken: "older-refresh",
+		};
+		const newer = {
+			addedAt: 2_000,
+			lastUsed: 2_000,
+			rateLimitResetTimes: {},
+			refreshToken: "newer-refresh",
+		};
+
+		expect(mergeStoredAccountPair(older, newer).refreshToken).toBe("newer-refresh");
+	});
+
+	it("disables the merged record if either input had enabled:false (fail-closed)", () => {
+		const a = {
+			addedAt: 1,
+			lastUsed: 1,
+			rateLimitResetTimes: {},
+			enabled: true,
+		};
+		const b = {
+			addedAt: 2,
+			lastUsed: 2,
+			rateLimitResetTimes: {},
+			enabled: false,
+		};
+
+		expect(mergeStoredAccountPair(a, b).enabled).toBe(false);
+		expect(mergeStoredAccountPair(b, a).enabled).toBe(false);
 	});
 });

--- a/test/runtime-contracts.test.ts
+++ b/test/runtime-contracts.test.ts
@@ -7,6 +7,7 @@ import {
 	isDeactivatedWorkspaceErrorMessage,
 	isUsageRequestTimeoutMessage,
 	OAUTH_CALLBACK_BIND_URL,
+	OAUTH_CALLBACK_LOOPBACK_HOST,
 	OAUTH_CALLBACK_PATH,
 	OAUTH_CALLBACK_PORT,
 	USAGE_REQUEST_TIMEOUT_MESSAGE,
@@ -29,7 +30,15 @@ describe("runtime contracts", () => {
 	it("keeps the OAuth callback runtime values aligned", () => {
 		expect(OAUTH_CALLBACK_PORT).toBe(1455);
 		expect(OAUTH_CALLBACK_PATH).toBe("/auth/callback");
+		expect(OAUTH_CALLBACK_LOOPBACK_HOST).toBe("127.0.0.1");
 		expect(OAUTH_CALLBACK_BIND_URL).toBe(`http://127.0.0.1:${OAUTH_CALLBACK_PORT}`);
-		expect(REDIRECT_URI).toBe(`http://localhost:${OAUTH_CALLBACK_PORT}${OAUTH_CALLBACK_PATH}`);
+		// RFC 8252 §7.3: redirect URI MUST use the 127.0.0.1 literal, matching
+		// the host the callback server binds to. `localhost` would resolve via
+		// DNS and is not equivalent.
+		expect(REDIRECT_URI).toBe(
+			`http://${OAUTH_CALLBACK_LOOPBACK_HOST}:${OAUTH_CALLBACK_PORT}${OAUTH_CALLBACK_PATH}`,
+		);
+		expect(REDIRECT_URI).toContain("127.0.0.1");
+		expect(REDIRECT_URI).not.toContain("localhost");
 	});
 });


### PR DESCRIPTION
## Summary

Phase-1 security fixes from audit `d92a8eed`.

## Changes

- **Credential merge** — `lib/auth/login-runner.ts`: extracts `mergeStoredAccountPair` and switches token fallback from `||` to `??`. An explicit empty-string token on the newer record (caller-cleared credential) no longer silently resurrects the older token. Audit top-20 #10.
- **RFC 8252** — `lib/auth/auth.ts`: `REDIRECT_URI` uses the `127.0.0.1` loopback literal via the existing `OAUTH_CALLBACK_LOOPBACK_HOST` runtime contract, matching the server bind host. Previously used `localhost`, which resolves via DNS and is not guaranteed equivalent.
- **Cross-process Zod validation** — `lib/schemas.ts` + `lib/accounts.ts:getCodexCliTokenCache`: adds `CodexCliAccountsSchema` and validates the Codex CLI accounts file through Zod at the JSON-parse boundary. Validation failure is a warn+skip (treat cache as empty); never throws. Audit top-20 #11.
- **Token redaction** — `lib/logger.ts`: extends `TOKEN_PATTERNS` with keyed-extraction regexes for opaque OpenAI `refresh_token` / `access_token` / `id_token` values embedded in JSON response bodies and URL-encoded forms. Existing SENSITIVE_KEYS path (structured objects) is unchanged; this catches the free-form string path. Audit top-20 #15.

## Tests

- `test/login-runner.test.ts`: `mergeStoredAccountPair` preserves empty newer token (no resurrection); falls back to older token only when newer is genuinely `undefined`; disables on fail-closed.
- `test/runtime-contracts.test.ts`: asserts `REDIRECT_URI` uses `127.0.0.1` and does not contain `localhost`.
- `test/hydrate-codex-cli.test.ts`: `CodexCliAccountsSchema` accepts well-formed + forward-compat shapes; rejects attacker variants (non-array accounts, non-object root, shape-smuggled tokens); never throws.
- `test/logger.test.ts`: opaque `refresh_token` / `access_token` / `id_token` values are masked in JSON strings; key names preserved.

## Audit refs

- `docs/audits/14-top20.md` #10, #11, #15
- `docs/audits/09-security-trust.md`

## Verification

`npm run typecheck`, `npm run lint`, `npm test` (2089 passed), `npm run build` — all pass on `fix/phase1-security`.

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

four targeted phase-1 security fixes: `??` nullish merge in `mergeStoredAccountPair` correctly prevents empty-string token resurrection; `REDIRECT_URI` now uses the `127.0.0.1` literal per RFC 8252 §7.3; `CodexCliAccountsSchema` gates the cross-process accounts file at parse time with warn+skip on failure; `TOKEN_PATTERNS` extended with keyed-extraction regexes plus the `lastIndexOf` fix for substring-of-key edge cases.

- one P2 in `mergeStoredAccountPair`: `addedAt` uses `Math.max`, which discards the original creation date on every deduplication merge — `Math.min` preserves account history
- pre-existing module-level TOCTOU window in `getCodexCliTokenCache` (concurrent calls during the async readFile both proceed past the TTL guard); not worsened by this PR but worth noting given the new Zod step widens the async window
- minor vitest gap: bare URL-encoded redaction is only pinned for the refresh key; the other two key names in that same pattern have no test cases

<h3>Confidence Score: 5/5</h3>

safe to merge; all remaining findings are P2 style/coverage suggestions with no blocking correctness or security issues

the four security fixes are correctly implemented and well-tested. the addedAt Math.max concern is a semantic P2 on a new helper function — it doesn't affect token safety or auth correctness, only account display ordering. no P0/P1 findings remain.

lib/auth/login-runner.ts — review the addedAt Math.max vs Math.min choice before the next merge of duplicate account records hits production

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/auth/login-runner.ts | introduces `mergeStoredAccountPair` with correct `??` semantics for empty-string token preservation; `addedAt: Math.max` may lose original creation date on deduplication merge |
| lib/auth/auth.ts | REDIRECT_URI now uses OAUTH_CALLBACK_LOOPBACK_HOST (127.0.0.1) literal per RFC 8252 §7.3; comment and runtime-contracts alignment both correct |
| lib/accounts.ts | Zod safeParse at JSON-parse boundary in getCodexCliTokenCache is correctly fail-safe (warn+skip); pre-existing module-level TOCTOU window on concurrent cache loads is noted but not worsened |
| lib/logger.ts | keyed-extraction TOKEN_PATTERNS and lastIndexOf fix are correct; global-flag regex state is safe because String.prototype.replace resets lastIndex per call |
| lib/schemas.ts | CodexCliAccountsSchema and CodexCliAccountEntrySchema use catchall(z.unknown()) for forward-compat; correctly rejects non-array accounts and non-object roots as confirmed by tests |
| test/login-runner.test.ts | mergeStoredAccountPair tests correctly pin empty-string token preservation, undefined fallback, and fail-closed enabled logic; concurrency test uses rename spy to assert serialized write-merge behavior |
| test/logger.test.ts | new maskString tests cover JSON-keyed and URL-encoded redaction including lastIndexOf regression; bare URL-encoded pattern only tested for refresh key, missing analogous assertions for other key names |
| test/hydrate-codex-cli.test.ts | schema tests cover well-formed, forward-compat, empty, attacker-shaped (non-array, non-object root, type-smuggled tokens), and no-throw invariants; solid coverage |
| test/runtime-contracts.test.ts | asserts REDIRECT_URI contains 127.0.0.1 and does not contain localhost; correctly pins the RFC 8252 invariant |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[getCodexCliTokenCache called] --> B{cache fresh?}
    B -- yes --> C[return cached Map]
    B -- no --> D[set codexCliTokenCacheLoadedAt = now]
    D --> E{file exists?}
    E -- no --> F[codexCliTokenCache = null, return null]
    E -- yes --> G[fs.readFile accounts.json]
    G --> H[JSON.parse raw]
    H --> I[CodexCliAccountsSchema.safeParse]
    I -- failure --> J[log.warn + return null]
    I -- success --> K[iterate validated.accounts]
    K --> L{email valid?}
    L -- no --> M[skip entry]
    L -- yes --> N{accessToken present?}
    N -- no --> M
    N -- yes --> O[set email to entry in Map]
    O --> P[codexCliTokenCache = Map, return]
    G -- throw --> Q[catch: log.debug, return null]
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Foc-codex-multi-auth%22%20on%20the%20existing%20branch%20%22fix%2Fphase1-security%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fphase1-security%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Alib%2Fauth%2Flogin-runner.ts%3A123-124%0A**%60addedAt%60%20takes%20%60Math.max%60%20instead%20of%20%60Math.min%60**%0A%0A%60addedAt%60%20is%20meant%20to%20record%20when%20the%20account%20was%20*first*%20added.%20taking%20%60Math.max%60%20of%20two%20duplicates%20always%20discards%20the%20original%20creation%20date%20%E2%80%94%20the%20merged%20record%20looks%20newer%20than%20either%20source.%20this%20loses%20%22account%20age%22%20info%20and%20can%20affect%20any%20ordering%20or%20display%20that%20relies%20on%20it.%20should%20almost%20certainly%20be%20%60Math.min%60%20to%20preserve%20the%20oldest%20known%20creation%20timestamp.%0A%0Aconsider%20using%20%60Math.min%60%20with%20a%20fallback%20to%20avoid%20losing%20history%20on%20every%20deduplication%20pass.%0A%0A%23%23%23%20Issue%202%20of%203%0Alib%2Faccounts.ts%3A107-111%0A**module-level%20cache%20has%20a%20TOCTOU%20window%20on%20concurrent%20calls**%0A%0A%60codexCliTokenCacheLoadedAt%20%3D%20now%60%20is%20set%20before%20the%20%60await%20fs.readFile%60%20completes.%20a%20second%20concurrent%20caller%20that%20arrives%20during%20the%20async%20read%20will%20see%20the%20updated%20timestamp%2C%20pass%20the%20TTL%20check%2C%20get%20the%20stale%20%28pre-validation%29%20%60codexCliTokenCache%60%2C%20and%20return%20it%20%E2%80%94%20while%20the%20first%20call%20is%20still%20running%20the%20new%20Zod%20validation.%20this%20is%20pre-existing%2C%20but%20the%20new%20validation%20step%20widens%20the%20window%20slightly.%0A%0Anet%20effect%20is%20just%20a%20redundant%20double-read%20%28reads%20are%20idempotent%29%2C%20not%20data%20loss%20%E2%80%94%20but%20worth%20noting%20per%20the%20concurrency%20audit%20posture.%20a%20%60Promise%60-based%20in-flight%20guard%20would%20eliminate%20the%20window%20entirely.%0A%0A%23%23%23%20Issue%203%20of%203%0Atest%2Flogger.test.ts%3A928-933%0A**missing%20vitest%20coverage%20for%20bare%20URL-encoded%20access%20and%20id%20token%20keys**%0A%0Athe%20bare-token%20regex%20covers%20three%20key%20names%2C%20but%20only%20the%20refresh%20key%20is%20exercised%20in%20the%20URL-encoded%20test%20block.%20add%20parallel%20assertions%20for%20the%20other%20two%20key%20names%20in%20query-log%20strings%20to%20confirm%20all%20three%20branches%20redact%20correctly.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: lib/auth/login-runner.ts
Line: 123-124

Comment:
**`addedAt` takes `Math.max` instead of `Math.min`**

`addedAt` is meant to record when the account was *first* added. taking `Math.max` of two duplicates always discards the original creation date — the merged record looks newer than either source. this loses "account age" info and can affect any ordering or display that relies on it. should almost certainly be `Math.min` to preserve the oldest known creation timestamp.

consider using `Math.min` with a fallback to avoid losing history on every deduplication pass.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: lib/accounts.ts
Line: 107-111

Comment:
**module-level cache has a TOCTOU window on concurrent calls**

`codexCliTokenCacheLoadedAt = now` is set before the `await fs.readFile` completes. a second concurrent caller that arrives during the async read will see the updated timestamp, pass the TTL check, get the stale (pre-validation) `codexCliTokenCache`, and return it — while the first call is still running the new Zod validation. this is pre-existing, but the new validation step widens the window slightly.

net effect is just a redundant double-read (reads are idempotent), not data loss — but worth noting per the concurrency audit posture. a `Promise`-based in-flight guard would eliminate the window entirely.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: test/logger.test.ts
Line: 928-933

Comment:
**missing vitest coverage for bare URL-encoded access and id token keys**

the bare-token regex covers three key names, but only the refresh key is exercised in the URL-encoded test block. add parallel assertions for the other two key names in query-log strings to confirm all three branches redact correctly.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(logger): use lastIndexOf to avoid ma..."](https://github.com/ndycode/oc-codex-multi-auth/commit/f38e6e53a4234625774ae02f7395551b0b7f8dca) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28725236)</sub>

<!-- /greptile_comment -->