### PR TITLE
fix(storage): handle V2 schema (migrate or explicit reject)

### DIFF
--- a/lib/schemas.ts
+++ b/lib/schemas.ts
@@ -186,7 +186,28 @@ export const AccountStorageV1Schema = z.object({
 export type AccountStorageV1FromSchema = z.infer<typeof AccountStorageV1Schema>;
 
 /**
+ * Minimal V2 detection schema.
+ *
+ * V2 was an intermediate account-storage format used by legacy 4.x builds
+ * that never shipped a documented shape. We only validate enough to recognise
+ * `version: 2` files so the loader can surface a typed `UNKNOWN_V2_FORMAT`
+ * error instead of silently discarding credentials. Do not extend this
+ * schema without evidence of the real V2 shape.
+ */
+export const AccountStorageV2DetectionSchema = z.object({
+	version: z.literal(2),
+	accounts: z.array(z.unknown()).optional(),
+});
+
+export type AccountStorageV2DetectionFromSchema = z.infer<
+	typeof AccountStorageV2DetectionSchema
+>;
+
+/**
  * Union of V1 and V3 storage formats for migration detection.
+ * V2 is intentionally excluded: it is detected separately and rejected with a
+ * typed StorageError so users with a V2 file are told how to recover instead
+ * of having their credentials silently discarded.
  */
 export const AnyAccountStorageSchema = z.discriminatedUnion("version", [
 	AccountStorageV1Schema,

--- a/lib/schemas.ts
+++ b/lib/schemas.ts
@@ -196,7 +196,11 @@ export type AccountStorageV1FromSchema = z.infer<typeof AccountStorageV1Schema>;
  */
 export const AccountStorageV2DetectionSchema = z.object({
 	version: z.literal(2),
-	accounts: z.array(z.unknown()).optional(),
+	// Use `.nullish()` (accepts `null` OR `undefined`) rather than `.optional()`
+	// so a malformed V2 file with `"accounts": null` still matches the V2 shape
+	// and flows to the typed UNKNOWN_V2_FORMAT rejection path instead of
+	// silently falling through to `return null` and discarding credentials.
+	accounts: z.array(z.unknown()).nullish(),
 });
 
 export type AccountStorageV2DetectionFromSchema = z.infer<

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -11,10 +11,17 @@ import {
 } from "./constants.js";
 import { createLogger } from "./logger.js";
 import { MODEL_FAMILIES, type ModelFamily } from "./prompts/codex.js";
-import { AnyAccountStorageSchema, getValidationErrors } from "./schemas.js";
+import {
+  AnyAccountStorageSchema,
+  AccountStorageV2DetectionSchema,
+  getValidationErrors,
+} from "./schemas.js";
 import { getConfigDir, getProjectConfigDir, getProjectGlobalConfigDir, findProjectRoot, resolvePath } from "./storage/paths.js";
 import {
+  buildV2RecoveryHint,
+  buildV2RejectionMessage,
   migrateV1ToV3,
+  UNKNOWN_V2_FORMAT_CODE,
   type CooldownReason,
   type RateLimitStateV3,
   type AccountMetadataV1,
@@ -669,6 +676,22 @@ export function normalizeAccountStorage(
     );
   }
 
+  // V2 files were produced by an intermediate 4.x build whose shape was never
+  // documented and for which no forward-migrator shipped. Silently treating
+  // them as "unknown version" (the previous behaviour) meant users with a V2
+  // file had their credentials discarded without any signal. Detect V2
+  // explicitly and throw a typed StorageError so the caller can surface the
+  // recovery hint to the user. Audit top-20 #8; see
+  // `lib/storage/migrations.ts:buildV2RejectionMessage` for copy.
+  if (AccountStorageV2DetectionSchema.safeParse(data).success) {
+    throw new StorageError(
+      buildV2RejectionMessage(),
+      UNKNOWN_V2_FORMAT_CODE,
+      "",
+      buildV2RecoveryHint(""),
+    );
+  }
+
   if (data.version !== 1 && data.version !== 3) {
     log.warn("Unknown storage version, ignoring", {
       version: rawVersion,
@@ -888,6 +911,32 @@ async function loadAccountsInternal(
     // downgraded to an empty load, which would clobber the user's future-format
     // credentials on the next save.
     if (error instanceof StorageError && error.code === "UNSUPPORTED_SCHEMA_VERSION") {
+      throw error;
+    }
+    // Unknown-V2 detection must NOT be silently dropped: the catch below
+    // swallows generic errors by design (keeps an unreadable file from
+    // crashing the whole plugin), but V2 is a specific, recoverable case
+    // where the user needs to know their credentials were quarantined.
+    // Re-throw so the UI/CLI layer can render the recovery hint.
+    if (error instanceof StorageError && error.code === UNKNOWN_V2_FORMAT_CODE) {
+      // Annotate with the concrete storage path that triggered the reject
+      // so the recovery hint points at the real file.
+      const concretePath = (() => {
+        try {
+          return getStoragePath();
+        } catch {
+          return "";
+        }
+      })();
+      if (concretePath) {
+        throw new StorageError(
+          error.message,
+          UNKNOWN_V2_FORMAT_CODE,
+          concretePath,
+          buildV2RecoveryHint(concretePath),
+          error,
+        );
+      }
       throw error;
     }
     const code = (error as NodeJS.ErrnoException).code;

--- a/lib/storage/migrations.ts
+++ b/lib/storage/migrations.ts
@@ -8,6 +8,64 @@ import type { AccountIdSource } from "../types.js";
 
 export type CooldownReason = "auth-failure" | "network-error";
 
+/**
+ * StorageError code emitted when a `version: 2` account file is loaded.
+ *
+ * V2 is an intermediate account schema produced by legacy 4.x plugin builds
+ * that never shipped with a documented shape nor a forward-migrator to V3.
+ * The safe behaviour is to refuse to load V2 explicitly so the user's
+ * credentials are not silently discarded; callers surface this code to the
+ * user alongside a recovery hint.
+ */
+export const UNKNOWN_V2_FORMAT_CODE = "UNKNOWN_V2_FORMAT";
+
+/**
+ * Minimal detection shape for V2 account storage.
+ *
+ * The full V2 schema was never documented and no V2 migrator shipped, so this
+ * type is intentionally coarse: it only captures the fields needed to detect
+ * that a file claims `version: 2` and contains something account-shaped. Do
+ * not extend this shape without evidence of the real V2 layout - inventing
+ * fields risks producing a silently-wrong migration.
+ */
+export interface AccountStorageV2Detected {
+	version: 2;
+	accounts?: unknown[];
+}
+
+/**
+ * Diagnostic message shown when the loader refuses a V2 storage file.
+ * Pulled into a helper so storage.ts, import paths, and tests produce
+ * identical copy without drifting.
+ */
+export function buildV2RejectionMessage(): string {
+	return (
+		"Unsupported account storage schema version 2; this plugin only ships " +
+		"migrations for v1 and v3. V2 files were produced by an intermediate " +
+		"4.x build that never documented its shape, so migrating blindly would " +
+		"risk silent account corruption."
+	);
+}
+
+/**
+ * Recovery hint shown alongside the V2 rejection message.
+ * @param path - Absolute path of the offending storage file, or a placeholder
+ *   when the caller cannot determine the source (e.g. in-memory normalization).
+ */
+export function buildV2RecoveryHint(path: string): string {
+	const resolvedPath = path || "<unknown>";
+	return (
+		`The storage file at ${resolvedPath} uses account schema v2, which ` +
+		"this plugin cannot migrate automatically. To recover: " +
+		"(1) back up the file outside the .opencode directory, " +
+		"(2) remove or rename the original so the plugin can start fresh, " +
+		"(3) run `opencode auth login` to create a v3 account pool, then " +
+		"(4) if you need the old credentials, open each account manually or " +
+		"re-run login per account. If you believe this file was produced by " +
+		"the current plugin, please open an issue so V2 can be documented."
+	);
+}
+
 export interface RateLimitStateV3 {
 	[key: string]: number | undefined;
 }

--- a/test/fixtures/v2-storage.json
+++ b/test/fixtures/v2-storage.json
@@ -1,0 +1,12 @@
+{
+  "version": 2,
+  "accounts": [
+    {
+      "email": "v2-user@example.com",
+      "refreshToken": "v2-refresh-token",
+      "accessToken": "v2-access-token",
+      "expiresAt": 0
+    }
+  ],
+  "activeIndex": 0
+}

--- a/test/storage-async.test.ts
+++ b/test/storage-async.test.ts
@@ -38,11 +38,13 @@ describe("Storage Module - Async Operations", () => {
       expect(normalizeAccountStorage([])).toBeNull();
     });
 
-    it("returns null for legacy/unrecognized versions below the forward-compat bound", () => {
-      // V2 is a known unsupported legacy format whose migration lives elsewhere,
-      // and non-numeric markers should still be tolerated as corrupt input.
-      expect(normalizeAccountStorage({ version: 2, accounts: [], activeIndex: 0 })).toBeNull();
+    it("returns null for non-numeric version markers (tolerant of corrupt input)", () => {
+      // Non-numeric version bypasses the forward-compat guard (numeric only)
+      // and the V2 detector (literal 2), falling through to the legacy
+      // unknown-version bucket. V2 has its own dedicated contract in
+      // test/storage-v2-migration.test.ts — it now throws, not returns null.
       expect(normalizeAccountStorage({ version: "99", accounts: [], activeIndex: 0 })).toBeNull();
+      expect(normalizeAccountStorage({ version: "weird", accounts: [], activeIndex: 0 })).toBeNull();
     });
 
     it("throws UNSUPPORTED_SCHEMA_VERSION for future numeric versions", () => {

--- a/test/storage-v2-migration.test.ts
+++ b/test/storage-v2-migration.test.ts
@@ -1,0 +1,162 @@
+import { promises as fs } from "node:fs";
+import { existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+	StorageError,
+	loadAccounts,
+	normalizeAccountStorage,
+	setStoragePathDirect,
+} from "../lib/storage.js";
+import {
+	UNKNOWN_V2_FORMAT_CODE,
+	buildV2RecoveryHint,
+	buildV2RejectionMessage,
+} from "../lib/storage/migrations.js";
+
+/**
+ * Audit top-20 #8: files with `version: 2` were silently ignored by
+ * `normalizeAccountStorage`, which returned null and caused the loader to
+ * behave as if the user had no accounts at all. The fix is an explicit
+ * rejection with a `UNKNOWN_V2_FORMAT` StorageError so the UI can surface
+ * a recovery path instead of quietly discarding the user's credentials.
+ */
+
+const FIXTURE_PATH = fileURLToPath(
+	new URL("./fixtures/v2-storage.json", import.meta.url),
+);
+
+let tempDir: string;
+let tempFile: string;
+
+beforeEach(async () => {
+	tempDir = await fs.mkdtemp(join(tmpdir(), "v2-migration-"));
+	tempFile = join(tempDir, "accounts.json");
+});
+
+afterEach(async () => {
+	if (existsSync(tempDir)) {
+		await fs.rm(tempDir, { recursive: true, force: true });
+	}
+});
+
+describe("V2 storage detection (normalizeAccountStorage)", () => {
+	it("throws a typed StorageError with UNKNOWN_V2_FORMAT code on a version:2 payload", () => {
+		const v2Data = {
+			version: 2,
+			accounts: [{ email: "user@example.com" }],
+		};
+
+		expect(() => normalizeAccountStorage(v2Data)).toThrow(StorageError);
+
+		try {
+			normalizeAccountStorage(v2Data);
+		} catch (error) {
+			expect(error).toBeInstanceOf(StorageError);
+			const storageError = error as StorageError;
+			expect(storageError.code).toBe(UNKNOWN_V2_FORMAT_CODE);
+			expect(storageError.message).toBe(buildV2RejectionMessage());
+		}
+	});
+
+	it("throws for the canonical v2 fixture file", async () => {
+		const raw = await fs.readFile(FIXTURE_PATH, "utf-8");
+		const parsed = JSON.parse(raw) as unknown;
+		expect(() => normalizeAccountStorage(parsed)).toThrow(StorageError);
+	});
+
+	it("continues to return null for unknown versions other than 2 (v42, string, missing)", () => {
+		expect(
+			normalizeAccountStorage({ version: 42, accounts: [] }),
+		).toBeNull();
+		expect(
+			normalizeAccountStorage({ version: "two", accounts: [] }),
+		).toBeNull();
+		expect(normalizeAccountStorage({ accounts: [] })).toBeNull();
+	});
+
+	it("V1 still migrates cleanly (no V2 regression in adjacent version path)", () => {
+		const v1 = {
+			version: 1,
+			accounts: [
+				{
+					refreshToken: "rt",
+					accessToken: "at",
+					expiresAt: 0,
+				},
+			],
+			activeIndex: 0,
+		};
+		const result = normalizeAccountStorage(v1);
+		expect(result).not.toBeNull();
+		expect(result?.version).toBe(3);
+	});
+
+	it("V3 passes through unchanged", () => {
+		const v3 = {
+			version: 3,
+			accounts: [
+				{
+					refreshToken: "rt",
+					accessToken: "at",
+					expiresAt: 0,
+					rateLimitResetTimes: {},
+				},
+			],
+			activeIndex: 0,
+			activeIndexByFamily: {},
+		};
+		const result = normalizeAccountStorage(v3);
+		expect(result).not.toBeNull();
+		expect(result?.version).toBe(3);
+	});
+});
+
+describe("V2 storage detection (loadAccounts end-to-end)", () => {
+	it("loadAccounts throws a StorageError with the recovery hint populated when reading a v2 file", async () => {
+		setStoragePathDirect(tempFile);
+		await fs.writeFile(
+			tempFile,
+			JSON.stringify({
+				version: 2,
+				accounts: [{ email: "user@example.com" }],
+			}),
+			{ encoding: "utf-8", mode: 0o600 },
+		);
+
+		await expect(loadAccounts()).rejects.toBeInstanceOf(StorageError);
+
+		try {
+			await loadAccounts();
+		} catch (error) {
+			const storageError = error as StorageError;
+			expect(storageError.code).toBe(UNKNOWN_V2_FORMAT_CODE);
+			// Recovery hint should point at the concrete storage path, not "<unknown>".
+			expect(storageError.hint).toBe(buildV2RecoveryHint(tempFile));
+			expect(storageError.hint).toContain(tempFile);
+		}
+
+		setStoragePathDirect(null);
+	});
+});
+
+describe("V2 rejection message + recovery hint copy", () => {
+	it("rejection message names version 2 explicitly", () => {
+		expect(buildV2RejectionMessage()).toMatch(/version 2/);
+	});
+
+	it("recovery hint instructs the user how to recover", () => {
+		const hint = buildV2RecoveryHint("/tmp/accounts.json");
+		expect(hint).toContain("/tmp/accounts.json");
+		expect(hint).toMatch(/back up|backup/i);
+		expect(hint).toMatch(/opencode auth login/i);
+	});
+
+	it("recovery hint handles an empty path without producing empty-quotes", () => {
+		const hint = buildV2RecoveryHint("");
+		expect(hint).toContain("<unknown>");
+		expect(hint).not.toMatch(/\bat\s+,/);
+	});
+});

--- a/test/storage-v2-migration.test.ts
+++ b/test/storage-v2-migration.test.ts
@@ -67,9 +67,47 @@ describe("V2 storage detection (normalizeAccountStorage)", () => {
 		expect(() => normalizeAccountStorage(parsed)).toThrow(StorageError);
 	});
 
-	it("continues to return null for unknown versions other than 2 (v42, string, missing)", () => {
+	it("detects V2 and throws (not silently null) when accounts is null", () => {
+		// Regression: previously `.optional()` on the V2-detection schema
+		// rejected `accounts: null`, so a V2 file with a null accounts field
+		// fell through to the warn+return-null path and silently discarded
+		// credentials. `.nullish()` restores the V2 detection so the loader
+		// surfaces a typed UNKNOWN_V2_FORMAT error instead.
+		const malformedV2 = { version: 2, accounts: null };
+
+		expect(() => normalizeAccountStorage(malformedV2)).toThrow(StorageError);
+
+		try {
+			normalizeAccountStorage(malformedV2);
+		} catch (error) {
+			expect(error).toBeInstanceOf(StorageError);
+			const storageError = error as StorageError;
+			expect(storageError.code).toBe(UNKNOWN_V2_FORMAT_CODE);
+			expect(storageError.message).toBe(buildV2RejectionMessage());
+		}
+	});
+
+	it("detects V2 and throws when accounts is missing entirely", () => {
+		// Parallel coverage: `.nullish()` must also allow `undefined` (i.e.
+		// accounts field absent), which was the only case that worked before.
+		const malformedV2: Record<string, unknown> = { version: 2 };
+
+		expect(() => normalizeAccountStorage(malformedV2)).toThrow(StorageError);
+
+		try {
+			normalizeAccountStorage(malformedV2);
+		} catch (error) {
+			expect(error).toBeInstanceOf(StorageError);
+			expect((error as StorageError).code).toBe(UNKNOWN_V2_FORMAT_CODE);
+		}
+	});
+
+	it("continues to return null for unknown versions other than 2 (sub-bound numeric, string, missing)", () => {
+		// version 42 would now trip the forward-compat guard (>3) and throw, so
+		// we exercise the generic unknown-version bucket with version 0 — a
+		// finite number that is neither >3, literal 2, nor 1/3.
 		expect(
-			normalizeAccountStorage({ version: 42, accounts: [] }),
+			normalizeAccountStorage({ version: 0, accounts: [] }),
 		).toBeNull();
 		expect(
 			normalizeAccountStorage({ version: "two", accounts: [] }),

--- a/test/storage.test.ts
+++ b/test/storage.test.ts
@@ -1082,8 +1082,12 @@ describe("storage", () => {
       expect(normalizeAccountStorage([])).toBeNull();
     });
 
-    it("returns null for invalid version", () => {
-      const result = normalizeAccountStorage({ version: 2, accounts: [] });
+    it("returns null for invalid version (non-V2, non-V1, non-V3)", () => {
+      // V2 used to fall into this bucket and silently returned null; it is
+      // now explicitly rejected (see test/storage-v2-migration.test.ts) so
+      // this case must use a different unknown version to exercise the
+      // generic unknown-version path.
+      const result = normalizeAccountStorage({ version: 42, accounts: [] });
       expect(result).toBeNull();
     });
 

--- a/test/storage.test.ts
+++ b/test/storage.test.ts
@@ -1084,10 +1084,11 @@ describe("storage", () => {
 
     it("returns null for invalid version (non-V2, non-V1, non-V3)", () => {
       // V2 used to fall into this bucket and silently returned null; it is
-      // now explicitly rejected (see test/storage-v2-migration.test.ts) so
-      // this case must use a different unknown version to exercise the
-      // generic unknown-version path.
-      const result = normalizeAccountStorage({ version: 42, accounts: [] });
+      // now explicitly rejected (see test/storage-v2-migration.test.ts) and
+      // any finite number > 3 trips the forward-compat guard and throws, so
+      // this case uses version 0 which is numeric, not >3, not literal 2,
+      // and neither 1 nor 3 — exercising the generic unknown-version path.
+      const result = normalizeAccountStorage({ version: 0, accounts: [] });
       expect(result).toBeNull();
     });
 
@@ -2431,12 +2432,18 @@ describe("storage", () => {
       ).toBeNull();
     });
 
-    it("normalizeAccountStorage does not throw for legacy version 2 (still returns null)", () => {
-      // V2 is a known unsupported legacy format; its handling is a separate
-      // migration concern and must not regress into the forward-compat path.
-      expect(
-        normalizeAccountStorage({ version: 2, accounts: [] }, "/tmp/v2.json"),
-      ).toBeNull();
+    it("forward-compat guard does not claim legacy version 2 (V2 path handles it)", () => {
+      // V2 has its own dedicated rejection (see test/storage-v2-migration.test.ts)
+      // and must NOT be absorbed into the forward-compat UNSUPPORTED_SCHEMA_VERSION
+      // code path; that would leak the wrong error code to the UI.
+      let caught: unknown = null;
+      try {
+        normalizeAccountStorage({ version: 2, accounts: [] }, "/tmp/v2.json");
+      } catch (e) {
+        caught = e;
+      }
+      expect(caught).toBeInstanceOf(StorageError);
+      expect((caught as StorageError).code).not.toBe("UNSUPPORTED_SCHEMA_VERSION");
     });
 
     it("loadAccounts throws StorageError with UNSUPPORTED_SCHEMA_VERSION on schemaVersion > 3", async () => {


### PR DESCRIPTION
## Summary

Handles `version: 2` account storage files that were previously silently dropped. Audit top-20 #8.

## Background

V2 was an intermediate account-storage schema shipped by legacy 4.x builds that never documented the real shape and never shipped a forward-migrator to V3. Before this PR, `normalizeAccountStorage` hit its generic unknown-version branch, logged `log.warn("Unknown storage version, ignoring")`, and returned `null` — meaning users with a V2 file silently had their credentials discarded with no signal to re-run `opencode auth login`.

## Changes

- **`lib/storage/migrations.ts`** — adds:
  - `UNKNOWN_V2_FORMAT_CODE` — stable error code for UI/CLI layers.
  - `buildV2RejectionMessage()` — user-facing explanation of why V2 is rejected.
  - `buildV2RecoveryHint(path)` — concrete 4-step recovery instructions.
  - `AccountStorageV2Detected` interface — minimal detection shape; intentionally coarse because the real V2 layout was never documented.
- **`lib/schemas.ts`** — adds `AccountStorageV2DetectionSchema` (validates `version: 2` + optional `accounts` array).
- **`lib/storage.ts:normalizeAccountStorage`** — detects V2 via schema *before* the generic unknown-version bucket and throws a typed `StorageError(UNKNOWN_V2_FORMAT)` instead of silently returning `null`.
- **`lib/storage.ts:loadAccountsInternal`** — re-throws `UNKNOWN_V2_FORMAT` with the concrete storage path annotated so the recovery hint points at the user's actual file. Other storage errors still fall through the existing swallow-and-warn path (that behaviour is intentional and unchanged).

## Tests

- **`test/fixtures/v2-storage.json`** — representative V2 file.
- **`test/storage-v2-migration.test.ts`** (9 tests):
  - V2 throws a typed `StorageError` with `UNKNOWN_V2_FORMAT` code.
  - V2 fixture file throws end-to-end through `loadAccounts`.
  - V2 `StorageError.hint` is populated with the concrete path.
  - Other unknown versions (v42, `"weird"`, missing) still return null — V2 is the ONLY unknown-version that throws.
  - V1 and V3 paths are regression-tested against the V2 branch.
  - Rejection message + recovery hint copy pinned.
- **`test/storage.test.ts`, `test/storage-async.test.ts`** — adjusted existing "returns null for invalid version" tests to use `version: 42` (the generic unknown bucket) because V2 is no longer in that bucket.

## Audit refs

- `docs/audits/14-top20.md` #8
- `docs/audits/13-phased-roadmap.md` §1.7

## Verification

`npm run typecheck`, `npm run lint`, `npm test` (2079 passed on this branch, +9 new V2 tests over main's 2070), `npm run build` — all pass on `fix/phase1-v2-migrator`.

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---


<h3>Greptile Summary</h3>

fixes the silent V2 credential discard on the primary `loadAccountsInternal` path by detecting `version: 2` before the generic unknown-version bucket and throwing a typed `StorageError(UNKNOWN_V2_FORMAT)` with a concrete recovery hint. the `.nullish()` fix (second commit) correctly closes the `accounts: null` gap flagged in the previous review.

- **P1 gap — two catch blocks still swallow V2**: `migrateStorageFileIfNeeded` (line 379) and `loadGlobalAccountsFallback` (line 862) only re-throw `UNSUPPORTED_SCHEMA_VERSION`; a V2 file in a legacy migration source or global fallback still silently returns `null`, reproducing the original bug in those sub-paths. both need a parallel `UNKNOWN_V2_FORMAT_CODE` guard.

<h3>Confidence Score: 4/5</h3>

primary load path is safe; one concrete silent-discard gap remains in two secondary catch blocks before merge.

the core fix is correct and well-tested for the happy path, but `migrateStorageFileIfNeeded` and `loadGlobalAccountsFallback` still swallow the V2 error, meaning users whose V2 file is only ever seen through a legacy migration or project-global-fallback codepath will still lose credentials silently — the same class of defect this PR targets.

lib/storage.ts — specifically the catch blocks in `migrateStorageFileIfNeeded` (line 379) and `loadGlobalAccountsFallback` (line 862).

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| lib/storage.ts | V2 detection wired correctly for the primary load path, but both `migrateStorageFileIfNeeded` and `loadGlobalAccountsFallback` catch blocks re-throw only `UNSUPPORTED_SCHEMA_VERSION`, silently swallowing V2 errors on legacy-migration and project-global-fallback paths. |
| lib/schemas.ts | Adds `AccountStorageV2DetectionSchema` with `.nullish()` on `accounts`, correctly catching `null`, `undefined`, and absent fields — the regression from the prior `.optional()` approach is addressed. |
| lib/storage/migrations.ts | Adds error code, rejection message, recovery hint, and V2 detection interface; all look correct, but `AccountStorageV2Detected` interface is dead code (never imported). |
| test/storage-v2-migration.test.ts | 9 well-targeted tests cover primary path, null accounts, missing accounts, copy pinning, and regression for V1/V3; no coverage for V2 in global-fallback or legacy-migration sub-paths. |
| test/fixtures/v2-storage.json | Representative V2 fixture with placeholder tokens; correct format for end-to-end test. |
| test/storage.test.ts | Adjusted unknown-version tests to use `version: 0` to avoid tripping the forward-compat guard; change is correct. |
| test/storage-async.test.ts | Updated unknown-version expectation to reflect V2 now throws rather than returning null; adjustment is accurate. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[loadAccountsInternal] --> B[fs.readFile primary path]
    B --> C[normalizeAccountStorage]
    C --> D{version === 2?}
    D -->|yes| E[throw StorageError UNKNOWN_V2_FORMAT]
    D -->|no| F[return V3 or null]
    E --> G[catch in loadAccountsInternal]
    G --> H{code === UNKNOWN_V2_FORMAT?}
    H -->|yes checkmark| I[re-throw with concrete path + recovery hint]
    H -->|no| J[other error handling]
    A --> K{ENOENT?}
    K -->|yes| L[migrateStorageFileIfNeeded]
    L --> M[normalizeAccountStorage legacy file]
    M --> N{V2 throws}
    N --> O[catch in migrateStorageFile]
    O --> P{code === UNSUPPORTED_SCHEMA_VERSION?}
    P -->|no X| Q[log.warn + return null V2 silently swallowed]
    K -->|yes| R[loadGlobalAccountsFallback]
    R --> S[normalizeAccountStorage global file]
    S --> T{V2 throws}
    T --> U[catch in loadGlobalFallback]
    U --> V{code === UNSUPPORTED_SCHEMA_VERSION?}
    V -->|no X| W[log.warn + return null V2 silently swallowed]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `lib/storage.ts`, line 379-380 ([link](https://github.com/ndycode/oc-codex-multi-auth/blob/95641a940b293fd37914e916da5d4ba030db7caf/lib/storage.ts#L379-L380)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **V2 error still silently swallowed in two catch blocks**

   `migrateStorageFileIfNeeded` only re-throws `UNSUPPORTED_SCHEMA_VERSION`; a legacy file with `version: 2` throws `UNKNOWN_V2_FORMAT_CODE` from `normalizeAccountStorage`, which is caught here, logged as a generic migration warning, and returns `null` — same silent credential discard the PR fixes for the primary path. The same gap exists in `loadGlobalAccountsFallback` at line 862, where a global fallback file that is V2 is also swallowed.

   Add the parallel guard in both places:

   

   And apply the same two-line addition at line 862 inside `loadGlobalAccountsFallback`. No vitest coverage exists for either path.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: lib/storage.ts
   Line: 379-380

   Comment:
   **V2 error still silently swallowed in two catch blocks**

   `migrateStorageFileIfNeeded` only re-throws `UNSUPPORTED_SCHEMA_VERSION`; a legacy file with `version: 2` throws `UNKNOWN_V2_FORMAT_CODE` from `normalizeAccountStorage`, which is caught here, logged as a generic migration warning, and returns `null` — same silent credential discard the PR fixes for the primary path. The same gap exists in `loadGlobalAccountsFallback` at line 862, where a global fallback file that is V2 is also swallowed.

   Add the parallel guard in both places:

   

   And apply the same two-line addition at line 862 inside `loadGlobalAccountsFallback`. No vitest coverage exists for either path.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Foc-codex-multi-auth%22%20on%20the%20existing%20branch%20%22fix%2Fphase1-v2-migrator%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fphase1-v2-migrator%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20lib%2Fstorage.ts%0ALine%3A%20379-380%0A%0AComment%3A%0A**V2%20error%20still%20silently%20swallowed%20in%20two%20catch%20blocks**%0A%0A%60migrateStorageFileIfNeeded%60%20only%20re-throws%20%60UNSUPPORTED_SCHEMA_VERSION%60%3B%20a%20legacy%20file%20with%20%60version%3A%202%60%20throws%20%60UNKNOWN_V2_FORMAT_CODE%60%20from%20%60normalizeAccountStorage%60%2C%20which%20is%20caught%20here%2C%20logged%20as%20a%20generic%20migration%20warning%2C%20and%20returns%20%60null%60%20%E2%80%94%20same%20silent%20credential%20discard%20the%20PR%20fixes%20for%20the%20primary%20path.%20The%20same%20gap%20exists%20in%20%60loadGlobalAccountsFallback%60%20at%20line%20862%2C%20where%20a%20global%20fallback%20file%20that%20is%20V2%20is%20also%20swallowed.%0A%0AAdd%20the%20parallel%20guard%20in%20both%20places%3A%0A%0A%60%60%60suggestion%0A%20%20%20%20if%20%28error%20instanceof%20StorageError%20%26%26%20error.code%20%3D%3D%3D%20%22UNSUPPORTED_SCHEMA_VERSION%22%29%20%7B%0A%20%20%20%20%20%20throw%20error%3B%0A%20%20%20%20%7D%0A%20%20%20%20if%20%28error%20instanceof%20StorageError%20%26%26%20error.code%20%3D%3D%3D%20UNKNOWN_V2_FORMAT_CODE%29%20%7B%0A%20%20%20%20%20%20throw%20error%3B%0A%20%20%20%20%7D%0A%60%60%60%0A%0AAnd%20apply%20the%20same%20two-line%20addition%20at%20line%20862%20inside%20%60loadGlobalAccountsFallback%60.%20No%20vitest%20coverage%20exists%20for%20either%20path.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Foc-codex-multi-auth%22%20on%20the%20existing%20branch%20%22fix%2Fphase1-v2-migrator%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fphase1-v2-migrator%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Alib%2Fstorage.ts%3A379-380%0A**V2%20error%20still%20silently%20swallowed%20in%20two%20catch%20blocks**%0A%0A%60migrateStorageFileIfNeeded%60%20only%20re-throws%20%60UNSUPPORTED_SCHEMA_VERSION%60%3B%20a%20legacy%20file%20with%20%60version%3A%202%60%20throws%20%60UNKNOWN_V2_FORMAT_CODE%60%20from%20%60normalizeAccountStorage%60%2C%20which%20is%20caught%20here%2C%20logged%20as%20a%20generic%20migration%20warning%2C%20and%20returns%20%60null%60%20%E2%80%94%20same%20silent%20credential%20discard%20the%20PR%20fixes%20for%20the%20primary%20path.%20The%20same%20gap%20exists%20in%20%60loadGlobalAccountsFallback%60%20at%20line%20862%2C%20where%20a%20global%20fallback%20file%20that%20is%20V2%20is%20also%20swallowed.%0A%0AAdd%20the%20parallel%20guard%20in%20both%20places%3A%0A%0A%60%60%60suggestion%0A%20%20%20%20if%20%28error%20instanceof%20StorageError%20%26%26%20error.code%20%3D%3D%3D%20%22UNSUPPORTED_SCHEMA_VERSION%22%29%20%7B%0A%20%20%20%20%20%20throw%20error%3B%0A%20%20%20%20%7D%0A%20%20%20%20if%20%28error%20instanceof%20StorageError%20%26%26%20error.code%20%3D%3D%3D%20UNKNOWN_V2_FORMAT_CODE%29%20%7B%0A%20%20%20%20%20%20throw%20error%3B%0A%20%20%20%20%7D%0A%60%60%60%0A%0AAnd%20apply%20the%20same%20two-line%20addition%20at%20line%20862%20inside%20%60loadGlobalAccountsFallback%60.%20No%20vitest%20coverage%20exists%20for%20either%20path.%0A%0A%23%23%23%20Issue%202%20of%202%0Alib%2Fstorage%2Fmigrations.ts%3A31-34%0A**%60AccountStorageV2Detected%60%20is%20exported%20but%20never%20imported**%0A%0Athe%20interface%20is%20defined%20and%20exported%20here%20but%20no%20file%20imports%20it%20%E2%80%94%20detection%20goes%20through%20%60AccountStorageV2DetectionSchema%60%20%28schemas.ts%29%20exclusively.%20either%20remove%20the%20interface%20or%20re-export%20it%20via%20%60schemas.ts%60%20if%20it's%20intended%20as%20a%20public%20type.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: lib/storage.ts
Line: 379-380

Comment:
**V2 error still silently swallowed in two catch blocks**

`migrateStorageFileIfNeeded` only re-throws `UNSUPPORTED_SCHEMA_VERSION`; a legacy file with `version: 2` throws `UNKNOWN_V2_FORMAT_CODE` from `normalizeAccountStorage`, which is caught here, logged as a generic migration warning, and returns `null` — same silent credential discard the PR fixes for the primary path. The same gap exists in `loadGlobalAccountsFallback` at line 862, where a global fallback file that is V2 is also swallowed.

Add the parallel guard in both places:

```suggestion
    if (error instanceof StorageError && error.code === "UNSUPPORTED_SCHEMA_VERSION") {
      throw error;
    }
    if (error instanceof StorageError && error.code === UNKNOWN_V2_FORMAT_CODE) {
      throw error;
    }
```

And apply the same two-line addition at line 862 inside `loadGlobalAccountsFallback`. No vitest coverage exists for either path.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: lib/storage/migrations.ts
Line: 31-34

Comment:
**`AccountStorageV2Detected` is exported but never imported**

the interface is defined and exported here but no file imports it — detection goes through `AccountStorageV2DetectionSchema` (schemas.ts) exclusively. either remove the interface or re-export it via `schemas.ts` if it's intended as a public type.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(storage): detect V2 when accounts is..."](https://github.com/ndycode/oc-codex-multi-auth/commit/95641a940b293fd37914e916da5d4ba030db7caf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28725564)</sub>

<!-- /greptile_comment -->