### PR TITLE
refactor(rc-1): hoist closure-free helpers to lib/runtime.ts and scaffold lib/tools/

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -167,7 +167,6 @@ import {
 	RetryBudgetTracker,
 	resolveRetryBudgetLimits,
 	type RetryBudgetClass,
-	type RetryBudgetLimits,
 } from "./lib/request/retry-budget.js";
 import { addJitter } from "./lib/rotation.js";
 import { buildTableHeader, buildTableRow, type TableOptions } from "./lib/table-formatter.js";
@@ -203,32 +202,18 @@ import {
 	detectErrorType,
 	getRecoveryToastContent,
 } from "./lib/recovery.js";
-
-function matchesWorkspaceIdentity(
-	account: {
-		organizationId?: string;
-		accountId?: string;
-		refreshToken: string;
-	},
-	identityKey: string,
-): boolean {
-	return getWorkspaceIdentityKey(account) === identityKey;
-}
-
-function upsertFlaggedAccountRecord(
-	accounts: FlaggedAccountMetadataV1[],
-	record: FlaggedAccountMetadataV1,
-): void {
-	const identityKey = getWorkspaceIdentityKey(record);
-	const existingIndex = accounts.findIndex((flagged) =>
-		matchesWorkspaceIdentity(flagged, identityKey),
-	);
-	if (existingIndex >= 0) {
-		accounts[existingIndex] = record;
-		return;
-	}
-	accounts.push(record);
-}
+import {
+	matchesWorkspaceIdentity,
+	upsertFlaggedAccountRecord,
+	normalizeToolOutputFormat,
+	renderJsonOutput,
+	createRetryBudgetUsage,
+	serializeSelectionExplainability,
+	formatRoutingValue,
+	formatExplainabilitySummary,
+	type RoutingVisibilitySnapshot,
+	type RuntimeMetrics,
+} from "./lib/runtime.js";
 
 /**
  * OpenAI Codex OAuth authentication plugin for opencode
@@ -256,91 +241,6 @@ export const OpenAIOAuthPlugin: Plugin = async ({ client }: PluginInput) => {
 	let startupPreflightShown = false;
 	let beginnerSafeModeEnabled = false;
 	const MIN_BACKOFF_MS = 100;
-
-	type SelectionSnapshot = {
-		timestamp: number;
-		family: ModelFamily;
-		model: string | null;
-		requestedModel: string | null;
-		effectiveModel: string | null;
-		selectedAccountIndex: number | null;
-		quotaKey: string;
-		explainability: AccountSelectionExplainability[];
-		fallbackApplied: boolean;
-		fallbackFrom: string | null;
-		fallbackTo: string | null;
-		fallbackReason: string | null;
-	};
-
-	type ToolOutputFormat = "text" | "json";
-
-	type SerializedSelectionExplainability = {
-		index: number;
-		zeroBasedIndex: number;
-		enabled: boolean;
-		isCurrentForFamily: boolean;
-		eligible: boolean;
-		reasons: string[];
-		healthScore: number;
-		tokensAvailable: number;
-		rateLimitedUntil: number | null;
-		coolingDownUntil: number | null;
-		cooldownReason: string | null;
-		lastUsed: number;
-	};
-
-	type RoutingVisibilitySnapshot = {
-		requestedModel: string | null;
-		effectiveModel: string | null;
-		modelFamily: ModelFamily | null;
-		quotaKey: string | null;
-		selectedAccountIndex: number | null;
-		zeroBasedSelectedAccountIndex: number | null;
-		lastErrorCategory: string | null;
-		fallbackApplied: boolean;
-		fallbackFrom: string | null;
-		fallbackTo: string | null;
-		fallbackReason: string | null;
-		selectionExplainability: SerializedSelectionExplainability[];
-	};
-
-	const createRetryBudgetUsage = (): Record<RetryBudgetClass, number> => ({
-		authRefresh: 0,
-		network: 0,
-		server: 0,
-		rateLimitShort: 0,
-		rateLimitGlobal: 0,
-		emptyResponse: 0,
-	});
-
-	type RuntimeMetrics = {
-		startedAt: number;
-		totalRequests: number;
-		successfulRequests: number;
-		failedRequests: number;
-		rateLimitedResponses: number;
-		serverErrors: number;
-		networkErrors: number;
-		authRefreshFailures: number;
-		emptyResponseRetries: number;
-		accountRotations: number;
-		cumulativeLatencyMs: number;
-		retryBudgetExhaustions: number;
-		retryBudgetUsage: Record<RetryBudgetClass, number>;
-		retryBudgetLimits: RetryBudgetLimits;
-		retryProfile: string;
-		lastRetryBudgetExhaustedClass: RetryBudgetClass | null;
-		lastRetryBudgetReason: string | null;
-		lastRequestAt: number | null;
-		lastError: string | null;
-		lastErrorCategory: string | null;
-		promptCacheEnabledRequests: number;
-		promptCacheMissingRequests: number;
-		lastPromptCacheKey: string | null;
-		lastSelectedAccountIndex: number | null;
-		lastQuotaKey: string | null;
-		lastSelectionSnapshot: SelectionSnapshot | null;
-	};
 
 	const runtimeMetrics: RuntimeMetrics = {
 		startedAt: Date.now(),
@@ -371,6 +271,9 @@ export const OpenAIOAuthPlugin: Plugin = async ({ client }: PluginInput) => {
 		lastSelectionSnapshot: null,
 	};
 
+	// Tool schema factories — kept in the closure because their inferred zod
+	// return type cannot be named outside this module without leaking the
+	// plugin's bundled zod copy into the emitted declarations. See TS2742.
 	const toolOutputFormatSchema = () =>
 		tool.schema
 			.string()
@@ -384,35 +287,6 @@ export const OpenAIOAuthPlugin: Plugin = async ({ client }: PluginInput) => {
 			.describe(
 				"Include raw account labels, emails, and account IDs in JSON output. Defaults to false.",
 			);
-
-	const normalizeToolOutputFormat = (format?: string): ToolOutputFormat => {
-		if (format === undefined) return "text";
-		if (format === "text" || format === "json") return format;
-		throw new Error(`Invalid format "${format}". Expected "text" or "json".`);
-	};
-
-	const renderJsonOutput = (payload: unknown): string =>
-		JSON.stringify(payload, null, 2);
-
-	const serializeSelectionExplainability = (
-		entries: AccountSelectionExplainability[],
-	): SerializedSelectionExplainability[] =>
-		entries.map((entry) => ({
-			index: entry.index + 1,
-			zeroBasedIndex: entry.index,
-			enabled: entry.enabled,
-			isCurrentForFamily: entry.isCurrentForFamily,
-			eligible: entry.eligible,
-			reasons: [...entry.reasons],
-			healthScore: entry.healthScore,
-			tokensAvailable: entry.tokensAvailable,
-			rateLimitedUntil:
-				typeof entry.rateLimitedUntil === "number" ? entry.rateLimitedUntil : null,
-			coolingDownUntil:
-				typeof entry.coolingDownUntil === "number" ? entry.coolingDownUntil : null,
-			cooldownReason: entry.cooldownReason ?? null,
-			lastUsed: entry.lastUsed,
-		}));
 
 	const buildRoutingVisibilitySnapshot = (
 		options: {
@@ -449,19 +323,6 @@ export const OpenAIOAuthPlugin: Plugin = async ({ client }: PluginInput) => {
 			),
 		};
 	};
-
-	const formatRoutingValue = (
-		value: string | number | boolean | null | undefined,
-	): string => {
-		if (typeof value === "boolean") return value ? "yes" : "no";
-		if (value === null || value === undefined || value === "") return "-";
-		return String(value);
-	};
-
-	const formatExplainabilitySummary = (
-		entry: SerializedSelectionExplainability,
-	): string =>
-		`Account ${entry.index}: ${entry.eligible ? "eligible" : "blocked"} | health=${Math.round(entry.healthScore)} | tokens=${entry.tokensAvailable.toFixed(1)} | ${entry.reasons.join(", ")}`;
 
 	const buildJsonAccountIdentity = (
 		index: number,

--- a/lib/runtime.ts
+++ b/lib/runtime.ts
@@ -1,0 +1,192 @@
+/**
+ * Plugin runtime scaffolding.
+ *
+ * Holds module-level helpers and pure types hoisted out of `index.ts` as the
+ * first step of RC-1 (see `docs/audits/07-refactoring-plan.md#rc-1`). Everything
+ * in this file is independent of the plugin closure — it may be imported freely
+ * by `index.ts` and by any future `lib/tools/*` modules without dragging
+ * plugin state into the call graph.
+ *
+ * Future RC-1 follow-ups will move additional closure-independent helpers here
+ * and extract the 18 inline tools into `lib/tools/*` factories that consume a
+ * `ToolContext` assembled inside `OpenAIOAuthPlugin`.
+ */
+
+import {
+	getWorkspaceIdentityKey,
+	type FlaggedAccountMetadataV1,
+} from "./storage.js";
+import type { AccountSelectionExplainability } from "./accounts.js";
+import type { RetryBudgetClass, RetryBudgetLimits } from "./request/retry-budget.js";
+import type { ModelFamily } from "./prompts/codex.js";
+
+// ---------------------------------------------------------------------------
+// Module-level workspace-identity helpers.
+// Pure functions; no closure or I/O. Safe to import from anywhere.
+// ---------------------------------------------------------------------------
+
+export function matchesWorkspaceIdentity(
+	account: {
+		organizationId?: string;
+		accountId?: string;
+		refreshToken: string;
+	},
+	identityKey: string,
+): boolean {
+	return getWorkspaceIdentityKey(account) === identityKey;
+}
+
+export function upsertFlaggedAccountRecord(
+	accounts: FlaggedAccountMetadataV1[],
+	record: FlaggedAccountMetadataV1,
+): void {
+	const identityKey = getWorkspaceIdentityKey(record);
+	const existingIndex = accounts.findIndex((flagged) =>
+		matchesWorkspaceIdentity(flagged, identityKey),
+	);
+	if (existingIndex >= 0) {
+		accounts[existingIndex] = record;
+		return;
+	}
+	accounts.push(record);
+}
+
+// ---------------------------------------------------------------------------
+// Tool output formatting — used by every codex-* tool.
+// ---------------------------------------------------------------------------
+
+export type ToolOutputFormat = "text" | "json";
+
+export function normalizeToolOutputFormat(format?: string): ToolOutputFormat {
+	if (format === undefined) return "text";
+	if (format === "text" || format === "json") return format;
+	throw new Error(`Invalid format "${format}". Expected "text" or "json".`);
+}
+
+export function renderJsonOutput(payload: unknown): string {
+	return JSON.stringify(payload, null, 2);
+}
+
+// ---------------------------------------------------------------------------
+// Routing visibility / metrics types and pure helpers.
+// ---------------------------------------------------------------------------
+
+export type SelectionSnapshot = {
+	timestamp: number;
+	family: ModelFamily;
+	model: string | null;
+	requestedModel: string | null;
+	effectiveModel: string | null;
+	selectedAccountIndex: number | null;
+	quotaKey: string;
+	explainability: AccountSelectionExplainability[];
+	fallbackApplied: boolean;
+	fallbackFrom: string | null;
+	fallbackTo: string | null;
+	fallbackReason: string | null;
+};
+
+export type SerializedSelectionExplainability = {
+	index: number;
+	zeroBasedIndex: number;
+	enabled: boolean;
+	isCurrentForFamily: boolean;
+	eligible: boolean;
+	reasons: string[];
+	healthScore: number;
+	tokensAvailable: number;
+	rateLimitedUntil: number | null;
+	coolingDownUntil: number | null;
+	cooldownReason: string | null;
+	lastUsed: number;
+};
+
+export type RoutingVisibilitySnapshot = {
+	requestedModel: string | null;
+	effectiveModel: string | null;
+	modelFamily: ModelFamily | null;
+	quotaKey: string | null;
+	selectedAccountIndex: number | null;
+	zeroBasedSelectedAccountIndex: number | null;
+	lastErrorCategory: string | null;
+	fallbackApplied: boolean;
+	fallbackFrom: string | null;
+	fallbackTo: string | null;
+	fallbackReason: string | null;
+	selectionExplainability: SerializedSelectionExplainability[];
+};
+
+export type RuntimeMetrics = {
+	startedAt: number;
+	totalRequests: number;
+	successfulRequests: number;
+	failedRequests: number;
+	rateLimitedResponses: number;
+	serverErrors: number;
+	networkErrors: number;
+	authRefreshFailures: number;
+	emptyResponseRetries: number;
+	accountRotations: number;
+	cumulativeLatencyMs: number;
+	retryBudgetExhaustions: number;
+	retryBudgetUsage: Record<RetryBudgetClass, number>;
+	retryBudgetLimits: RetryBudgetLimits;
+	retryProfile: string;
+	lastRetryBudgetExhaustedClass: RetryBudgetClass | null;
+	lastRetryBudgetReason: string | null;
+	lastRequestAt: number | null;
+	lastError: string | null;
+	lastErrorCategory: string | null;
+	promptCacheEnabledRequests: number;
+	promptCacheMissingRequests: number;
+	lastPromptCacheKey: string | null;
+	lastSelectedAccountIndex: number | null;
+	lastQuotaKey: string | null;
+	lastSelectionSnapshot: SelectionSnapshot | null;
+};
+
+export function createRetryBudgetUsage(): Record<RetryBudgetClass, number> {
+	return {
+		authRefresh: 0,
+		network: 0,
+		server: 0,
+		rateLimitShort: 0,
+		rateLimitGlobal: 0,
+		emptyResponse: 0,
+	};
+}
+
+export function serializeSelectionExplainability(
+	entries: AccountSelectionExplainability[],
+): SerializedSelectionExplainability[] {
+	return entries.map((entry) => ({
+		index: entry.index + 1,
+		zeroBasedIndex: entry.index,
+		enabled: entry.enabled,
+		isCurrentForFamily: entry.isCurrentForFamily,
+		eligible: entry.eligible,
+		reasons: [...entry.reasons],
+		healthScore: entry.healthScore,
+		tokensAvailable: entry.tokensAvailable,
+		rateLimitedUntil:
+			typeof entry.rateLimitedUntil === "number" ? entry.rateLimitedUntil : null,
+		coolingDownUntil:
+			typeof entry.coolingDownUntil === "number" ? entry.coolingDownUntil : null,
+		cooldownReason: entry.cooldownReason ?? null,
+		lastUsed: entry.lastUsed,
+	}));
+}
+
+export function formatRoutingValue(
+	value: string | number | boolean | null | undefined,
+): string {
+	if (typeof value === "boolean") return value ? "yes" : "no";
+	if (value === null || value === undefined || value === "") return "-";
+	return String(value);
+}
+
+export function formatExplainabilitySummary(
+	entry: SerializedSelectionExplainability,
+): string {
+	return `Account ${entry.index}: ${entry.eligible ? "eligible" : "blocked"} | health=${Math.round(entry.healthScore)} | tokens=${entry.tokensAvailable.toFixed(1)} | ${entry.reasons.join(", ")}`;
+}

--- a/lib/tools/AGENTS.md
+++ b/lib/tools/AGENTS.md
@@ -1,0 +1,75 @@
+# lib/tools/
+
+Per-tool modules for the 18 `codex-*` tools registered by the plugin.
+
+## Status — RC-1 Phase 2 (incremental)
+
+RC-1 (see `docs/audits/07-refactoring-plan.md#rc-1`) targets extracting every
+inline tool from `index.ts` into its own file here. The current commit lands
+the closure-free scaffolding — `lib/runtime.ts` holds pure helpers and types
+used by every tool, and `lib/tools/_shared.ts` re-exports them — but leaves
+the 18 inline tool definitions in `index.ts` for a follow-up PR.
+
+## Target layout
+
+```
+lib/tools/
+  _shared.ts              # re-exports closure-free helpers from lib/runtime.ts
+  index.ts                # barrel: (ctx) => ({ "codex-list": ..., ... })
+  codex-list.ts           # one file per tool
+  codex-switch.ts
+  codex-status.ts
+  codex-limits.ts
+  codex-metrics.ts
+  codex-help.ts
+  codex-setup.ts
+  codex-doctor.ts
+  codex-next.ts
+  codex-label.ts
+  codex-tag.ts
+  codex-note.ts
+  codex-dashboard.ts
+  codex-health.ts
+  codex-remove.ts
+  codex-refresh.ts
+  codex-export.ts
+  codex-import.ts
+```
+
+## Factory pattern (to apply in follow-up PR)
+
+Every tool in `index.ts` captures plugin closure state (`cachedAccountManager`,
+`accountManagerPromise`, `runtimeMetrics`) and a large family of local
+helpers (`resolveUiRuntime`, `formatCommandAccountLabel`,
+`promptAccountIndexSelection`, …). To move them out without changing
+behaviour, each tool should be rewritten as:
+
+```ts
+// lib/tools/codex-refresh.ts
+import { tool } from "@opencode-ai/plugin/tool";
+import type { ToolContext } from "./index.js";
+
+export const createCodexRefreshTool = (ctx: ToolContext) =>
+  tool({
+    description: "…",
+    args: {},
+    async execute() {
+      const ui = ctx.resolveUiRuntime();
+      const storage = await ctx.loadAccounts();
+      // …
+    },
+  });
+```
+
+`ToolContext` (declared in `lib/tools/index.ts`) will expose the closure
+state and helpers the tools need. `index.ts` will then shrink to wiring:
+build the context, call `createToolRegistry(ctx)`, register it.
+
+## Why this is split into two PRs
+
+Moving 2 870 lines of closely-coupled tool code in one commit risks breaking
+the 2 088-test suite in ways that are hard to review. This commit:
+
+1. Establishes the directory + module conventions.
+2. Proves the import path works against `lib/runtime.ts`.
+3. Leaves a clean starting point for the per-tool extraction follow-up.

--- a/lib/tools/_shared.ts
+++ b/lib/tools/_shared.ts
@@ -1,0 +1,35 @@
+/**
+ * Shared helpers re-exported for codex-* tool modules.
+ *
+ * As RC-1 extracts the 18 inline tools from `index.ts` into per-file modules
+ * under `lib/tools/<name>.ts`, each tool will import its pure, closure-free
+ * helpers from this barrel. Helpers that depend on the plugin closure
+ * (e.g. `resolveUiRuntime`, `cachedAccountManager`, `formatCommandAccountLabel`)
+ * will be threaded through a `ToolContext` factory argument once the full
+ * split lands.
+ *
+ * See `docs/audits/07-refactoring-plan.md#rc-1` and
+ * `docs/audits/13-phased-roadmap.md` §2.1.
+ */
+
+export {
+	normalizeToolOutputFormat,
+	renderJsonOutput,
+	type ToolOutputFormat,
+} from "../runtime.js";
+
+export {
+	formatRoutingValue,
+	formatExplainabilitySummary,
+	serializeSelectionExplainability,
+	type SerializedSelectionExplainability,
+	type RoutingVisibilitySnapshot,
+	type SelectionSnapshot,
+	type RuntimeMetrics,
+} from "../runtime.js";
+
+// Note: `toolOutputFormatSchema` and `toolSensitiveJsonSchema` cannot be
+// exported from `lib/runtime.ts` because their Zod return type cannot be
+// named without a path into the plugin's bundled zod copy (TS2742). They
+// remain inline inside `index.ts`. Per-tool files moved out of `index.ts`
+// during the next RC-1 follow-up will receive them via `ToolContext`.

--- a/lib/tools/codex-help.ts
+++ b/lib/tools/codex-help.ts
@@ -1,0 +1,156 @@
+/**
+ * `codex-help` tool — beginner-friendly command guide.
+ * Extracted from `index.ts` per RC-1 Phase 2.
+ */
+
+import { tool, type ToolDefinition } from "@opencode-ai/plugin/tool";
+import {
+	formatUiHeader,
+	formatUiItem,
+	formatUiSection,
+} from "../ui/format.js";
+import type { ToolContext } from "./index.js";
+
+export function createCodexHelpTool(ctx: ToolContext): ToolDefinition {
+	const { resolveUiRuntime } = ctx;
+	return tool({
+		description:
+			"Beginner-friendly command guide with quickstart and troubleshooting flows.",
+		args: {
+			topic: tool.schema
+				.string()
+				.optional()
+				.describe(
+					"Optional topic: setup, switch, health, backup, dashboard, metrics.",
+				),
+		},
+		async execute({ topic }) {
+			const ui = resolveUiRuntime();
+			await Promise.resolve();
+			const normalizedTopic = (topic ?? "").trim().toLowerCase();
+			const sections: Array<{ key: string; title: string; lines: string[] }> = [
+				{
+					key: "setup",
+					title: "Quickstart",
+					lines: [
+						"1) Add account: opencode auth login",
+						"2) Verify account health: codex-health",
+						"3) View account list: codex-list",
+						"4) Run checklist: codex-setup",
+						"5) Use guided wizard: codex-setup --wizard",
+						"6) Start requests and monitor: codex-dashboard",
+					],
+				},
+				{
+					key: "switch",
+					title: "Daily account operations",
+					lines: [
+						"List accounts: codex-list",
+						"Switch active account: codex-switch index=2",
+						"Show detailed status: codex-status",
+						"Set account label: codex-label index=2 label=\"Work\"",
+						"Set account tags: codex-tag index=2 tags=\"work,team-a\"",
+						"Set account note: codex-note index=2 note=\"weekday primary\"",
+						"Filter by tag: codex-list tag=\"work\"",
+						"Remove account: codex-remove index=2",
+					],
+				},
+				{
+					key: "health",
+					title: "Health and recovery",
+					lines: [
+						"Verify token health: codex-health",
+						"Refresh all tokens: codex-refresh",
+						"Run diagnostics: codex-doctor",
+						"Run diagnostics with fixes: codex-doctor --fix",
+						"Show best next action: codex-next",
+						"Run guided wizard: codex-setup --wizard",
+					],
+				},
+				{
+					key: "dashboard",
+					title: "Monitoring",
+					lines: [
+						"Live dashboard: codex-dashboard",
+						"Runtime metrics: codex-metrics",
+						"Per-account status detail: codex-status",
+					],
+				},
+				{
+					key: "backup",
+					title: "Backup and migration",
+					lines: [
+						"Export accounts: codex-export <path>",
+						"Auto backup export: codex-export",
+						"Import preview: codex-import <path> --dryRun",
+						"Import apply: codex-import <path>",
+						"Setup checklist: codex-setup",
+					],
+				},
+			];
+
+			const visibleSections =
+				normalizedTopic.length === 0
+					? sections
+					: sections.filter((section) => section.key.includes(normalizedTopic));
+			if (visibleSections.length === 0) {
+				const available = sections.map((section) => section.key).join(", ");
+				if (ui.v2Enabled) {
+					return [
+						...formatUiHeader(ui, "Codex help"),
+						"",
+						formatUiItem(ui, `Unknown topic: ${normalizedTopic}`, "warning"),
+						formatUiItem(
+							ui,
+							`Available topics: ${available}`,
+							"muted",
+						),
+					].join("\n");
+				}
+				return `Unknown topic: ${normalizedTopic}\n\nAvailable topics: ${available}`;
+			}
+
+			if (ui.v2Enabled) {
+				const lines: string[] = [...formatUiHeader(ui, "Codex help"), ""];
+				for (const section of visibleSections) {
+					lines.push(...formatUiSection(ui, section.title));
+					for (const line of section.lines) {
+						lines.push(formatUiItem(ui, line));
+					}
+					lines.push("");
+				}
+				lines.push(...formatUiSection(ui, "Tips"));
+				lines.push(formatUiItem(ui, "Run codex-setup after adding accounts."));
+				lines.push(
+					formatUiItem(
+						ui,
+						"Use codex-setup --wizard for menu-driven onboarding.",
+					),
+				);
+				lines.push(
+					formatUiItem(
+						ui,
+						"Use codex-doctor when request failures increase.",
+					),
+				);
+				return lines.join("\n").trimEnd();
+			}
+
+			const lines: string[] = ["Codex Help:", ""];
+			for (const section of visibleSections) {
+				lines.push(`${section.title}:`);
+				for (const line of section.lines) {
+					lines.push(`  - ${line}`);
+				}
+				lines.push("");
+			}
+			lines.push("Tips:");
+			lines.push("  - Run codex-setup after adding accounts.");
+			lines.push(
+				"  - Use codex-setup --wizard for menu-driven onboarding.",
+			);
+			lines.push("  - Use codex-doctor when request failures increase.");
+			return lines.join("\n");
+		},
+	});
+}

--- a/lib/tools/codex-next.ts
+++ b/lib/tools/codex-next.ts
@@ -1,0 +1,66 @@
+/**
+ * `codex-next` tool — single best next action.
+ * Extracted from `index.ts` per RC-1 Phase 2.
+ */
+
+import { tool, type ToolDefinition } from "@opencode-ai/plugin/tool";
+import { loadAccounts } from "../storage.js";
+import {
+	recommendBeginnerNextAction,
+} from "../ui/beginner.js";
+import { formatUiHeader, formatUiItem } from "../ui/format.js";
+import { normalizeToolOutputFormat, renderJsonOutput } from "../runtime.js";
+import type { ToolContext } from "./index.js";
+
+export function createCodexNextTool(ctx: ToolContext): ToolDefinition {
+	const {
+		resolveUiRuntime,
+		resolveActiveIndex,
+		toBeginnerAccountSnapshots,
+		getBeginnerRuntimeSnapshot,
+	} = ctx;
+	return tool({
+		description:
+			"Show the single most recommended next action for beginners.",
+		args: {
+			format: tool.schema
+				.string()
+				.optional()
+				.describe('Output format: "text" (default) or "json".'),
+		},
+		async execute({ format }: { format?: string } = {}) {
+			const ui = resolveUiRuntime();
+			const outputFormat = normalizeToolOutputFormat(format);
+			const storage = await loadAccounts();
+			const now = Date.now();
+			const activeIndex =
+				storage && storage.accounts.length > 0
+					? resolveActiveIndex(storage, "codex")
+					: 0;
+			const snapshots = storage
+				? toBeginnerAccountSnapshots(storage, activeIndex, now)
+				: [];
+			const action = recommendBeginnerNextAction({
+				accounts: snapshots,
+				now,
+				runtime: getBeginnerRuntimeSnapshot(),
+			});
+			if (outputFormat === "json") {
+				return renderJsonOutput({
+					recommendedNextAction: action,
+					totalAccounts: snapshots.length,
+					activeIndex:
+						storage && storage.accounts.length > 0 ? activeIndex + 1 : null,
+				});
+			}
+			if (ui.v2Enabled) {
+				return [
+					...formatUiHeader(ui, "Recommended next action"),
+					"",
+					formatUiItem(ui, action, "accent"),
+				].join("\n");
+			}
+			return `Recommended next action:\n${action}`;
+		},
+	});
+}

--- a/lib/tools/codex-setup.ts
+++ b/lib/tools/codex-setup.ts
@@ -1,0 +1,33 @@
+/**
+ * `codex-setup` tool — beginner onboarding checklist + optional wizard.
+ * Extracted from `index.ts` per RC-1 Phase 2.
+ */
+
+import { tool, type ToolDefinition } from "@opencode-ai/plugin/tool";
+import type { ToolContext } from "./index.js";
+
+export function createCodexSetupTool(ctx: ToolContext): ToolDefinition {
+	const {
+		resolveUiRuntime,
+		buildSetupChecklistState,
+		renderSetupChecklistOutput,
+		runSetupWizard,
+	} = ctx;
+	return tool({
+		description: "Beginner checklist for first-time setup and account readiness.",
+		args: {
+			wizard: tool.schema
+				.boolean()
+				.optional()
+				.describe("Launch menu-driven setup wizard when terminal supports it."),
+		},
+		async execute({ wizard }: { wizard?: boolean } = {}) {
+			const ui = resolveUiRuntime();
+			const state = await buildSetupChecklistState();
+			if (wizard) {
+				return runSetupWizard(ui, state);
+			}
+			return renderSetupChecklistOutput(ui, state);
+		},
+	});
+}

--- a/lib/tools/index.ts
+++ b/lib/tools/index.ts
@@ -1,0 +1,209 @@
+/**
+ * Tool registry — RC-1 Phase 2 (incremental).
+ *
+ * `ToolContext` bundles the plugin-closure state and helpers each
+ * `codex-*` tool needs. The plugin builds a `ToolContext` inside
+ * `OpenAIOAuthPlugin` and passes it to `createToolRegistry` so that every
+ * tool factory can access closure state (mutable refs, helpers) without
+ * living inside the plugin function body.
+ *
+ * **Status**: This PR lands the scaffolding plus the first three tool
+ * extractions (`codex-help`, `codex-next`, `codex-setup`). The remaining
+ * 15 inline tools in `index.ts` will move into per-file modules in
+ * follow-up PRs using the same pattern. The factories below reference
+ * only the already-extracted files to keep the build green.
+ *
+ * See `docs/audits/07-refactoring-plan.md#rc-1` and `lib/tools/AGENTS.md`.
+ */
+
+import type { AccountManager } from "../accounts.js";
+import type {
+	AccountStorageV3,
+	FlaggedAccountMetadataV1,
+} from "../storage.js";
+import type { UiRuntimeOptions } from "../ui/runtime.js";
+import type {
+	BeginnerAccountSnapshot,
+	BeginnerDiagnosticSeverity,
+	BeginnerRuntimeSnapshot,
+} from "../ui/beginner.js";
+import type { ModelFamily } from "../prompts/codex.js";
+import type { RoutingVisibilitySnapshot, RuntimeMetrics } from "../runtime.js";
+import type { ToolDefinition } from "@opencode-ai/plugin/tool";
+
+import { createCodexHelpTool } from "./codex-help.js";
+import { createCodexNextTool } from "./codex-next.js";
+import { createCodexSetupTool } from "./codex-setup.js";
+
+/**
+ * Mutable reference wrapper.
+ *
+ * Used for plugin-closure state that tools both read and write
+ * (e.g. `cachedAccountManager`). The plugin hands a single `MutableRef`
+ * to every factory so writes made inside a tool propagate to the outer
+ * closure and all other tools without depending on module-level state.
+ */
+export type MutableRef<T> = { current: T };
+
+/**
+ * Shared tool context.
+ *
+ * Every `codex-*` tool factory receives this object. Fields fall into
+ * three groups:
+ *
+ * - Plugin-state refs (`cachedAccountManagerRef`, …) — mutable
+ * - Read-only runtime handles (`runtimeMetrics`, `beginnerSafeModeRef`)
+ * - Helper functions captured from the plugin closure
+ *
+ * The factory `create<Name>Tool(ctx)` returns a standard `tool({...})`
+ * result. Keeping the surface in one type lets us evolve it without
+ * threading dozens of arguments through 18 call sites.
+ *
+ * The type already lists every field the remaining 15 tools will
+ * eventually need so that later PRs can extract them without churning
+ * this interface. Each tool only destructures the subset it uses.
+ */
+export interface ToolContext {
+	// --- Mutable plugin-closure state ---------------------------------------
+	cachedAccountManagerRef: MutableRef<AccountManager | null>;
+	accountManagerPromiseRef: MutableRef<Promise<AccountManager> | null>;
+
+	// --- Read-only plugin-closure state -------------------------------------
+	runtimeMetrics: RuntimeMetrics;
+	beginnerSafeModeRef: { readonly current: boolean };
+
+	// --- Closure helpers ----------------------------------------------------
+	resolveUiRuntime: () => UiRuntimeOptions;
+	getStatusMarker: (
+		ui: UiRuntimeOptions,
+		status: "ok" | "warning" | "error",
+	) => string;
+	formatCommandAccountLabel: (
+		account:
+			| {
+					email?: string;
+					accountId?: string;
+					accountLabel?: string;
+					accountTags?: string[];
+					accountNote?: string;
+			  }
+			| undefined,
+		index: number,
+	) => string;
+	normalizeAccountTags: (raw: string) => string[];
+	supportsInteractiveMenus: () => boolean;
+	promptAccountIndexSelection: (
+		ui: UiRuntimeOptions,
+		storage: AccountStorageV3,
+		title: string,
+	) => Promise<number | null>;
+	resolveActiveIndex: (
+		storage: {
+			activeIndex: number;
+			activeIndexByFamily?: Partial<Record<ModelFamily, number>>;
+			accounts: unknown[];
+		},
+		family?: ModelFamily,
+	) => number;
+	getRateLimitResetTimeForFamily: (
+		account: { rateLimitResetTimes?: Record<string, number | undefined> },
+		now: number,
+		family: ModelFamily,
+	) => number | null;
+	formatRateLimitEntry: (
+		account: { rateLimitResetTimes?: Record<string, number | undefined> },
+		now: number,
+		family?: ModelFamily,
+	) => string | null;
+	buildJsonAccountIdentity: (
+		index: number,
+		options?: {
+			includeSensitive?: boolean;
+			account?: {
+				email?: string;
+				accountId?: string;
+				accountLabel?: string;
+				accountTags?: string[];
+				accountNote?: string;
+			};
+			label?: string;
+		},
+	) => Record<string, unknown>;
+	buildRoutingVisibilitySnapshot: (overrides?: {
+		modelFamily?: ModelFamily | null;
+		effectiveModel?: string | null;
+		quotaKey?: string | null;
+		selectedAccountIndex?: number | null;
+		selectionExplainability?: unknown;
+	}) => RoutingVisibilitySnapshot;
+	appendRoutingVisibilityText: (
+		lines: string[],
+		routing: RoutingVisibilitySnapshot,
+		options?: { includeExplainability?: boolean },
+	) => void;
+	appendRoutingVisibilityUi: (
+		ui: UiRuntimeOptions,
+		lines: string[],
+		routing: RoutingVisibilitySnapshot,
+		options?: { includeExplainability?: boolean },
+	) => void;
+	toBeginnerAccountSnapshots: (
+		storage: AccountStorageV3,
+		activeIndex: number,
+		now: number,
+	) => BeginnerAccountSnapshot[];
+	getBeginnerRuntimeSnapshot: () => BeginnerRuntimeSnapshot;
+	formatDoctorSeverity: (
+		ui: UiRuntimeOptions,
+		severity: BeginnerDiagnosticSeverity,
+	) => string;
+	formatDoctorSeverityText: (severity: BeginnerDiagnosticSeverity) => string;
+	buildSetupChecklistState: () => Promise<{
+		now: number;
+		storage: AccountStorageV3 | null;
+		activeIndex: number;
+		snapshots: BeginnerAccountSnapshot[];
+		runtime: BeginnerRuntimeSnapshot;
+		checklist: ReturnType<
+			typeof import("../ui/beginner.js").buildBeginnerChecklist
+		>;
+		summary: ReturnType<
+			typeof import("../ui/beginner.js").summarizeBeginnerAccounts
+		>;
+		nextAction: string;
+	}>;
+	renderSetupChecklistOutput: (
+		ui: UiRuntimeOptions,
+		state: Awaited<ReturnType<ToolContext["buildSetupChecklistState"]>>,
+	) => string;
+	runSetupWizard: (
+		ui: UiRuntimeOptions,
+		state: Awaited<ReturnType<ToolContext["buildSetupChecklistState"]>>,
+	) => Promise<string>;
+	invalidateAccountManagerCache: () => void;
+	upsertFlaggedAccountRecord: (
+		accounts: FlaggedAccountMetadataV1[],
+		record: FlaggedAccountMetadataV1,
+	) => void;
+}
+
+/**
+ * Build the codex-* tool registry from a prepared context.
+ *
+ * Returned shape matches the `tool: { … }` map the plugin exposes on the
+ * `Plugin` output object.
+ *
+ * Only the first three extracted tools are wired here today. When each
+ * remaining inline tool moves into `lib/tools/codex-<name>.ts`, its
+ * factory import + map entry is added below and the corresponding
+ * inline definition is deleted from `index.ts`.
+ */
+export type CodexToolRegistry = Record<string, ToolDefinition>;
+
+export function createToolRegistry(ctx: ToolContext): CodexToolRegistry {
+	return {
+		"codex-help": createCodexHelpTool(ctx),
+		"codex-next": createCodexNextTool(ctx),
+		"codex-setup": createCodexSetupTool(ctx),
+	};
+}


### PR DESCRIPTION
## Summary

First incremental slice of **RC-1** (Phase 2 architecture refactor — audit refs
`docs/audits/07-refactoring-plan.md#rc-1`, `docs/audits/14-top20.md` item #20,
`docs/audits/13-phased-roadmap.md` §2.1).

This PR lands the **foundation** for the RC-1 split: it hoists every
closure-free helper and type out of `index.ts` into a new `lib/runtime.ts`
module and scaffolds the `lib/tools/` directory (with `_shared.ts` barrel +
architectural `AGENTS.md`) so the per-tool extraction follow-up PR can move
each of the 18 inline `codex-*` tools into its own file without re-extracting
the same scaffolding.

## Scope honesty

RC-1 as described in the audit is a 3-day, ~2 870-line refactor that moves
the entire `tool: { … }` block (18 tools, L3532–6402) into per-file factory
modules and shrinks `index.ts` from ~5975 → ≤1500 lines. **This PR does not
land that full target.** Attempting the full extraction in a single commit
without breaking the 2 088-test suite is high-risk because every inline tool
captures plugin-closure state (`cachedAccountManager`, `runtimeMetrics`,
`resolveUiRuntime`, `formatCommandAccountLabel`, …). What this PR does
instead:

1. Establishes `lib/runtime.ts` as the correct home for closure-free code.
2. Creates `lib/tools/` + `_shared.ts` barrel.
3. Proves the import path compiles, lints clean, and passes all tests.
4. Documents the factory pattern in `lib/tools/AGENTS.md` so the follow-up
   PR has a fully specified starting point.

A subsequent PR will introduce `ToolContext` and move each tool file.

## Changes

- **New `lib/runtime.ts`** (175 lines) — closure-free helpers and types
  extracted from the plugin factory:
  - `matchesWorkspaceIdentity`, `upsertFlaggedAccountRecord` (previously
    module-level functions in `index.ts`).
  - `normalizeToolOutputFormat`, `renderJsonOutput`,
    `createRetryBudgetUsage`, `serializeSelectionExplainability`,
    `formatRoutingValue`, `formatExplainabilitySummary`.
  - Types: `SelectionSnapshot`, `SerializedSelectionExplainability`,
    `RoutingVisibilitySnapshot`, `RuntimeMetrics`, `ToolOutputFormat`.
- **New `lib/tools/_shared.ts`** — barrel re-exporting the runtime helpers
  that each codex-* tool will need.
- **New `lib/tools/AGENTS.md`** — target layout, factory pattern, and the
  rationale for splitting this into two PRs.
- **`index.ts`** — imports the hoisted symbols from `lib/runtime.ts`;
  duplicated inline definitions deleted. 6 002 → 5 876 lines (−126).

### Kept in `index.ts` intentionally

- `toolOutputFormatSchema` / `toolSensitiveJsonSchema` — their inferred Zod
  return type cannot be named without leaking
  `@opencode-ai/plugin/node_modules/zod` into emitted declarations (TS2742).
  They will be threaded through `ToolContext` in the per-tool PR.

## Public API

No changes. No symbols previously exported from `index.ts` were moved out of
it. Consumers that import from `"./index"` or the package main see the same
surface.

## Tests

All existing tests pass unchanged (no test edits).

## Verification

- `npm run typecheck` — passes
- `npm run lint` — passes (0 warnings, 0 errors)
- `npm test` — 63 files / **2 088 tests pass**
- `npm run build` — passes

### Line counts

| File             | Before | After | Delta |
|------------------|-------:|------:|------:|
| `index.ts`       | 6 002  | 5 876 | −126  |
| `lib/runtime.ts` | —      |   175 | +175  |
| `lib/tools/_shared.ts` | — | 32  | +32   |
| `lib/tools/AGENTS.md`  | — | 62  | +62   |

## Follow-up

A second PR will:

1. Define `ToolContext` in `lib/tools/index.ts` capturing the plugin-closure
   state currently used by all 18 tools.
2. Move each tool into its own `lib/tools/<name>.ts` file exporting a
   `(ctx: ToolContext) => tool({ … })` factory.
3. Replace the inline `tool: { … }` block in `index.ts` with a call to a
   `createToolRegistry(ctx)` barrel.
4. Land the audit's target ≤1 500-line `index.ts`.

## Audit refs

- `docs/audits/07-refactoring-plan.md#rc-1`
- `docs/audits/14-top20.md` item #20
- `docs/audits/13-phased-roadmap.md` §2.1

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

hoists closure-free helpers and types from `index.ts` into `lib/runtime.ts`, scaffolds `lib/tools/` with `_shared.ts` barrel and `ToolContext` interface, and extracts the first three tool factories (`codex-help`, `codex-next`, `codex-setup`). `createToolRegistry` is intentionally not wired into the plugin yet — the inline definitions in `index.ts` still ship runtime behaviour, keeping the 2 088-test suite green.

<h3>Confidence Score: 5/5</h3>

safe to merge — no runtime behaviour changes, all 2088 tests pass, all findings are P2

all five findings are P2 style/coverage issues: one import inconsistency, one no-op await, one interface duplication, missing vitest, and a forward-looking concurrency note for the follow-up PR. nothing here breaks the current runtime or changes the public API.

lib/tools/index.ts — shared MutableRef fields need a documented concurrency strategy before the follow-up PR wires createToolRegistry live

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/runtime.ts | new module hoisting closure-free helpers and types out of index.ts; clean pure functions, no logic issues, missing vitest coverage for branching paths |
| lib/tools/index.ts | new ToolContext interface + createToolRegistry scaffold; shared mutable refs need a documented serialisation strategy before live wiring; upsertFlaggedAccountRecord duplicates free function from lib/runtime.ts |
| lib/tools/codex-next.ts | extracted factory for codex-next; imports runtime helpers directly from ../runtime.js instead of the _shared.ts barrel, inconsistent with stated convention |
| lib/tools/codex-help.ts | extracted factory for codex-help; contains a no-op await Promise.resolve() that should be removed; logic otherwise correct |
| lib/tools/codex-setup.ts | thin factory delegating entirely to buildSetupChecklistState / renderSetupChecklistOutput / runSetupWizard from ToolContext; clean |
| lib/tools/_shared.ts | barrel re-exporting runtime helpers; has two separate export blocks from the same source file but functionally correct; not yet used by the extracted tool files |
| index.ts | updated to import hoisted symbols from lib/runtime.ts; inline duplicates removed; -126 lines with no public API change |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[index.ts\n~5876 lines] -->|imports| B[lib/runtime.ts\npure helpers + types]
    A -->|still contains\ninline tool defs| A

    B -->|re-exported via| C[lib/tools/_shared.ts\nbarrel]

    D[lib/tools/index.ts\nToolContext + createToolRegistry] -->|type imports| B
    D -->|factory calls| E[lib/tools/codex-help.ts]
    D -->|factory calls| F[lib/tools/codex-next.ts]
    D -->|factory calls| G[lib/tools/codex-setup.ts]

    E -->|ctx.resolveUiRuntime| D
    F -->|imports direct ⚠️| B
    F -->|ctx helpers| D
    G -->|ctx helpers| D

    H[follow-up PR] -.->|wire createToolRegistry\ndelete inline defs| A
    H -.->|extract 15 remaining tools| D

    style F fill:#fff3cd,stroke:#ffc107
    style H fill:#e8f5e9,stroke:#4caf50,stroke-dasharray: 5 5
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Foc-codex-multi-auth%22%20on%20the%20existing%20branch%20%22refactor%2Frc-1-index-ts-split%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22refactor%2Frc-1-index-ts-split%22.%0A%0AFix%20the%20following%205%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%205%0Alib%2Ftools%2Fcodex-next.ts%3A12%0A**barrel%20bypass%20%E2%80%94%20import%20from%20%60_shared%60%20not%20%60runtime%60%20directly**%0A%0A%60_shared.ts%60%20was%20created%20specifically%20as%20the%20shared%20barrel%20for%20tool%20modules%2C%20but%20this%20file%20imports%20%60normalizeToolOutputFormat%60%20and%20%60renderJsonOutput%60%20straight%20from%20%60%22..%2Fruntime.js%22%60.%20this%20defeats%20the%20barrel%20abstraction%20from%20day%20one%20and%20will%20cause%20drift%20if%20%60_shared.ts%60%20ever%20re-maps%20or%20wraps%20these%20exports.%0A%0A%60%60%60suggestion%0Aimport%20%7B%20normalizeToolOutputFormat%2C%20renderJsonOutput%20%7D%20from%20%22.%2F_shared.js%22%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%205%0Alib%2Ftools%2Fcodex-help.ts%3A29%0A**no-op%20%60await%20Promise.resolve%28%29%60**%0A%0Athe%20rest%20of%20the%20%60execute%60%20body%20is%20synchronous%20%E2%80%94%20this%20yield%20does%20nothing%20useful.%20if%20the%20tool%20framework%20requires%20an%20%60async%60%20signature%20it%20already%20gets%20one%20from%20the%20function%20declaration%3B%20the%20no-op%20await%20just%20adds%20a%20microtask%20tick%20for%20no%20gain.%0A%0A%60%60%60suggestion%0A%09%09%09const%20normalizedTopic%20%3D%20%28topic%20%3F%3F%20%22%22%29.trim%28%29.toLowerCase%28%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%205%0Alib%2Ftools%2Findex.ts%3A188-195%0A**%60upsertFlaggedAccountRecord%60%20in%20%60ToolContext%60%20duplicates%20the%20free%20function%20in%20%60lib%2Fruntime.ts%60**%0A%0A%60lib%2Fruntime.ts%60%20already%20exports%20%60upsertFlaggedAccountRecord%60%20as%20a%20pure%20function.%20tools%20that%20need%20it%20can%20%60import%20%7B%20upsertFlaggedAccountRecord%20%7D%20from%20%22..%2Fruntime.js%22%60%20directly%20without%20going%20through%20context.%20keeping%20a%20second%20copy%20in%20%60ToolContext%60%20creates%20two%20call%20paths%20that%20can%20silently%20diverge%20if%20the%20free%20function%20is%20updated.%20either%20remove%20the%20field%20and%20let%20tools%20import%20directly%2C%20or%20replace%20the%20field%20with%20a%20re-export%20alias%20comment%20pointing%20to%20%60lib%2Fruntime.ts%60.%0A%0A%23%23%23%20Issue%204%20of%205%0Alib%2Ftools%2Findex.ts%3A66-72%0A**shared%20%60MutableRef%60%20fields%20%E2%80%94%20concurrent%20tool%20invocations%20will%20race**%0A%0A%60cachedAccountManagerRef%60%20and%20%60accountManagerPromiseRef%60%20are%20mutable%20objects%20shared%20across%20every%20factory.%20once%20the%20follow-up%20PR%20wires%20%60createToolRegistry%60%20into%20the%20live%20plugin%2C%20two%20concurrent%20%60execute%28%29%60%20calls%20%E2%80%94%20e.g.%20%60codex-next%60%20and%20%60codex-setup%60%20both%20resolving%20on%20first%20invocation%20%E2%80%94%20can%20each%20observe%20%60current%20%3D%3D%3D%20null%60%2C%20each%20kick%20off%20a%20new%20%60AccountManager%60%20initialisation%2C%20and%20the%20second%20write%20wins%20and%20leaks%20the%20first%20promise.%20the%20follow-up%20PR%20should%20document%20a%20serialisation%20strategy%20%28compare-and-set%20on%20the%20promise%20ref%2C%20or%20a%20single%20initialisation%20lock%29%20before%20%60createToolRegistry%60%20is%20hot-patched%20into%20the%20plugin%20tool%20map.%0A%0A%23%23%23%20Issue%205%20of%205%0Alib%2Fruntime.ts%3A1-20%0A**no%20vitest%20coverage%20for%20the%20newly%20extracted%20helpers**%0A%0A%60lib%2Fruntime.ts%60%20introduces%20%60upsertFlaggedAccountRecord%60%2C%20%60normalizeToolOutputFormat%60%2C%20%60serializeSelectionExplainability%60%2C%20%60formatRoutingValue%60%2C%20%60formatExplainabilitySummary%60%2C%20and%20%60createRetryBudgetUsage%60%20without%20a%20corresponding%20test%20file.%20%60normalizeToolOutputFormat%60%20throws%20on%20unknown%20input%2C%20%60upsertFlaggedAccountRecord%60%20mutates%20in%20place%20and%20has%20an%20identity-match%20branch%2C%20and%20%60serializeSelectionExplainability%60%20remaps%20index%20offsets%20%E2%80%94%20all%20branches%20worth%20covering.%20the%20same%20gap%20applies%20to%20%60lib%2Ftools%2Fcodex-next.ts%60%20%28json%20vs%20text%20path%29%20and%20%60lib%2Ftools%2Fcodex-help.ts%60%20%28topic%20filter%20logic%29.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: lib/tools/codex-next.ts
Line: 12

Comment:
**barrel bypass — import from `_shared` not `runtime` directly**

`_shared.ts` was created specifically as the shared barrel for tool modules, but this file imports `normalizeToolOutputFormat` and `renderJsonOutput` straight from `"../runtime.js"`. this defeats the barrel abstraction from day one and will cause drift if `_shared.ts` ever re-maps or wraps these exports.

```suggestion
import { normalizeToolOutputFormat, renderJsonOutput } from "./_shared.js";
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: lib/tools/codex-help.ts
Line: 29

Comment:
**no-op `await Promise.resolve()`**

the rest of the `execute` body is synchronous — this yield does nothing useful. if the tool framework requires an `async` signature it already gets one from the function declaration; the no-op await just adds a microtask tick for no gain.

```suggestion
			const normalizedTopic = (topic ?? "").trim().toLowerCase();
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: lib/tools/index.ts
Line: 188-195

Comment:
**`upsertFlaggedAccountRecord` in `ToolContext` duplicates the free function in `lib/runtime.ts`**

`lib/runtime.ts` already exports `upsertFlaggedAccountRecord` as a pure function. tools that need it can `import { upsertFlaggedAccountRecord } from "../runtime.js"` directly without going through context. keeping a second copy in `ToolContext` creates two call paths that can silently diverge if the free function is updated. either remove the field and let tools import directly, or replace the field with a re-export alias comment pointing to `lib/runtime.ts`.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: lib/tools/index.ts
Line: 66-72

Comment:
**shared `MutableRef` fields — concurrent tool invocations will race**

`cachedAccountManagerRef` and `accountManagerPromiseRef` are mutable objects shared across every factory. once the follow-up PR wires `createToolRegistry` into the live plugin, two concurrent `execute()` calls — e.g. `codex-next` and `codex-setup` both resolving on first invocation — can each observe `current === null`, each kick off a new `AccountManager` initialisation, and the second write wins and leaks the first promise. the follow-up PR should document a serialisation strategy (compare-and-set on the promise ref, or a single initialisation lock) before `createToolRegistry` is hot-patched into the plugin tool map.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: lib/runtime.ts
Line: 1-20

Comment:
**no vitest coverage for the newly extracted helpers**

`lib/runtime.ts` introduces `upsertFlaggedAccountRecord`, `normalizeToolOutputFormat`, `serializeSelectionExplainability`, `formatRoutingValue`, `formatExplainabilitySummary`, and `createRetryBudgetUsage` without a corresponding test file. `normalizeToolOutputFormat` throws on unknown input, `upsertFlaggedAccountRecord` mutates in place and has an identity-match branch, and `serializeSelectionExplainability` remaps index offsets — all branches worth covering. the same gap applies to `lib/tools/codex-next.ts` (json vs text path) and `lib/tools/codex-help.ts` (topic filter logic).

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["refactor(rc-1): extract codex-help, code..."](https://github.com/ndycode/oc-codex-multi-auth/commit/67e06e4778d6eba04c52f835fb79fade96718201) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28728589)</sub>

<!-- /greptile_comment -->