### PR TITLE
fix(installer): deep-merge provider.openai + --dry-run preview

### DIFF
--- a/scripts/install-oc-codex-multi-auth-core.js
+++ b/scripts/install-oc-codex-multi-auth-core.js
@@ -109,6 +109,76 @@ function formatJson(obj) {
 	return `${JSON.stringify(obj, null, 2)}\n`;
 }
 
+// Top-level keys inside `provider.openai` that the installer owns absolutely.
+// These are always sourced from the template (overwritten or removed) so the
+// plugin's required runtime shape is authoritative. Any OTHER key the user has
+// placed under `provider.openai` is preserved as-is. `models` is handled
+// separately because it's a map where user-added model ids must survive while
+// template-shipped ids win on collision.
+const MANAGED_OPENAI_KEYS = new Set(["baseURL", "apiKey", "options"]);
+
+function isPlainObject(value) {
+	return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+// Deep-merge `provider.openai` preserving unknown user keys while letting the
+// installer overwrite the managed shape it ships. This replaces the earlier
+// wholesale overwrite which clobbered custom user-added keys (see audit top-20
+// #6).
+function mergeOpenaiProvider(existingOpenai, templateOpenai) {
+	const existingSafe = isPlainObject(existingOpenai) ? existingOpenai : {};
+	const templateSafe = isPlainObject(templateOpenai) ? templateOpenai : {};
+
+	const result = {};
+
+	// 1. Start with the user's non-managed keys (unknown-to-installer settings).
+	for (const [key, value] of Object.entries(existingSafe)) {
+		if (MANAGED_OPENAI_KEYS.has(key)) continue;
+		if (key === "models") continue; // handled explicitly below
+		result[key] = value;
+	}
+
+	// 2. Apply template-managed keys. Installer is source of truth for these.
+	for (const [key, value] of Object.entries(templateSafe)) {
+		if (key === "models") continue; // handled explicitly below
+		result[key] = value;
+	}
+
+	// 3. Merge `models` by id: template wins on collision, user-added ids survive.
+	const existingModels = isPlainObject(existingSafe.models) ? existingSafe.models : {};
+	const templateModels = isPlainObject(templateSafe.models) ? templateSafe.models : {};
+	const mergedModels = { ...existingModels, ...templateModels };
+	if (Object.keys(mergedModels).length > 0) {
+		result.models = mergedModels;
+	}
+
+	return result;
+}
+
+// Naive line-by-line diff for displaying config changes in dry-run. Good enough
+// for eyeballing; not intended to be parsed or round-tripped.
+function formatConfigDiff(existingConfig, nextConfig) {
+	const oldText = existingConfig === undefined ? "" : formatJson(existingConfig);
+	const newText = formatJson(nextConfig);
+	if (oldText === newText) {
+		return "(no changes)";
+	}
+	const lines = [];
+	lines.push("--- existing");
+	lines.push("+++ proposed");
+	if (existingConfig === undefined) {
+		lines.push("- (no existing config)");
+	} else {
+		for (const line of oldText.split("\n")) {
+			lines.push(`- ${line}`);
+		}
+	}
+	for (const line of newText.split("\n")) {
+		lines.push(`+ ${line}`);
+	}
+	return lines.join("\n");
+}
+
 function mergeFullTemplate(modernTemplate, legacyTemplate) {
 	const modernModels = modernTemplate.provider?.openai?.models ?? {};
 	const legacyModels = legacyTemplate.provider?.openai?.models ?? {};
@@ -318,32 +388,39 @@ export async function runInstaller(argv = process.argv.slice(2), options = {}) {
 	template.plugin = [PACKAGE_NAME];
 
 	let nextConfig = template;
+	let existingConfig;
 	if (existsSync(paths.configPath)) {
 		const backupPath = await backupConfig(paths.configPath, dryRun);
 		log(`${dryRun ? "[dry-run] Would create backup" : "Backup created"}: ${backupPath}`);
 
 		try {
 			const existing = await readJson(paths.configPath);
+			existingConfig = existing;
 			const merged = { ...existing };
 			merged.plugin = normalizePluginList(existing.plugin);
 			const provider = (existing.provider && typeof existing.provider === "object")
 				? { ...existing.provider }
 				: {};
-			provider.openai = template.provider.openai;
+			provider.openai = mergeOpenaiProvider(existing.provider?.openai, template.provider?.openai);
 			merged.provider = provider;
 			nextConfig = merged;
 		} catch (error) {
 			log(`Warning: Could not parse existing config (${formatErrorForLog(error)}). Replacing with template.`);
+			existingConfig = undefined;
 			nextConfig = template;
 		}
 	} else {
 		log("No existing config found. Creating new global config.");
 	}
 
+	let wrote = false;
 	if (dryRun) {
 		log(`[dry-run] Would write ${paths.configPath} using ${configMode} config`);
+		log(`[dry-run] Diff for ${paths.configPath}:`);
+		log(formatConfigDiff(existingConfig, nextConfig));
 	} else {
 		await writeFileAtomic(paths.configPath, formatJson(nextConfig));
+		wrote = true;
 		log(`Wrote ${paths.configPath} (${configMode} config)`);
 	}
 
@@ -366,6 +443,8 @@ export async function runInstaller(argv = process.argv.slice(2), options = {}) {
 		action: "install",
 		configMode,
 		configPath: paths.configPath,
+		dryRun: Boolean(dryRun),
+		wrote,
 	};
 }
 
@@ -373,7 +452,9 @@ export const __test = {
 	buildPaths,
 	backupConfig,
 	copyFileWithWindowsRetry,
+	formatConfigDiff,
 	mergeFullTemplate,
+	mergeOpenaiProvider,
 	parseCliArgs,
 	writeFileAtomic,
 	renameWithWindowsRetry,

--- a/test/install-oc-codex-multi-auth.test.ts
+++ b/test/install-oc-codex-multi-auth.test.ts
@@ -42,7 +42,7 @@ describe("install-oc-codex-multi-auth script", () => {
 		expect(errorSpy).not.toHaveBeenCalled();
 	});
 
-	it("writes the merged full catalog and normalizes plugin entries", async () => {
+	it("writes the merged full catalog, preserves user model entries, and normalizes plugin entries", async () => {
 		vi.resetModules();
 		tempHome = await createTempHome();
 		const { runInstaller } = await import("../scripts/install-oc-codex-multi-auth-core.js");
@@ -99,11 +99,15 @@ describe("install-oc-codex-multi-auth script", () => {
 		const legacyTemplate = JSON.parse(
 			await readFile(new URL("../config/opencode-legacy.json", import.meta.url), "utf-8"),
 		) as OpenAiTemplate;
+		// Template catalog ids plus the user's preserved `old` entry (deep-merge).
 		const expectedCount = Object.keys(modernTemplate.provider.openai.models).length
-			+ Object.keys(legacyTemplate.provider.openai.models).length;
+			+ Object.keys(legacyTemplate.provider.openai.models).length
+			+ 1;
 		expect(Object.keys(saved.provider.openai.models)).toHaveLength(expectedCount);
 		expect(saved.provider.openai.models["gpt-5.4"]).toBeDefined();
 		expect(saved.provider.openai.models["gpt-5.4-high"]).toBeDefined();
+		// User-added model survives deep-merge without overriding template ids.
+		expect(saved.provider.openai.models["old"]).toEqual({ name: "old" });
 		const configEntries = await readdir(configDir);
 		expect(configEntries).toEqual(
 			expect.arrayContaining([
@@ -111,6 +115,164 @@ describe("install-oc-codex-multi-auth script", () => {
 				expect.stringMatching(/^opencode\.json\.bak-/),
 			]),
 		);
+	});
+
+	it("deep-merges provider.openai preserving user customizations while overwriting managed keys", async () => {
+		vi.resetModules();
+		tempHome = await createTempHome();
+		const { runInstaller } = await import("../scripts/install-oc-codex-multi-auth-core.js");
+		const configDir = join(tempHome, ".config", "opencode");
+		const configPath = join(configDir, "opencode.json");
+
+		await mkdir(configDir, { recursive: true });
+		await writeFile(
+			configPath,
+			JSON.stringify({
+				provider: {
+					openai: {
+						baseURL: "https://legacy.example.com",
+						apiKey: "{env:OPENAI_API_KEY}",
+						myCustomKey: "preserved",
+						nested: { foo: "bar" },
+						options: { textVerbosity: "low" },
+						models: {
+							"gpt-5.4": { name: "user override" },
+							"my-fine-tune": { name: "custom user model" },
+						},
+					},
+				},
+			}, null, 2),
+			"utf-8",
+		);
+
+		await expect(
+			runInstaller(["--no-cache-clear"], {
+				env: {
+					...process.env,
+					HOME: tempHome,
+					USERPROFILE: tempHome,
+				},
+			}),
+		).resolves.toMatchObject({
+			action: "install",
+			exitCode: 0,
+		});
+
+		const saved = JSON.parse(await readFile(configPath, "utf-8")) as {
+			provider: {
+				openai: Record<string, unknown> & {
+					options?: Record<string, unknown>;
+					models?: Record<string, unknown>;
+				};
+			};
+		};
+
+		// Managed keys overwritten: baseURL / apiKey removed (template does not set
+		// them), options replaced with template value, models.gpt-5.4 reset to template.
+		expect(saved.provider.openai.baseURL).toBeUndefined();
+		expect(saved.provider.openai.apiKey).toBeUndefined();
+		expect(saved.provider.openai.options).not.toEqual({ textVerbosity: "low" });
+		expect(saved.provider.openai.models?.["gpt-5.4"]).not.toEqual({ name: "user override" });
+
+		// Non-managed keys preserved as-is.
+		expect(saved.provider.openai.myCustomKey).toBe("preserved");
+		expect(saved.provider.openai.nested).toEqual({ foo: "bar" });
+
+		// User-added model surviving deep-merge.
+		expect(saved.provider.openai.models?.["my-fine-tune"]).toEqual({ name: "custom user model" });
+	});
+
+	it("dry-run does not write and prints a diff to stdout", async () => {
+		vi.resetModules();
+		tempHome = await createTempHome();
+		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const { runInstaller } = await import("../scripts/install-oc-codex-multi-auth-core.js");
+		const configDir = join(tempHome, ".config", "opencode");
+		const configPath = join(configDir, "opencode.json");
+
+		await mkdir(configDir, { recursive: true });
+		await writeFile(
+			configPath,
+			JSON.stringify({
+				plugin: ["existing-plugin"],
+				provider: {
+					openai: {
+						models: { "pre-existing": { name: "pre-existing" } },
+					},
+				},
+			}, null, 2),
+			"utf-8",
+		);
+
+		const result = await runInstaller(["--dry-run", "--no-cache-clear"], {
+			env: {
+				...process.env,
+				HOME: tempHome,
+				USERPROFILE: tempHome,
+			},
+		});
+
+		expect(result).toMatchObject({ action: "install", dryRun: true, wrote: false, exitCode: 0 });
+
+		const stdout = logSpy.mock.calls.map((call) => String(call[0])).join("\n");
+		expect(stdout).toContain("[dry-run] Diff for");
+		expect(stdout).toContain("provider");
+		expect(stdout).toContain("--- existing");
+		expect(stdout).toContain("+++ proposed");
+
+		// Disk state must remain the literal prior contents (no overwrite, no backup write).
+		const onDisk = JSON.parse(await readFile(configPath, "utf-8")) as {
+			plugin: string[];
+			provider: { openai: { models: Record<string, unknown> } };
+		};
+		expect(onDisk.plugin).toEqual(["existing-plugin"]);
+		expect(onDisk.provider.openai.models["pre-existing"]).toBeDefined();
+		const entries = await readdir(configDir);
+		expect(entries).toEqual(["opencode.json"]);
+	});
+
+	it("formatConfigDiff unit: emits proposed markers when there is no existing config", async () => {
+		vi.resetModules();
+		const { __test } = await import("../scripts/install-oc-codex-multi-auth-core.js");
+		const diff = __test.formatConfigDiff(undefined, { provider: { openai: { models: {} } } });
+		expect(diff).toContain("--- existing");
+		expect(diff).toContain("+++ proposed");
+		expect(diff).toContain("- (no existing config)");
+		expect(diff).toContain("+ ");
+		expect(diff).toContain("provider");
+	});
+
+	it("mergeOpenaiProvider unit: strips unknown managed keys even when template omits them", async () => {
+		vi.resetModules();
+		const { __test } = await import("../scripts/install-oc-codex-multi-auth-core.js");
+		const merged = __test.mergeOpenaiProvider(
+			{
+				baseURL: "https://legacy.example.com",
+				apiKey: "user-secret",
+				options: { textVerbosity: "low" },
+				myCustomKey: "keep",
+				models: {
+					shared: { name: "user-shared" },
+					userOnly: { name: "user-only" },
+				},
+			},
+			{
+				options: { textVerbosity: "medium" },
+				models: {
+					shared: { name: "template-shared" },
+					templateOnly: { name: "template-only" },
+				},
+			},
+		);
+		expect(merged.baseURL).toBeUndefined();
+		expect(merged.apiKey).toBeUndefined();
+		expect(merged.options).toEqual({ textVerbosity: "medium" });
+		expect(merged.myCustomKey).toBe("keep");
+		expect(merged.models).toEqual({
+			shared: { name: "template-shared" },
+			userOnly: { name: "user-only" },
+			templateOnly: { name: "template-only" },
+		});
 	});
 
 	it("keeps cache files when --no-cache-clear is set but still unpins the cached package entry", async () => {


### PR DESCRIPTION
## Summary

Installer no longer clobbers user customizations inside `provider.openai`, and `--dry-run` now prints a proposed-vs-existing diff instead of silently skipping the write. Audit top-20 #6.

## Changes

### `scripts/install-oc-codex-multi-auth-core.js`

- **`mergeOpenaiProvider(existing, template)`** — deep-merge strategy:
  - Managed keys (`baseURL`, `apiKey`, `options`) are overwritten from the template (installer is source of truth).
  - Unknown keys the user put under `provider.openai` (e.g. `myCustomKey`, `nested`) are preserved as-is.
  - `models` is merged by id: template wins on collision, user-added ids survive.
- Replaces the previous line `provider.openai = template.provider.openai` which wholesale replaced the user's subtree.
- **`formatConfigDiff(existing, next)`** — naive line-by-line diff renderer used for dry-run preview (plain-text, not intended for machine consumption).
- **`runInstaller`** result now includes `dryRun: boolean` and `wrote: boolean` so tests and callers can assert no disk mutation happened on `--dry-run`.
- On `--dry-run`: logs `[dry-run] Diff for <path>:` followed by `formatConfigDiff(...)`; previously emitted only `[dry-run] Would write ...` with no visibility into what would change.

The CLI entry `scripts/install-oc-codex-multi-auth.js` already wires `process.argv` through `runInstaller()`, and `parseCliArgs` already handles `--dry-run`, so no CLI-entry change is required.

## Tests

`test/install-oc-codex-multi-auth.test.ts` adds 4 new cases:

- **Deep-merge preservation** — user's `myCustomKey` and `nested` survive; `baseURL` / `apiKey` (managed) get stripped; user's `my-fine-tune` model survives alongside template models; template's `gpt-5.4` overrides the user's `gpt-5.4` override.
- **Dry-run no-write + diff output** — `--dry-run` returns `{dryRun: true, wrote: false}`, logs contain `[dry-run] Diff for`, `--- existing`, `+++ proposed`, and on-disk file is bitwise unchanged (no backup written either).
- **`formatConfigDiff` unit** — emits `--- existing` / `+++ proposed` markers and `- (no existing config)` placeholder when there was no prior file.
- **`mergeOpenaiProvider` unit** — strips managed keys even when the template omits them; preserves user's `myCustomKey` and user-only model ids; template wins on shared model ids.

The existing "writes the merged full catalog" test was updated to assert the user's extra model survives deep-merge (expected count `+1`).

## Audit refs

- `docs/audits/14-top20.md` #6
- `docs/audits/13-phased-roadmap.md` §1.8

## Verification

`npm run typecheck`, `npm run lint`, `npm test` (2074 passed on this branch, +4 new installer tests over main's 2070), `npm run build` — all pass on `fix/phase1-installer`.

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

this pr replaces the wholesale `provider.openai = template.provider.openai` overwrite with a deep-merge that preserves user-added keys and model ids while keeping the installer authoritative over managed keys (`baseURL`, `apiKey`, `options`); it also upgrades `--dry-run` from a silent skip to a full before/after diff logged to stdout, and surfaces `dryRun`/`wrote` on the result object so callers and tests can assert no disk mutation occurred.

no concurrency hazard introduced — `writeFileAtomic` already handles the rename-on-windows retry loop, and the new code path runs entirely within the existing single-writer installer flow. no new token safety risks; stripping `apiKey` from user config when the template omits it is explicitly the designed behavior and is covered by the managed-keys semantics.

<h3>Confidence Score: 5/5</h3>

safe to merge — all remaining findings are cosmetic p2s with no correctness or data-integrity impact

no p0/p1 issues found; the deep-merge logic is sound and well-tested; the trailing-newline diff cosmetic and the comment-clarity note are minor; the "(no changes)" coverage gap is low risk since the branch is a simple string return

scripts/install-oc-codex-multi-auth-core.js — formatConfigDiff trailing-line cosmetic; step-2 comment clarity

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| scripts/install-oc-codex-multi-auth-core.js | adds mergeOpenaiProvider (deep-merge preserving user keys) and formatConfigDiff (dry-run preview); runInstaller now returns dryRun/wrote flags; minor: trailing newline in formatJson causes spurious diff lines and step-2 comment is misleading |
| test/install-oc-codex-multi-auth.test.ts | adds 4 new integration/unit tests covering deep-merge, dry-run no-write, formatConfigDiff, and mergeOpenaiProvider; updates existing catalog test with +1 count; missing vitest case for formatConfigDiff no-changes branch |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[runInstaller] --> B{config file exists?}
    B -- no --> C[nextConfig = template]
    B -- yes --> D[backupConfig dry-run safe]
    D --> E{parse existing JSON}
    E -- error --> F[warn, nextConfig = template\nexistingConfig = undefined]
    E -- ok --> G[existingConfig = existing]
    G --> H[mergeOpenaiProvider\nexisting.provider.openai\n+ template.provider.openai]
    H --> I[step 1: copy user non-managed\nnon-models keys]
    I --> J[step 2: overwrite with\nall template keys except models]
    J --> K[step 3: merge models by id\ntemplate wins on collision]
    K --> L[nextConfig = merged]
    C --> M{--dry-run?}
    F --> M
    L --> M
    M -- yes --> N[log diff via formatConfigDiff\nwrote = false]
    M -- no --> O[writeFileAtomic\nwrote = true]
    N --> P[return dryRun:true, wrote:false]
    O --> Q[return dryRun:false, wrote:true]
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Foc-codex-multi-auth%22%20on%20the%20existing%20branch%20%22fix%2Fphase1-installer%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fphase1-installer%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Ascripts%2Finstall-oc-codex-multi-auth-core.js%3A172-178%0A**spurious%20trailing%20diff%20lines%20from%20split%20on%20newline**%0A%0A%60formatJson%60%20always%20appends%20%60%5Cn%60%2C%20so%20%60oldText.split%28%22%5Cn%22%29%60%20yields%20an%20empty%20string%20as%20the%20last%20element%20%E2%80%94%20producing%20a%20trailing%20%60%22-%20%22%60%20%28dash%20%2B%20space%29%20at%20the%20bottom%20of%20both%20the%20existing%20and%20proposed%20sections%20every%20time.%20not%20machine-parseable%20by%20design%2C%20but%20confusing%20when%20eyeballing%20the%20output.%0A%0A%60%60%60suggestion%0A%09%09for%20%28const%20line%20of%20oldText.trimEnd%28%29.split%28%22%5Cn%22%29%29%20%7B%0A%09%09%09lines.push%28%60-%20%24%7Bline%7D%60%29%3B%0A%09%09%7D%0A%09%7D%0A%09for%20%28const%20line%20of%20newText.trimEnd%28%29.split%28%22%5Cn%22%29%29%20%7B%0A%09%09lines.push%28%60%2B%20%24%7Bline%7D%60%29%3B%0A%09%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Ascripts%2Finstall-oc-codex-multi-auth-core.js%3A141-145%0A**step%202%20comment%20says%20%22managed%20keys%22%20but%20applies%20all%20template%20keys**%0A%0Athe%20loop%20iterates%20every%20key%20in%20the%20template%2C%20not%20just%20%60MANAGED_OPENAI_KEYS%60.%20if%20the%20template%20ever%20ships%20a%20key%20like%20%60organizationId%60%20that%20a%20user%20had%20set%20to%20a%20custom%20value%2C%20it%20will%20be%20silently%20overwritten%20%E2%80%94%20a%20fact%20the%20comment%20obscures.%20suggest%20clarifying%20to%20avoid%20future%20confusion%3A%0A%0A%60%60%60suggestion%0A%09%2F%2F%202.%20Apply%20all%20template%20keys%20%28except%20models%29.%20For%20any%20key%20the%20template%20ships%2C%0A%09%2F%2F%20the%20installer%20is%20source%20of%20truth%20and%20wins%20over%20user%20values.%20MANAGED_OPENAI_KEYS%0A%09%2F%2F%20are%20the%20additional%20set%20that%20get%20*removed*%20from%20user%20config%20even%20when%20the%0A%09%2F%2F%20template%20stops%20shipping%20them%20%28see%20step%201%29.%0A%09for%20%28const%20%5Bkey%2C%20value%5D%20of%20Object.entries%28templateSafe%29%29%20%7B%0A%09%09if%20%28key%20%3D%3D%3D%20%22models%22%29%20continue%3B%20%2F%2F%20handled%20explicitly%20below%0A%09%09result%5Bkey%5D%20%3D%20value%3B%0A%09%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Atest%2Finstall-oc-codex-multi-auth.test.ts%3A233-240%0A**missing%20vitest%20coverage%20for%20the%20%60%22%28no%20changes%29%22%60%20branch**%0A%0Athe%20%60formatConfigDiff%60%20unit%20test%20only%20covers%20the%20%60existingConfig%20%3D%3D%3D%20undefined%60%20path.%20the%20early-return%20%60%22%28no%20changes%29%22%60%20branch%20%28when%20%60oldText%20%3D%3D%3D%20newText%60%29%20has%20no%20test.%20worth%20adding%20a%20case%20%E2%80%94%20e.g.%20call%20%60__test.formatConfigDiff%28obj%2C%20obj%29%60%20and%20assert%20the%20result%20equals%20%60%22%28no%20changes%29%22%60%20%E2%80%94%20especially%20since%20dry-run%20could%20hit%20this%20when%20the%20config%20is%20already%20up-to-date.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: scripts/install-oc-codex-multi-auth-core.js
Line: 172-178

Comment:
**spurious trailing diff lines from split on newline**

`formatJson` always appends `\n`, so `oldText.split("\n")` yields an empty string as the last element — producing a trailing `"- "` (dash + space) at the bottom of both the existing and proposed sections every time. not machine-parseable by design, but confusing when eyeballing the output.

```suggestion
		for (const line of oldText.trimEnd().split("\n")) {
			lines.push(`- ${line}`);
		}
	}
	for (const line of newText.trimEnd().split("\n")) {
		lines.push(`+ ${line}`);
	}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: scripts/install-oc-codex-multi-auth-core.js
Line: 141-145

Comment:
**step 2 comment says "managed keys" but applies all template keys**

the loop iterates every key in the template, not just `MANAGED_OPENAI_KEYS`. if the template ever ships a key like `organizationId` that a user had set to a custom value, it will be silently overwritten — a fact the comment obscures. suggest clarifying to avoid future confusion:

```suggestion
	// 2. Apply all template keys (except models). For any key the template ships,
	// the installer is source of truth and wins over user values. MANAGED_OPENAI_KEYS
	// are the additional set that get *removed* from user config even when the
	// template stops shipping them (see step 1).
	for (const [key, value] of Object.entries(templateSafe)) {
		if (key === "models") continue; // handled explicitly below
		result[key] = value;
	}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: test/install-oc-codex-multi-auth.test.ts
Line: 233-240

Comment:
**missing vitest coverage for the `"(no changes)"` branch**

the `formatConfigDiff` unit test only covers the `existingConfig === undefined` path. the early-return `"(no changes)"` branch (when `oldText === newText`) has no test. worth adding a case — e.g. call `__test.formatConfigDiff(obj, obj)` and assert the result equals `"(no changes)"` — especially since dry-run could hit this when the config is already up-to-date.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(installer): deep-merge provider.open..."](https://github.com/ndycode/oc-codex-multi-auth/commit/e84d7e0afa5f4e0ae892aaa952aee2b4f25d063c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28725671)</sub>

<!-- /greptile_comment -->