### PR TITLE
refactor(rc-6): split runtime-contracts into oauth-constants + error-sentinels

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -155,7 +155,7 @@ import {
 	createUsageRequestTimeoutError,
 	DEACTIVATED_WORKSPACE_ERROR_CODE,
 	isDeactivatedWorkspaceErrorMessage,
-} from "./lib/runtime-contracts.js";
+} from "./lib/error-sentinels.js";
 import { applyFastSessionDefaults } from "./lib/request/request-transformer.js";
 import {
 	getRateLimitBackoff,

--- a/lib/auth/auth.ts
+++ b/lib/auth/auth.ts
@@ -6,7 +6,7 @@ import {
 	OAUTH_CALLBACK_LOOPBACK_HOST,
 	OAUTH_CALLBACK_PATH,
 	OAUTH_CALLBACK_PORT,
-} from "../runtime-contracts.js";
+} from "../oauth-constants.js";
 import { safeParseOAuthTokenResponse } from "../schemas.js";
 
 // OAuth constants (from openai/codex)

--- a/lib/auth/server.ts
+++ b/lib/auth/server.ts
@@ -7,7 +7,7 @@ import {
 	OAUTH_CALLBACK_LOOPBACK_HOST,
 	OAUTH_CALLBACK_PATH,
 	OAUTH_CALLBACK_PORT,
-} from "../runtime-contracts.js";
+} from "../oauth-constants.js";
 
 /**
  * Start a small local HTTP server that waits for /auth/callback and returns the code

--- a/lib/error-sentinels.ts
+++ b/lib/error-sentinels.ts
@@ -1,13 +1,16 @@
 /**
- * Shared runtime constants and sentinel helpers only. This module is pure: it
- * does not perform I/O, persistence, or logging, so centralizing these values
- * does not introduce new Windows lock or token-redaction surfaces.
+ * Sentinel error codes and factory/matcher helpers.
+ *
+ * These sentinels are the runtime contract between throwing code paths (e.g.
+ * request pipeline, usage tracking) and the orchestrator in `index.ts` that
+ * inspects error messages to decide on account rotation, cooldown, and retry
+ * behaviour. Keeping the sentinel string and its create/match helpers in one
+ * module guarantees producers and consumers cannot drift apart.
+ *
+ * This module is pure: it performs no I/O, persistence, or logging, so
+ * centralizing these values does not introduce new Windows lock or
+ * token-redaction surfaces.
  */
-export const OAUTH_CALLBACK_LOOPBACK_HOST = "127.0.0.1";
-export const OAUTH_CALLBACK_PORT = 1455;
-export const OAUTH_CALLBACK_PATH = "/auth/callback";
-export const OAUTH_CALLBACK_BIND_URL = `http://${OAUTH_CALLBACK_LOOPBACK_HOST}:${OAUTH_CALLBACK_PORT}`;
-
 export const DEACTIVATED_WORKSPACE_ERROR_CODE = "deactivated_workspace";
 export const USAGE_REQUEST_TIMEOUT_MESSAGE = "Usage request timed out";
 

--- a/lib/oauth-constants.ts
+++ b/lib/oauth-constants.ts
@@ -1,0 +1,17 @@
+/**
+ * OAuth callback loopback constants.
+ *
+ * These define the 127.0.0.1 loopback address, port, and path that both the
+ * local OAuth callback server (`lib/auth/server.ts`) and the redirect URI
+ * builder (`lib/auth/auth.ts`) must agree on. Keeping them in one module
+ * prevents drift between the bound host/port and the advertised redirect URI,
+ * which RFC 8252 §7.3 requires to match exactly.
+ *
+ * This module is pure: it performs no I/O, persistence, or logging, so
+ * centralizing these values does not introduce new Windows lock or
+ * token-redaction surfaces.
+ */
+export const OAUTH_CALLBACK_LOOPBACK_HOST = "127.0.0.1";
+export const OAUTH_CALLBACK_PORT = 1455;
+export const OAUTH_CALLBACK_PATH = "/auth/callback";
+export const OAUTH_CALLBACK_BIND_URL = `http://${OAUTH_CALLBACK_LOOPBACK_HOST}:${OAUTH_CALLBACK_PORT}`;

--- a/lib/request/fetch-helpers.ts
+++ b/lib/request/fetch-helpers.ts
@@ -11,7 +11,7 @@ import { transformRequestBody, normalizeModel } from "./request-transformer.js";
 import { convertSseToJson, ensureContentType } from "./response-handler.js";
 import type { UserConfig, RequestBody } from "../types.js";
 import { CodexAuthError } from "../errors.js";
-import { DEACTIVATED_WORKSPACE_ERROR_CODE } from "../runtime-contracts.js";
+import { DEACTIVATED_WORKSPACE_ERROR_CODE } from "../error-sentinels.js";
 import { isRecord } from "../utils.js";
 import {
         CODEX_BASE_URL,

--- a/test/doc-parity.test.ts
+++ b/test/doc-parity.test.ts
@@ -2,7 +2,7 @@ import { readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
-import { OAUTH_CALLBACK_PATH, OAUTH_CALLBACK_PORT } from "../lib/runtime-contracts.js";
+import { OAUTH_CALLBACK_PATH, OAUTH_CALLBACK_PORT } from "../lib/oauth-constants.js";
 import { transformRequestBody } from "../lib/request/request-transformer.js";
 import type { RequestBody, UserConfig } from "../lib/types.js";
 

--- a/test/error-sentinels.test.ts
+++ b/test/error-sentinels.test.ts
@@ -1,19 +1,14 @@
 import { describe, expect, it } from "vitest";
-import { REDIRECT_URI } from "../lib/auth/auth.js";
 import {
 	createDeactivatedWorkspaceError,
 	createUsageRequestTimeoutError,
 	DEACTIVATED_WORKSPACE_ERROR_CODE,
 	isDeactivatedWorkspaceErrorMessage,
 	isUsageRequestTimeoutMessage,
-	OAUTH_CALLBACK_BIND_URL,
-	OAUTH_CALLBACK_LOOPBACK_HOST,
-	OAUTH_CALLBACK_PATH,
-	OAUTH_CALLBACK_PORT,
 	USAGE_REQUEST_TIMEOUT_MESSAGE,
-} from "../lib/runtime-contracts.js";
+} from "../lib/error-sentinels.js";
 
-describe("runtime contracts", () => {
+describe("error sentinels", () => {
 	it("creates stable sentinel errors for workspace deactivation and usage timeouts", () => {
 		const deactivatedWorkspaceError = createDeactivatedWorkspaceError();
 		const usageTimeoutError = createUsageRequestTimeoutError();
@@ -25,20 +20,5 @@ describe("runtime contracts", () => {
 		expect(usageTimeoutError.message).toBe(USAGE_REQUEST_TIMEOUT_MESSAGE);
 		expect(isUsageRequestTimeoutMessage(usageTimeoutError.message)).toBe(true);
 		expect(isUsageRequestTimeoutMessage("request timed out")).toBe(false);
-	});
-
-	it("keeps the OAuth callback runtime values aligned", () => {
-		expect(OAUTH_CALLBACK_PORT).toBe(1455);
-		expect(OAUTH_CALLBACK_PATH).toBe("/auth/callback");
-		expect(OAUTH_CALLBACK_LOOPBACK_HOST).toBe("127.0.0.1");
-		expect(OAUTH_CALLBACK_BIND_URL).toBe(`http://127.0.0.1:${OAUTH_CALLBACK_PORT}`);
-		// RFC 8252 §7.3: redirect URI MUST use the 127.0.0.1 literal, matching
-		// the host the callback server binds to. `localhost` would resolve via
-		// DNS and is not equivalent.
-		expect(REDIRECT_URI).toBe(
-			`http://${OAUTH_CALLBACK_LOOPBACK_HOST}:${OAUTH_CALLBACK_PORT}${OAUTH_CALLBACK_PATH}`,
-		);
-		expect(REDIRECT_URI).toContain("127.0.0.1");
-		expect(REDIRECT_URI).not.toContain("localhost");
 	});
 });

--- a/test/oauth-constants.test.ts
+++ b/test/oauth-constants.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { REDIRECT_URI } from "../lib/auth/auth.js";
+import {
+	OAUTH_CALLBACK_BIND_URL,
+	OAUTH_CALLBACK_LOOPBACK_HOST,
+	OAUTH_CALLBACK_PATH,
+	OAUTH_CALLBACK_PORT,
+} from "../lib/oauth-constants.js";
+
+describe("oauth callback constants", () => {
+	it("keeps the OAuth callback runtime values aligned", () => {
+		expect(OAUTH_CALLBACK_PORT).toBe(1455);
+		expect(OAUTH_CALLBACK_PATH).toBe("/auth/callback");
+		expect(OAUTH_CALLBACK_LOOPBACK_HOST).toBe("127.0.0.1");
+		expect(OAUTH_CALLBACK_BIND_URL).toBe(`http://127.0.0.1:${OAUTH_CALLBACK_PORT}`);
+		// RFC 8252 §7.3: redirect URI MUST use the 127.0.0.1 literal, matching
+		// the host the callback server binds to. `localhost` would resolve via
+		// DNS and is not equivalent.
+		expect(REDIRECT_URI).toBe(
+			`http://${OAUTH_CALLBACK_LOOPBACK_HOST}:${OAUTH_CALLBACK_PORT}${OAUTH_CALLBACK_PATH}`,
+		);
+		expect(REDIRECT_URI).toContain("127.0.0.1");
+		expect(REDIRECT_URI).not.toContain("localhost");
+	});
+});


### PR DESCRIPTION
## Summary

Audit-driven rename/split from `docs/audits/07-refactoring-plan.md` **RC-6** and `docs/audits/16-code-health.md` (MEDIUM, T16): `lib/runtime-contracts.ts` was flagged as misleadingly named. The 28-line file held two unrelated concerns — OAuth callback loopback constants **and** unrelated error-message sentinels with their create/match helpers. No file-level overlap with `lib/schemas.ts` or `lib/types.ts`; the real problem was a name that invites unrelated future additions.

Split into two purpose-specific modules so each filename matches its content:

- **`lib/oauth-constants.ts`** — `OAUTH_CALLBACK_LOOPBACK_HOST` / `_PORT` / `_PATH` / `_BIND_URL`. These are the loopback values the OAuth callback server (`lib/auth/server.ts`) binds to and the redirect-URI builder (`lib/auth/auth.ts`) advertises; keeping them together prevents RFC 8252 §7.3 drift.
- **`lib/error-sentinels.ts`** — `DEACTIVATED_WORKSPACE_ERROR_CODE` / `USAGE_REQUEST_TIMEOUT_MESSAGE` plus `createDeactivatedWorkspaceError` / `isDeactivatedWorkspaceErrorMessage` / `createUsageRequestTimeoutError` / `isUsageRequestTimeoutMessage`. Producer/consumer runtime contract between the request pipeline (`lib/request/fetch-helpers.ts`) and the orchestrator (`index.ts`).

### Importer updates

Updated every site that imported from `../runtime-contracts.js` to the split module that actually owns the symbol. 4 source files + 1 test file:

| File | Change |
| --- | --- |
| `lib/auth/auth.ts` | `../runtime-contracts.js` → `../oauth-constants.js` (OAuth callback consts) |
| `lib/auth/server.ts` | `../runtime-contracts.js` → `../oauth-constants.js` (OAuth callback consts) |
| `lib/request/fetch-helpers.ts` | `../runtime-contracts.js` → `../error-sentinels.js` (`DEACTIVATED_WORKSPACE_ERROR_CODE`) |
| `index.ts` | `./lib/runtime-contracts.js` → `./lib/error-sentinels.js` (sentinel helpers) |
| `test/doc-parity.test.ts` | `../lib/runtime-contracts.js` → `../lib/oauth-constants.js` |

### Test split

`test/runtime-contracts.test.ts` covered both concerns in one file. Split to match the new source layout:

- `test/oauth-constants.test.ts` — OAuth callback alignment + `REDIRECT_URI` RFC 8252 §7.3 check.
- `test/error-sentinels.test.ts` — sentinel factory + matcher round-trip.

### `lib/utils.ts` decision

Audit RC-6 also mentioned `lib/utils.ts`. Reviewed the file directly: 52 lines, 4 generic helpers (`isRecord`, `nowMs`, `toStringValue`, `sleep`), single responsibility (generic runtime utilities), name already accurately describes the content. **Left untouched**; this PR scopes strictly to the misnamed file.

## Why now

- Audit `docs/audits/16-code-health.md` Finding MEDIUM RC-6: "lib/runtime-contracts.ts is misnamed — contains OAuth loopback constants, not runtime contracts".
- Audit `docs/audits/07-refactoring-plan.md` §RC-6: "rename misnamed module + split grab-bag utils".
- Audit `docs/audits/_findings/T01-architecture.md` (ledger id 4), `T05-type-safety.md` L5, `T16-code-health.md` cross-reference the same naming issue.

## Verification

Every check run against the pushed branch on Windows (matches CI environment):

- `npm run typecheck` — PASS
- `npm run lint` — PASS (eslint `--max-warnings=0` via lint-staged pre-commit)
- `npm test` — **2088/2088 tests pass** (matches baseline; the two new split tests replace the one old test and preserve identical assertions)
- `npm run build` — PASS

## Non-goals / out of scope

- No behavior change, no API surface change — all renamed identifiers keep their existing names and types.
- No consolidation into `lib/constants.ts` or `lib/errors.ts`. The audit listed that as an alternative; splitting into dedicated cohesive files matches the other in-flight RC splits (RC-2 storage split) better and keeps diff small.
- `lib/utils.ts` left alone (justification above).
- Historical audit docs under `docs/audits/**` and `.sisyphus/**` still cite the old filename — those are dated evidence that motivated this refactor, not docs to rewrite.

## Related

- Base: `main` at `ac2f4d8` (post-RC-2 storage split).
- Parallel: RC-4 recovery consolidation, RC-9 boundary validation (non-overlapping files).

## Checklist

- [x] Branch from latest `main`
- [x] Rename `lib/runtime-contracts.ts` — split into two accurately-named modules
- [x] `lib/utils.ts` audited; left unchanged (already focused)
- [x] All importers updated
- [x] All existing tests pass unchanged behavior; new test files mirror the split
- [x] `npm run typecheck && npm run lint && npm test && npm run build` pass

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

pure refactor split of `lib/runtime-contracts.ts` into `lib/oauth-constants.ts` (loopback constants) and `lib/error-sentinels.ts` (error sentinel factories + matchers). all five import sites are updated to the correct split module, the old file is gone, and both test files mirror the new layout with identical assertions. no behavior change, no new exports, no api surface change.

all four ci gates (`typecheck`, `lint`, `test`, `build`) reported passing.

<h3>Confidence Score: 5/5</h3>

safe to merge — pure rename/split with no behavior change, all importers updated, old file removed, ci gates green

all nine changed files are mechanically correct: two new pure modules, five updated import paths (all using .js esm specifiers), two new test files mirroring the split. no windows lock or token-safety surfaces introduced. no concurrency concerns. only finding is a p2 style suggestion to split a single it() block in the new error-sentinels test.

no files require special attention

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/oauth-constants.ts | new module housing loopback host/port/path/bind-url constants; pure, no i/o, JSDoc explains RFC 8252 §7.3 rationale |
| lib/error-sentinels.ts | new module with two sentinel strings plus factory/matcher pairs; pure functions, correct equality checks, clear JSDoc |
| lib/auth/auth.ts | import path updated from runtime-contracts to oauth-constants; REDIRECT_URI construction unchanged |
| lib/auth/server.ts | import path updated from runtime-contracts to oauth-constants; all four constants consumed correctly |
| lib/request/fetch-helpers.ts | import path updated from runtime-contracts to error-sentinels; DEACTIVATED_WORKSPACE_ERROR_CODE usage unchanged |
| index.ts | import updated from lib/runtime-contracts to lib/error-sentinels; all four sentinel symbols correctly re-imported |
| test/oauth-constants.test.ts | new test file; covers port/path/host/bind-url values and RFC 8252 REDIRECT_URI check; import path updated correctly |
| test/error-sentinels.test.ts | new test file; both sentinel families tested in a single it() block — minor: independent it() per family would isolate failures better |
| test/doc-parity.test.ts | import updated from lib/runtime-contracts to lib/oauth-constants; parity assertions unchanged |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    OC[lib/oauth-constants.ts\nHOST · PORT · PATH · BIND_URL] --> AA[lib/auth/auth.ts\nREDIRECT_URI builder]
    OC --> AS[lib/auth/server.ts\nHTTP callback server]
    OC --> DPT[test/doc-parity.test.ts]
    OC --> OCT[test/oauth-constants.test.ts]

    ES[lib/error-sentinels.ts\nDEACTIVATED_WORKSPACE_ERROR_CODE\nUSAGE_REQUEST_TIMEOUT_MESSAGE\nfactory + matcher helpers] --> FH[lib/request/fetch-helpers.ts\nisDeactivatedWorkspaceError]
    ES --> IDX[index.ts\norchestrator / rotation logic]
    ES --> EST[test/error-sentinels.test.ts]

    OLD([lib/runtime-contracts.ts\n— removed —]) -. was split into .-> OC
    OLD -. was split into .-> ES
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Foc-codex-multi-auth%22%20on%20the%20existing%20branch%20%22refactor%2Frc-6-rename-utils%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22refactor%2Frc-6-rename-utils%22.%0A%0AFix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atest%2Ferror-sentinels.test.ts%3A12-23%0A**single%20%60it%28%29%60%20mixes%20two%20independent%20sentinels**%0A%0Aboth%20the%20deactivated-workspace%20and%20usage-timeout%20families%20are%20asserted%20in%20one%20block.%20if%20either%20factory%20breaks%2C%20the%20failure%20message%20won't%20identify%20which%20sentinel%20is%20at%20fault.%20split%20into%20two%20%60it%28%29%60%20calls%20so%20vitest%20isolates%20the%20failure%20%E2%80%94%20keeps%20the%20same%20assertion%20count%2C%20just%20improves%20diagnosability.%0A%0A%60%60%60suggestion%0A%09it%28%22creates%20stable%20sentinel%20errors%20for%20workspace%20deactivation%22%2C%20%28%29%20%3D%3E%20%7B%0A%09%09const%20deactivatedWorkspaceError%20%3D%20createDeactivatedWorkspaceError%28%29%3B%0A%0A%09%09expect%28deactivatedWorkspaceError.message%29.toBe%28DEACTIVATED_WORKSPACE_ERROR_CODE%29%3B%0A%09%09expect%28isDeactivatedWorkspaceErrorMessage%28deactivatedWorkspaceError.message%29%29.toBe%28true%29%3B%0A%09%09expect%28isDeactivatedWorkspaceErrorMessage%28%22workspace-deactivated%22%29%29.toBe%28false%29%3B%0A%09%7D%29%3B%0A%0A%09it%28%22creates%20stable%20sentinel%20errors%20for%20usage%20timeouts%22%2C%20%28%29%20%3D%3E%20%7B%0A%09%09const%20usageTimeoutError%20%3D%20createUsageRequestTimeoutError%28%29%3B%0A%0A%09%09expect%28usageTimeoutError.message%29.toBe%28USAGE_REQUEST_TIMEOUT_MESSAGE%29%3B%0A%09%09expect%28isUsageRequestTimeoutMessage%28usageTimeoutError.message%29%29.toBe%28true%29%3B%0A%09%09expect%28isUsageRequestTimeoutMessage%28%22request%20timed%20out%22%29%29.toBe%28false%29%3B%0A%09%7D%29%3B%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: test/error-sentinels.test.ts
Line: 12-23

Comment:
**single `it()` mixes two independent sentinels**

both the deactivated-workspace and usage-timeout families are asserted in one block. if either factory breaks, the failure message won't identify which sentinel is at fault. split into two `it()` calls so vitest isolates the failure — keeps the same assertion count, just improves diagnosability.

```suggestion
	it("creates stable sentinel errors for workspace deactivation", () => {
		const deactivatedWorkspaceError = createDeactivatedWorkspaceError();

		expect(deactivatedWorkspaceError.message).toBe(DEACTIVATED_WORKSPACE_ERROR_CODE);
		expect(isDeactivatedWorkspaceErrorMessage(deactivatedWorkspaceError.message)).toBe(true);
		expect(isDeactivatedWorkspaceErrorMessage("workspace-deactivated")).toBe(false);
	});

	it("creates stable sentinel errors for usage timeouts", () => {
		const usageTimeoutError = createUsageRequestTimeoutError();

		expect(usageTimeoutError.message).toBe(USAGE_REQUEST_TIMEOUT_MESSAGE);
		expect(isUsageRequestTimeoutMessage(usageTimeoutError.message)).toBe(true);
		expect(isUsageRequestTimeoutMessage("request timed out")).toBe(false);
	});
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["refactor(rc-6): split runtime-contracts ..."](https://github.com/ndycode/oc-codex-multi-auth/commit/d4b36e312ebfb4e2ac2607aa309b6d3818e99910) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28729837)</sub>

<!-- /greptile_comment -->