### PR TITLE
refactor(rc-9): Zod-validate remaining process boundaries

### DIFF
--- a/lib/config.ts
+++ b/lib/config.ts
@@ -8,7 +8,13 @@ import {
 	type RetryProfile,
 } from "./request/retry-budget.js";
 import { logWarn } from "./logger.js";
-import { PluginConfigSchema, getValidationErrors } from "./schemas.js";
+import {
+	PluginConfigSchema,
+	getValidationErrors,
+	EnvBooleanSchema,
+	EnvNumberSchema,
+	makeEnvEnumSchema,
+} from "./schemas.js";
 
 const CONFIG_PATH = join(homedir(), ".opencode", "openai-codex-auth-config.json");
 const TUI_COLOR_PROFILES = new Set(["truecolor", "ansi16", "ansi256"]);
@@ -89,21 +95,63 @@ export function loadPluginConfig(): PluginConfig {
 			}
 		}
 
-		const schemaErrors = getValidationErrors(PluginConfigSchema, userConfig);
-		if (schemaErrors.length > 0) {
-			logWarn(`Plugin config validation warnings: ${schemaErrors.slice(0, 3).join(", ")}`);
+		// RC-9: validate at the process boundary. Reject anything that is not
+		// a JSON object, then route through PluginConfigSchema so bad values
+		// from an external config file never flow into the merged runtime
+		// config. Callers still see DEFAULT_CONFIG as the base, so an invalid
+		// file degrades gracefully instead of silently mis-configuring retry
+		// budgets, timeouts, or feature flags.
+		if (!isRecord(userConfig)) {
+			logWarn(
+				`Plugin config at ${CONFIG_PATH} is not a JSON object; using defaults.`,
+			);
+			return DEFAULT_CONFIG;
 		}
 
-		return {
-			...DEFAULT_CONFIG,
-			...(userConfig as Partial<PluginConfig>),
-		};
+		const parseResult = PluginConfigSchema.safeParse(userConfig);
+		if (parseResult.success) {
+			return {
+				...DEFAULT_CONFIG,
+				...parseResult.data,
+			};
+		}
+
+		// Top-level schema failed. Preserve legacy logging so existing
+		// operators still see the familiar "validation warnings" string, then
+		// salvage the subset of keys that individually pass validation so a
+		// single bad field does not wipe out every other user setting.
+		const schemaErrors = getValidationErrors(PluginConfigSchema, userConfig);
+		logWarn(
+			`Plugin config validation warnings: ${schemaErrors.slice(0, 3).join(", ")}`,
+		);
+		const salvaged = salvageValidKeys(userConfig);
+		return { ...DEFAULT_CONFIG, ...salvaged };
 	} catch (error) {
 		logWarn(
 			`Failed to load config from ${CONFIG_PATH}: ${(error as Error).message}`,
 		);
 		return DEFAULT_CONFIG;
 	}
+}
+
+/**
+ * Salvage the subset of user-supplied config keys that individually pass
+ * schema validation. Used when the top-level parse fails so callers still
+ * benefit from valid keys while invalid ones are discarded instead of
+ * silently cast into place.
+ */
+function salvageValidKeys(raw: Record<string, unknown>): Partial<PluginConfig> {
+	const salvaged: Record<string, unknown> = {};
+	for (const [key, value] of Object.entries(raw)) {
+		const probe = PluginConfigSchema.safeParse({ [key]: value });
+		if (probe.success) {
+			const candidate = (probe.data as Record<string, unknown>)[key];
+			if (candidate !== undefined) {
+				salvaged[key] = candidate;
+			}
+		}
+	}
+	return salvaged as Partial<PluginConfig>;
 }
 
 function stripUtf8Bom(content: string): string {
@@ -121,22 +169,30 @@ function isRecord(value: unknown): value is Record<string, unknown> {
  * @param pluginConfig - Plugin configuration from file
  * @returns True if CODEX_MODE should be enabled
  */
+// RC-9: the env-var parsing helpers below are thin wrappers around Zod
+// schemas that live in `lib/schemas.ts`. Keeping them here (instead of
+// inlining the schema use at every call site) preserves the existing
+// `resolveBooleanSetting` / `resolveNumberSetting` call graph while ensuring
+// every process-boundary env read flows through a validated schema. Each
+// helper surfaces `undefined` on invalid input so callers can fall back to
+// the config file / default instead of silently honouring a poisoned value.
 function parseBooleanEnv(value: string | undefined): boolean | undefined {
-	if (value === undefined) return undefined;
-	return value === "1";
+	const result = EnvBooleanSchema.safeParse(value);
+	return result.success ? result.data : undefined;
 }
 
 function parseNumberEnv(value: string | undefined): number | undefined {
-	if (value === undefined) return undefined;
-	const parsed = Number(value);
-	if (!Number.isFinite(parsed)) return undefined;
-	return parsed;
+	const result = EnvNumberSchema.safeParse(value);
+	return result.success ? result.data : undefined;
 }
 
-function parseStringEnv(value: string | undefined): string | undefined {
-	if (value === undefined) return undefined;
-	const trimmed = value.trim().toLowerCase();
-	return trimmed.length > 0 ? trimmed : undefined;
+function parseEnumEnv<T extends string>(
+	value: string | undefined,
+	allowed: ReadonlySet<T>,
+): T | undefined {
+	const schema = makeEnvEnumSchema(allowed);
+	const result = schema.safeParse(value);
+	return result.success ? result.data : undefined;
 }
 
 function resolveBooleanSetting(
@@ -171,9 +227,15 @@ function resolveStringSetting<T extends string>(
 	defaultValue: T,
 	allowedValues: ReadonlySet<string>,
 ): T {
-	const envValue = parseStringEnv(process.env[envName]);
-	if (envValue && allowedValues.has(envValue)) {
-		return envValue as T;
+	// RC-9: validate the env-supplied enum through a Zod schema so unknown
+	// values fall back to the config / default instead of being accepted
+	// verbatim.
+	const envValue = parseEnumEnv(
+		process.env[envName],
+		allowedValues as ReadonlySet<T>,
+	);
+	if (envValue !== undefined) {
+		return envValue;
 	}
 	if (configValue && allowedValues.has(configValue)) {
 		return configValue;
@@ -236,10 +298,17 @@ export function getBeginnerSafeMode(pluginConfig: PluginConfig): boolean {
 	);
 }
 
+const FAST_SESSION_STRATEGIES = new Set(["hybrid", "always"] as const);
+
 export function getFastSessionStrategy(pluginConfig: PluginConfig): "hybrid" | "always" {
-	const env = (process.env.CODEX_AUTH_FAST_SESSION_STRATEGY ?? "").trim().toLowerCase();
-	if (env === "always") return "always";
-	if (env === "hybrid") return "hybrid";
+	// RC-9: validate env-supplied strategy through the shared Zod enum helper
+	// so bogus values (e.g. `CODEX_AUTH_FAST_SESSION_STRATEGY=turbo`) fall
+	// back to the config / default instead of propagating.
+	const envValue = parseEnumEnv(
+		process.env.CODEX_AUTH_FAST_SESSION_STRATEGY,
+		FAST_SESSION_STRATEGIES as ReadonlySet<"hybrid" | "always">,
+	);
+	if (envValue !== undefined) return envValue;
 	return pluginConfig.fastSessionStrategy === "always" ? "always" : "hybrid";
 }
 
@@ -314,9 +383,15 @@ export function getRetryAllAccountsMaxRetries(pluginConfig: PluginConfig): numbe
 export function getUnsupportedCodexPolicy(
 	pluginConfig: PluginConfig,
 ): UnsupportedCodexPolicy {
-	const envPolicy = parseStringEnv(process.env.CODEX_AUTH_UNSUPPORTED_MODEL_POLICY);
-	if (envPolicy && UNSUPPORTED_CODEX_POLICIES.has(envPolicy)) {
-		return envPolicy as UnsupportedCodexPolicy;
+	// RC-9: validate the env-supplied policy through the shared Zod enum
+	// helper. Unknown policy strings fall back to the config / legacy
+	// fallback path rather than being accepted as-is.
+	const envPolicy = parseEnumEnv(
+		process.env.CODEX_AUTH_UNSUPPORTED_MODEL_POLICY,
+		UNSUPPORTED_CODEX_POLICIES as ReadonlySet<UnsupportedCodexPolicy>,
+	);
+	if (envPolicy !== undefined) {
+		return envPolicy;
 	}
 
 	const configPolicy =

--- a/lib/schemas.ts
+++ b/lib/schemas.ts
@@ -425,3 +425,203 @@ export function getValidationErrors(schema: z.ZodType, data: unknown): string[] 
 		return `${path}${issue.message}`;
 	});
 }
+
+// ============================================================================
+// JWT Payload Schema (process boundary: decoded JWT from OAuth provider)
+// ============================================================================
+
+/**
+ * JWT payload schema.
+ *
+ * The JWT is produced by the OAuth provider (ChatGPT backend) and decoded on
+ * the client. Unknown claims are preserved via `catchall(z.unknown())` so we
+ * never reject a valid-but-unfamiliar token, but the claims we actually read
+ * (account id, email, organization hints) are shape-checked. A failed parse
+ * causes callers to treat the JWT as opaque (same behavior as an undecodable
+ * JWT) instead of blindly casting arbitrary JSON into our `JWTPayload` type.
+ */
+export const JWTPayloadSchema = z
+	.object({
+		"https://api.openai.com/auth": z
+			.object({
+				chatgpt_account_id: z.string().optional(),
+				organizations: z.unknown().optional(),
+				email: z.string().optional(),
+				chatgpt_user_email: z.string().optional(),
+			})
+			.catchall(z.unknown())
+			.optional(),
+		organizations: z.unknown().optional(),
+		orgs: z.unknown().optional(),
+		accounts: z.unknown().optional(),
+		workspaces: z.unknown().optional(),
+		teams: z.unknown().optional(),
+		email: z.string().optional(),
+		preferred_username: z.string().optional(),
+	})
+	.catchall(z.unknown());
+
+export type JWTPayloadFromSchema = z.infer<typeof JWTPayloadSchema>;
+
+/**
+ * Safely parse a decoded JWT payload.
+ * Returns null on failure so callers can treat the token as opaque.
+ */
+export function safeParseJWTPayload(data: unknown): JWTPayloadFromSchema | null {
+	const result = JWTPayloadSchema.safeParse(data);
+	if (!result.success) {
+		return null;
+	}
+	return result.data;
+}
+
+// ============================================================================
+// Prompt Cache Metadata Schemas (process boundary: on-disk cache files)
+// ============================================================================
+
+/**
+ * Cache metadata for Codex instructions fetched from GitHub.
+ *
+ * File lives at `~/.opencode/cache/<model>-instructions-meta.json` and is
+ * read at startup and after stale-while-revalidate refreshes. The file can be
+ * corrupted, truncated, or produced by a different plugin version, so the
+ * schema is strict: invalid files fall back to "no cached metadata" (the
+ * same state as a missing file) and force a fresh fetch.
+ */
+export const CacheMetadataSchema = z.object({
+	etag: z.string().nullable(),
+	tag: z.string(),
+	lastChecked: z.number(),
+	url: z.string(),
+});
+
+export type CacheMetadataFromSchema = z.infer<typeof CacheMetadataSchema>;
+
+export function safeParseCacheMetadata(data: unknown): CacheMetadataFromSchema | null {
+	const result = CacheMetadataSchema.safeParse(data);
+	if (!result.success) {
+		return null;
+	}
+	return result.data;
+}
+
+/**
+ * Cache metadata for the OpenCode codex prompt fetched from GitHub.
+ *
+ * File lives at `~/.opencode/cache/opencode-codex-meta.json`. Same trust
+ * considerations as `CacheMetadataSchema`; fall back to empty cache on
+ * parse failure instead of crashing the prompt fetcher.
+ */
+export const OpenCodeCodexCacheMetaSchema = z.object({
+	etag: z.string(),
+	lastFetch: z.string().optional(),
+	lastChecked: z.number(),
+	sourceUrl: z.string().optional(),
+});
+
+export type OpenCodeCodexCacheMetaFromSchema = z.infer<typeof OpenCodeCodexCacheMetaSchema>;
+
+export function safeParseOpenCodeCodexCacheMeta(
+	data: unknown,
+): OpenCodeCodexCacheMetaFromSchema | null {
+	const result = OpenCodeCodexCacheMetaSchema.safeParse(data);
+	if (!result.success) {
+		return null;
+	}
+	return result.data;
+}
+
+// ============================================================================
+// Environment Variable Schemas (process boundary: process.env)
+// ============================================================================
+
+/**
+ * Boolean env-var parser.
+ *
+ * Historical semantics (kept verbatim for backward compatibility with the
+ * pre-RC-9 `parseBooleanEnv` helper): the literal string `"1"` is truthy, any
+ * other non-empty string (including `"0"`, `"yes"`, `"true"`) is falsy, and
+ * `undefined` remains `undefined` so callers can fall back to the config
+ * file / hard-coded default. The schema does not throw on invalid input;
+ * boolean env vars are a process boundary but one where permissive parsing
+ * is the documented contract.
+ */
+export const EnvBooleanSchema = z
+	.string()
+	.optional()
+	.transform((value): boolean | undefined => {
+		if (value === undefined) return undefined;
+		return value === "1";
+	});
+
+/**
+ * Numeric env-var parser.
+ *
+ * Accepts any string that coerces to a finite JS number. Non-finite values
+ * (empty string, `"abc"`, `"NaN"`, `"Infinity"` treated as non-finite) fall
+ * back to undefined so callers can apply config-file / hard-coded defaults
+ * instead of silently using a poisoned value.
+ */
+export const EnvNumberSchema = z
+	.string()
+	.optional()
+	.transform((value): number | undefined => {
+		if (value === undefined) return undefined;
+		const trimmed = value.trim();
+		if (trimmed.length === 0) return undefined;
+		const parsed = Number(trimmed);
+		return Number.isFinite(parsed) ? parsed : undefined;
+	});
+
+/**
+ * Factory for a string-enum env-var parser.
+ *
+ * Produces a Zod schema that trims+lower-cases the raw env value and accepts
+ * it only when it is a member of `allowed`. Any other value becomes
+ * undefined so the caller falls back to the config file / default.
+ */
+export function makeEnvEnumSchema<T extends string>(
+	allowed: ReadonlySet<T> | readonly T[],
+) {
+	const set: ReadonlySet<string> =
+		allowed instanceof Set ? (allowed as ReadonlySet<string>) : new Set(allowed);
+	return z
+		.string()
+		.optional()
+		.transform((value): T | undefined => {
+			if (value === undefined) return undefined;
+			const trimmed = value.trim().toLowerCase();
+			if (trimmed.length === 0) return undefined;
+			return set.has(trimmed) ? (trimmed as T) : undefined;
+		});
+}
+
+/**
+ * Schema for `CODEX_AUTH_ACCOUNT_ID`.
+ *
+ * A manual account-id override supplied via env var. Must be a non-empty
+ * trimmed string within a sane length bound; empty / whitespace-only /
+ * absurdly-long values fall back to undefined so the rotation code picks
+ * an account from the configured pool instead of honouring a bogus override.
+ */
+const ACCOUNT_ID_OVERRIDE_MAX_LENGTH = 256;
+
+export const AccountIdOverrideSchema = z
+	.string()
+	.optional()
+	.transform((value): string | undefined => {
+		if (value === undefined) return undefined;
+		const trimmed = value.trim();
+		if (trimmed.length === 0) return undefined;
+		if (trimmed.length > ACCOUNT_ID_OVERRIDE_MAX_LENGTH) return undefined;
+		return trimmed;
+	});
+
+/**
+ * Parse an env-var value through the account-id override schema.
+ * Returns `undefined` on any validation failure.
+ */
+export function parseAccountIdOverride(value: string | undefined): string | undefined {
+	const result = AccountIdOverrideSchema.safeParse(value);
+	return result.success ? result.data : undefined;
+}

--- a/test/schemas-env.test.ts
+++ b/test/schemas-env.test.ts
@@ -1,0 +1,305 @@
+/**
+ * RC-9: process-boundary schemas added to lib/schemas.ts.
+ *
+ * Covers env-var parsers (`EnvBooleanSchema`, `EnvNumberSchema`,
+ * `makeEnvEnumSchema`), the account-id override schema, the JWT payload
+ * schema, the on-disk cache metadata schemas, and the Codex CLI cross-process
+ * accounts schema. Each boundary must accept the documented shape and fall
+ * back (to `undefined` / `null`) on invalid input without throwing.
+ */
+import { describe, it, expect } from "vitest";
+import {
+	AccountIdOverrideSchema,
+	CacheMetadataSchema,
+	CodexCliAccountEntrySchema,
+	CodexCliAccountsSchema,
+	EnvBooleanSchema,
+	EnvNumberSchema,
+	JWTPayloadSchema,
+	OpenCodeCodexCacheMetaSchema,
+	makeEnvEnumSchema,
+	parseAccountIdOverride,
+	safeParseCacheMetadata,
+	safeParseJWTPayload,
+	safeParseOpenCodeCodexCacheMeta,
+} from "../lib/schemas.js";
+
+describe("EnvBooleanSchema (RC-9 env-boundary)", () => {
+	it("treats literal '1' as true (historical contract)", () => {
+		const result = EnvBooleanSchema.safeParse("1");
+		expect(result.success).toBe(true);
+		if (result.success) expect(result.data).toBe(true);
+	});
+
+	it("treats any other non-empty string as false (historical contract)", () => {
+		for (const value of ["0", "true", "yes", "on", "TRUE", "2"]) {
+			const result = EnvBooleanSchema.safeParse(value);
+			expect(result.success).toBe(true);
+			if (result.success) expect(result.data).toBe(false);
+		}
+	});
+
+	it("passes undefined through so callers fall back to config/default", () => {
+		const result = EnvBooleanSchema.safeParse(undefined);
+		expect(result.success).toBe(true);
+		if (result.success) expect(result.data).toBeUndefined();
+	});
+
+	it("rejects non-string, non-undefined inputs (e.g. numbers, objects)", () => {
+		expect(EnvBooleanSchema.safeParse(1).success).toBe(false);
+		expect(EnvBooleanSchema.safeParse({}).success).toBe(false);
+		expect(EnvBooleanSchema.safeParse(null).success).toBe(false);
+	});
+});
+
+describe("EnvNumberSchema (RC-9 env-boundary)", () => {
+	it("parses finite numeric strings", () => {
+		const result = EnvNumberSchema.safeParse("42");
+		expect(result.success).toBe(true);
+		if (result.success) expect(result.data).toBe(42);
+	});
+
+	it("parses negative and fractional numbers", () => {
+		const neg = EnvNumberSchema.safeParse("-3.5");
+		expect(neg.success).toBe(true);
+		if (neg.success) expect(neg.data).toBe(-3.5);
+	});
+
+	it("falls back to undefined on non-finite input", () => {
+		for (const value of ["", "abc", "NaN", "Infinity", "-Infinity"]) {
+			const result = EnvNumberSchema.safeParse(value);
+			expect(result.success).toBe(true);
+			if (result.success) expect(result.data).toBeUndefined();
+		}
+	});
+
+	it("passes undefined through", () => {
+		const result = EnvNumberSchema.safeParse(undefined);
+		expect(result.success).toBe(true);
+		if (result.success) expect(result.data).toBeUndefined();
+	});
+});
+
+describe("makeEnvEnumSchema (RC-9 env-boundary)", () => {
+	const schema = makeEnvEnumSchema(["alpha", "beta", "gamma"] as const);
+
+	it("accepts exact allowed values", () => {
+		const result = schema.safeParse("alpha");
+		expect(result.success).toBe(true);
+		if (result.success) expect(result.data).toBe("alpha");
+	});
+
+	it("normalizes case and surrounding whitespace", () => {
+		const result = schema.safeParse("  BETA  ");
+		expect(result.success).toBe(true);
+		if (result.success) expect(result.data).toBe("beta");
+	});
+
+	it("falls back to undefined on unknown values", () => {
+		const result = schema.safeParse("delta");
+		expect(result.success).toBe(true);
+		if (result.success) expect(result.data).toBeUndefined();
+	});
+
+	it("falls back to undefined on empty / whitespace-only strings", () => {
+		for (const value of ["", "   "]) {
+			const result = schema.safeParse(value);
+			expect(result.success).toBe(true);
+			if (result.success) expect(result.data).toBeUndefined();
+		}
+	});
+
+	it("accepts a ReadonlySet of allowed values", () => {
+		const setSchema = makeEnvEnumSchema(new Set(["one", "two"]));
+		expect(setSchema.safeParse("one").success).toBe(true);
+		const res = setSchema.safeParse("three");
+		expect(res.success).toBe(true);
+		if (res.success) expect(res.data).toBeUndefined();
+	});
+});
+
+describe("AccountIdOverrideSchema + parseAccountIdOverride (RC-9 env-boundary)", () => {
+	it("accepts a trimmed, non-empty account id", () => {
+		expect(parseAccountIdOverride("acct_123")).toBe("acct_123");
+		expect(parseAccountIdOverride("  acct_123  ")).toBe("acct_123");
+	});
+
+	it("rejects empty / whitespace-only overrides by returning undefined", () => {
+		expect(parseAccountIdOverride("")).toBeUndefined();
+		expect(parseAccountIdOverride("   ")).toBeUndefined();
+	});
+
+	it("rejects overrides longer than the documented maximum (256)", () => {
+		const huge = "a".repeat(257);
+		expect(parseAccountIdOverride(huge)).toBeUndefined();
+	});
+
+	it("keeps overrides exactly at the maximum length", () => {
+		const atMax = "a".repeat(256);
+		expect(parseAccountIdOverride(atMax)).toBe(atMax);
+	});
+
+	it("passes undefined through (env var not set)", () => {
+		expect(parseAccountIdOverride(undefined)).toBeUndefined();
+	});
+
+	it("schema itself rejects non-string inputs", () => {
+		expect(AccountIdOverrideSchema.safeParse(123).success).toBe(false);
+		expect(AccountIdOverrideSchema.safeParse({}).success).toBe(false);
+	});
+});
+
+describe("JWTPayloadSchema + safeParseJWTPayload (RC-9 boundary)", () => {
+	it("accepts a minimal payload and preserves unknown claims", () => {
+		const raw = {
+			email: "user@example.com",
+			"https://api.openai.com/auth": {
+				chatgpt_account_id: "acct_123",
+				email: "user@example.com",
+			},
+			custom_claim: "preserved",
+		};
+		const parsed = safeParseJWTPayload(raw);
+		expect(parsed).not.toBeNull();
+		expect(parsed?.email).toBe("user@example.com");
+		// catchall preserves unknown claims at the top level
+		expect((parsed as Record<string, unknown> | null)?.custom_claim).toBe("preserved");
+	});
+
+	it("returns null when the top-level value is not an object", () => {
+		expect(safeParseJWTPayload("not-an-object")).toBeNull();
+		expect(safeParseJWTPayload(42)).toBeNull();
+		expect(safeParseJWTPayload(null)).toBeNull();
+	});
+
+	it("rejects payloads where the auth claim has a wrong shape", () => {
+		const result = JWTPayloadSchema.safeParse({
+			"https://api.openai.com/auth": "not-an-object",
+		});
+		expect(result.success).toBe(false);
+	});
+});
+
+describe("CacheMetadataSchema + safeParseCacheMetadata (RC-9 boundary)", () => {
+	it("accepts a well-formed cache metadata record", () => {
+		const result = safeParseCacheMetadata({
+			etag: "W/\"abc\"",
+			tag: "v1",
+			lastChecked: 1_700_000_000,
+			url: "https://example.com/prompt.md",
+		});
+		expect(result).not.toBeNull();
+		expect(result?.tag).toBe("v1");
+	});
+
+	it("allows etag to be null (first fetch without an ETag)", () => {
+		const result = safeParseCacheMetadata({
+			etag: null,
+			tag: "v1",
+			lastChecked: 1,
+			url: "https://example.com/x",
+		});
+		expect(result).not.toBeNull();
+		expect(result?.etag).toBeNull();
+	});
+
+	it("returns null on malformed metadata", () => {
+		expect(safeParseCacheMetadata({})).toBeNull();
+		expect(
+			safeParseCacheMetadata({
+				etag: "abc",
+				tag: 1,
+				lastChecked: 1,
+				url: "x",
+			}),
+		).toBeNull();
+		expect(safeParseCacheMetadata(null)).toBeNull();
+	});
+});
+
+describe("OpenCodeCodexCacheMetaSchema + safeParseOpenCodeCodexCacheMeta (RC-9 boundary)", () => {
+	it("accepts a well-formed opencode-codex cache metadata record", () => {
+		const result = safeParseOpenCodeCodexCacheMeta({
+			etag: "W/\"xyz\"",
+			lastChecked: 1_700_000_000,
+			sourceUrl: "https://example.com/opencode-codex.md",
+		});
+		expect(result).not.toBeNull();
+		expect(result?.etag).toBe("W/\"xyz\"");
+	});
+
+	it("returns null on malformed metadata", () => {
+		expect(safeParseOpenCodeCodexCacheMeta({})).toBeNull();
+		expect(
+			safeParseOpenCodeCodexCacheMeta({
+				etag: 1,
+				lastChecked: 1,
+			}),
+		).toBeNull();
+	});
+
+	it("requires etag and lastChecked (the only non-optional fields)", () => {
+		const missingEtag = OpenCodeCodexCacheMetaSchema.safeParse({
+			lastChecked: 1,
+		});
+		const missingLastChecked = OpenCodeCodexCacheMetaSchema.safeParse({
+			etag: "abc",
+		});
+		expect(missingEtag.success).toBe(false);
+		expect(missingLastChecked.success).toBe(false);
+	});
+});
+
+describe("CodexCliAccountsSchema + CodexCliAccountEntrySchema (RC-9 cross-process)", () => {
+	it("accepts a file with an accounts array of well-formed entries", () => {
+		const raw = {
+			accounts: [
+				{
+					email: "user@example.com",
+					accountId: "acct_123",
+					auth: {
+						tokens: {
+							access_token: "at",
+							refresh_token: "rt",
+							id_token: "idt",
+						},
+					},
+				},
+			],
+		};
+		const result = CodexCliAccountsSchema.safeParse(raw);
+		expect(result.success).toBe(true);
+	});
+
+	it("preserves unknown fields via catchall (forward compat)", () => {
+		const raw = {
+			accounts: [
+				{
+					email: "user@example.com",
+					auth: { tokens: { access_token: "at", bonus_claim: "kept" } },
+					future_field: { nested: true },
+				},
+			],
+			metadata: { schema_version: 9001 },
+		};
+		const result = CodexCliAccountsSchema.safeParse(raw);
+		expect(result.success).toBe(true);
+	});
+
+	it("accepts an empty accounts file (accounts: [])", () => {
+		const result = CodexCliAccountsSchema.safeParse({ accounts: [] });
+		expect(result.success).toBe(true);
+	});
+
+	it("rejects entries where auth.tokens has wrong field types", () => {
+		const result = CodexCliAccountEntrySchema.safeParse({
+			auth: { tokens: { access_token: 123 } },
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it("rejects a top-level non-object file", () => {
+		expect(CodexCliAccountsSchema.safeParse("not-an-object").success).toBe(false);
+		expect(CodexCliAccountsSchema.safeParse(null).success).toBe(false);
+	});
+});


### PR DESCRIPTION
## Summary

Phase-2 architecture refactor RC-9. Validates remaining process boundaries with Zod so malformed external input (env vars, on-disk config, cross-process JSON files, decoded JWTs) can never silently cast into typed internal state.

## Boundaries validated

- `loadPluginConfig()` in `lib/config.ts`: on-disk `~/.opencode/openai-codex-auth-config.json` now flows through `PluginConfigSchema.safeParse`. Non-object files fall back to defaults. Top-level parse failures log a warning and salvage the subset of individually-valid keys so one bad field no longer wipes out every other user setting.
- `CODEX_MODE`, `CODEX_TUI_V2`, `CODEX_AUTH_BEGINNER_SAFE_MODE`, `CODEX_AUTH_FAST_SESSION`, `CODEX_AUTH_SESSION_RECOVERY`, `CODEX_AUTH_AUTO_RESUME`, `CODEX_AUTH_PER_PROJECT_ACCOUNTS`, `CODEX_AUTH_PARALLEL_PROBING`, `CODEX_AUTH_PID_OFFSET_ENABLED`, `CODEX_AUTH_RETRY_ALL_RATE_LIMITED`, `CODEX_AUTH_FALLBACK_UNSUPPORTED_MODEL`, `CODEX_AUTH_FALLBACK_GPT53_TO_GPT52`: boolean env vars now flow through `EnvBooleanSchema` (historical `"1" === true` semantics preserved).
- `CODEX_AUTH_FAST_SESSION_MAX_INPUT_ITEMS`, `CODEX_AUTH_RETRY_ALL_MAX_WAIT_MS`, `CODEX_AUTH_RETRY_ALL_MAX_RETRIES`, `CODEX_AUTH_TOKEN_REFRESH_SKEW_MS`, `CODEX_AUTH_RATE_LIMIT_TOAST_DEBOUNCE_MS`, `CODEX_AUTH_TOAST_DURATION_MS`, `CODEX_AUTH_PARALLEL_PROBING_MAX_CONCURRENCY`, `CODEX_AUTH_EMPTY_RESPONSE_MAX_RETRIES`, `CODEX_AUTH_EMPTY_RESPONSE_RETRY_DELAY_MS`, `CODEX_AUTH_FETCH_TIMEOUT_MS`, `CODEX_AUTH_STREAM_STALL_TIMEOUT_MS`: numeric env vars flow through `EnvNumberSchema`. Empty / whitespace-only values now fall back to `undefined` instead of silently coercing to `0`.
- `CODEX_AUTH_REQUEST_TRANSFORM_MODE`, `CODEX_TUI_COLOR_PROFILE`, `CODEX_TUI_GLYPHS`, `CODEX_AUTH_FAST_SESSION_STRATEGY`, `CODEX_AUTH_RETRY_PROFILE`, `CODEX_AUTH_UNSUPPORTED_MODEL_POLICY`: enum env vars flow through `makeEnvEnumSchema(allowed)` which trims + lowercases and rejects unknown values.
- `CODEX_AUTH_ACCOUNT_ID`: now validated via `AccountIdOverrideSchema` / `parseAccountIdOverride` — trimmed, non-empty, capped at 256 chars; invalid overrides fall back to `undefined` so rotation picks from the configured pool.
- Decoded JWT payloads: `JWTPayloadSchema` + `safeParseJWTPayload` treat the provider-decoded JWT as untrusted JSON; unknown claims are preserved via `catchall(z.unknown())` but shape-checked fields (account id, email, organizations) are validated.
- On-disk prompt caches: `CacheMetadataSchema` + `OpenCodeCodexCacheMetaSchema` (with `safeParse*` helpers) validate `~/.opencode/cache/<model>-instructions-meta.json` and `~/.opencode/cache/opencode-codex-meta.json` before use.
- Codex CLI cross-process accounts file: `CodexCliAccountEntrySchema` + `CodexCliAccountsSchema` validate the JSON file produced by a separate Codex CLI process with `catchall(z.unknown())` for forward-compat.

## Pattern

Every boundary uses `safeParse` and falls back to a documented default (`undefined`, `null`, or `DEFAULT_CONFIG`) on failure. No boundary throws. A failure path also never silently replaces a valid user setting with defaults — `salvageValidKeys` in `lib/config.ts` keeps valid sibling keys when the top-level parse fails.

## Tests

New file `test/schemas-env.test.ts` with 33 cases covering:

- valid shapes for every new schema
- empty / whitespace-only strings for every env parser
- wrong-type inputs (numbers, objects, null) for schemas that should reject
- oversize `CODEX_AUTH_ACCOUNT_ID` values
- unknown enum values for `makeEnvEnumSchema`
- malformed JWT, cache metadata, and Codex CLI account files
- forward-compat: unknown fields preserved via `catchall` on `CodexCliAccountsSchema` and `JWTPayloadSchema`

Existing `test/schemas.test.ts` and `test/plugin-config.test.ts` coverage is preserved.

## Audit refs

- `docs/audits/07-refactoring-plan.md#rc-9` — "Configuration validation at process boundary"
- `docs/audits/05-medium.md`

## Verification

- `npm run typecheck` — passes
- `npm run lint` — passes
- `npm test` — 2121 / 2121 tests pass (64 files)
- `npm run build` — passes

## Non-goals

- No storage / auth / account boundaries were re-validated in this PR (those are covered by earlier RCs).
- Default behaviour of every public getter is unchanged for valid input — this PR only changes what happens when input is malformed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration & Environment Validation**
  * Enhanced configuration file validation with stricter type checking and early rejection of invalid data
  * Environment variables now properly validated for boolean, number, and enum types with safe fallback handling
  * Improved error handling for invalid configurations with fallback to defaults

* **Tests**
  * Added comprehensive test suite covering configuration parsing, environment variable validation, and data integrity checks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---


<h3>Greptile Summary</h3>

solid rc-9 refactor that routes every remaining process boundary (env-vars, on-disk config, jwts, cache files, codex-cli accounts file) through named zod schemas with consistent `safeParse` + documented fallback. the `salvageValidKeys` approach in `loadPluginConfig` is well-reasoned — one bad field no longer wipes out all user settings.

- **P1**: `parseAccountIdOverride` is defined and tested but `lib/auth/login-runner.ts` still reads `CODEX_AUTH_ACCOUNT_ID` via `(process.env.CODEX_AUTH_ACCOUNT_ID ?? "").trim()` — the 256-char cap and zod validation are not applied at the actual boundary, contradicting the pr description.

<h3>Confidence Score: 4/5</h3>

safe to merge after wiring parseAccountIdOverride into login-runner.ts — all other boundaries are correctly validated

one P1 gap: CODEX_AUTH_ACCOUNT_ID is described as validated but login-runner.ts bypasses the schema entirely; fix is a two-line import + call change. all other env-var, config-file, JWT, cache, and cross-process boundaries are correctly routed through safeParse with documented fallbacks.

lib/auth/login-runner.ts — needs parseAccountIdOverride wired in to complete the stated boundary validation

<details open><summary><h3>Security Review</h3></summary>

- **`CODEX_AUTH_ACCOUNT_ID` boundary gap** (`lib/auth/login-runner.ts:176`): `parseAccountIdOverride` is not imported/called here; a long (>256 char) account-id override passes through and is forwarded to api requests. windows users running this via batch scripts that accidentally set this var to garbage would propagate it silently rather than falling back to pool rotation.
</details>


<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| lib/schemas.ts | adds EnvBooleanSchema, EnvNumberSchema, makeEnvEnumSchema, AccountIdOverrideSchema, JWTPayloadSchema, CacheMetadataSchema, OpenCodeCodexCacheMetaSchema, CodexCliAccountsSchema — all correct; parseAccountIdOverride exported but not yet consumed at its actual call site |
| lib/config.ts | env-var helpers now delegate to Zod schemas; salvageValidKeys logic is sound; makeEnvEnumSchema reconstructed per parseEnumEnv call is a minor inefficiency |
| test/schemas-env.test.ts | 33 new cases covering valid, empty/whitespace, wrong-type, oversize, and unknown-enum inputs for every new schema; missing a plugin-config.test.ts case for the mixed-valid/invalid salvage path |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[process.env boolean var] -->|parseBooleanEnv| B[EnvBooleanSchema.safeParse]
    C[process.env number var] -->|parseNumberEnv| D[EnvNumberSchema.safeParse]
    E[process.env enum var] -->|parseEnumEnv| F[makeEnvEnumSchema.safeParse]
    G[process.env CODEX_AUTH_ACCOUNT_ID] -->|ad-hoc .trim only| H[login-runner.ts no cap]

    B -->|success| I[typed boolean]
    B -->|fail/undefined| J[config/default fallback]
    D -->|success| K[typed number]
    D -->|empty/NaN/undefined| L[config/default fallback]
    F -->|valid enum| M[typed enum T]
    F -->|unknown/empty| N[config/default fallback]

    O[on-disk config JSON] --> P{isRecord?}
    P -->|no| Q[DEFAULT_CONFIG]
    P -->|yes| R[PluginConfigSchema.safeParse]
    R -->|success| S[merge with DEFAULT_CONFIG]
    R -->|fail| T[getValidationErrors + warn]
    T --> U[salvageValidKeys per-key probe]
    U --> V[DEFAULT_CONFIG + valid subset]

    W[decoded JWT] --> X[JWTPayloadSchema.safeParse]
    X -->|success| Y[typed JWTPayload + catchall]
    X -->|fail| Z[null treat as opaque]

    AA[Codex CLI accounts file] --> AB[CodexCliAccountsSchema.safeParse]
    AB -->|success| AC[typed accounts + catchall]
    AB -->|fail| AD[warn + empty cache]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `lib/auth/login-runner.ts`, line 176-179 ([link](https://github.com/ndycode/oc-codex-multi-auth/blob/94a0d30d2a6f6311d0241c1af018ba523d822446/lib/auth/login-runner.ts#L176-L179)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> <a href="#"><img alt="security" src="https://greptile-static-assets.s3.amazonaws.com/badges/Security.svg?v=1" align="top"></a> **`parseAccountIdOverride` not wired up at the actual read site**

   the pr describes `CODEX_AUTH_ACCOUNT_ID` as "now validated via `AccountIdOverrideSchema` / `parseAccountIdOverride`", but this file still uses ad-hoc `(process.env.CODEX_AUTH_ACCOUNT_ID ?? "").trim()`. the new helper is exported from `lib/schemas.ts` and unit-tested, but never imported here — so the 256-char cap and strict Zod validation are not applied at the real process boundary. a maliciously long override string passes through and gets forwarded to the api + partially logged.

   you'll need to add `import { parseAccountIdOverride } from "../schemas.js";` at the top of this file, then:

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: lib/auth/login-runner.ts
   Line: 176-179

   Comment:
   **`parseAccountIdOverride` not wired up at the actual read site**

   the pr describes `CODEX_AUTH_ACCOUNT_ID` as "now validated via `AccountIdOverrideSchema` / `parseAccountIdOverride`", but this file still uses ad-hoc `(process.env.CODEX_AUTH_ACCOUNT_ID ?? "").trim()`. the new helper is exported from `lib/schemas.ts` and unit-tested, but never imported here — so the 256-char cap and strict Zod validation are not applied at the real process boundary. a maliciously long override string passes through and gets forwarded to the api + partially logged.

   you'll need to add `import { parseAccountIdOverride } from "../schemas.js";` at the top of this file, then:

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Foc-codex-multi-auth%22%20on%20the%20existing%20branch%20%22refactor%2Frc-9-boundary-validation%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22refactor%2Frc-9-boundary-validation%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20lib%2Fauth%2Flogin-runner.ts%0ALine%3A%20176-179%0A%0AComment%3A%0A**%60parseAccountIdOverride%60%20not%20wired%20up%20at%20the%20actual%20read%20site**%0A%0Athe%20pr%20describes%20%60CODEX_AUTH_ACCOUNT_ID%60%20as%20%22now%20validated%20via%20%60AccountIdOverrideSchema%60%20%2F%20%60parseAccountIdOverride%60%22%2C%20but%20this%20file%20still%20uses%20ad-hoc%20%60%28process.env.CODEX_AUTH_ACCOUNT_ID%20%3F%3F%20%22%22%29.trim%28%29%60.%20the%20new%20helper%20is%20exported%20from%20%60lib%2Fschemas.ts%60%20and%20unit-tested%2C%20but%20never%20imported%20here%20%E2%80%94%20so%20the%20256-char%20cap%20and%20strict%20Zod%20validation%20are%20not%20applied%20at%20the%20real%20process%20boundary.%20a%20maliciously%20long%20override%20string%20passes%20through%20and%20gets%20forwarded%20to%20the%20api%20%2B%20partially%20logged.%0A%0Ayou'll%20need%20to%20add%20%60import%20%7B%20parseAccountIdOverride%20%7D%20from%20%22..%2Fschemas.js%22%3B%60%20at%20the%20top%20of%20this%20file%2C%20then%3A%0A%0A%60%60%60suggestion%0A%09const%20override%20%3D%20parseAccountIdOverride%28process.env.CODEX_AUTH_ACCOUNT_ID%29%3B%0A%09if%20%28override%29%20%7B%0A%09%09const%20suffix%20%3D%20override.length%20%3E%206%20%3F%20override.slice%28-6%29%20%3A%20override%3B%0A%09%09logInfo%28%60Using%20account%20override%20from%20CODEX_AUTH_ACCOUNT_ID%20%28id%3A%24%7Bsuffix%7D%29%60%29%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Foc-codex-multi-auth%22%20on%20the%20existing%20branch%20%22refactor%2Frc-9-boundary-validation%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22refactor%2Frc-9-boundary-validation%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Alib%2Fauth%2Flogin-runner.ts%3A176-179%0A**%60parseAccountIdOverride%60%20not%20wired%20up%20at%20the%20actual%20read%20site**%0A%0Athe%20pr%20describes%20%60CODEX_AUTH_ACCOUNT_ID%60%20as%20%22now%20validated%20via%20%60AccountIdOverrideSchema%60%20%2F%20%60parseAccountIdOverride%60%22%2C%20but%20this%20file%20still%20uses%20ad-hoc%20%60%28process.env.CODEX_AUTH_ACCOUNT_ID%20%3F%3F%20%22%22%29.trim%28%29%60.%20the%20new%20helper%20is%20exported%20from%20%60lib%2Fschemas.ts%60%20and%20unit-tested%2C%20but%20never%20imported%20here%20%E2%80%94%20so%20the%20256-char%20cap%20and%20strict%20Zod%20validation%20are%20not%20applied%20at%20the%20real%20process%20boundary.%20a%20maliciously%20long%20override%20string%20passes%20through%20and%20gets%20forwarded%20to%20the%20api%20%2B%20partially%20logged.%0A%0Ayou'll%20need%20to%20add%20%60import%20%7B%20parseAccountIdOverride%20%7D%20from%20%22..%2Fschemas.js%22%3B%60%20at%20the%20top%20of%20this%20file%2C%20then%3A%0A%0A%60%60%60suggestion%0A%09const%20override%20%3D%20parseAccountIdOverride%28process.env.CODEX_AUTH_ACCOUNT_ID%29%3B%0A%09if%20%28override%29%20%7B%0A%09%09const%20suffix%20%3D%20override.length%20%3E%206%20%3F%20override.slice%28-6%29%20%3A%20override%3B%0A%09%09logInfo%28%60Using%20account%20override%20from%20CODEX_AUTH_ACCOUNT_ID%20%28id%3A%24%7Bsuffix%7D%29%60%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Alib%2Fconfig.ts%3A189-196%0A**%60makeEnvEnumSchema%60%20reconstructed%20on%20every%20call**%0A%0A%60makeEnvEnumSchema%28allowed%29%60%20allocates%20a%20new%20zod%20schema%20object%20on%20every%20invocation%20of%20%60parseEnumEnv%60.%20all%20callers%20pass%20module-level%20%60const%60%20sets%20%28%60TUI_COLOR_PROFILES%60%2C%20%60FAST_SESSION_STRATEGIES%60%2C%20etc.%29%2C%20so%20the%20schema%20could%20be%20built%20once%20alongside%20each%20set%20and%20passed%20in.%20not%20a%20correctness%20issue%20at%20startup%20frequency%2C%20but%20worth%20tightening%20before%20this%20pattern%20spreads%20to%20hot%20paths.%0A%0A%60%60%60suggestion%0Afunction%20parseEnumEnv%3CT%20extends%20string%3E%28%0A%09value%3A%20string%20%7C%20undefined%2C%0A%09schema%3A%20ReturnType%3Ctypeof%20makeEnvEnumSchema%3E%2C%0A%29%3A%20T%20%7C%20undefined%20%7B%0A%09const%20result%20%3D%20schema.safeParse%28value%29%3B%0A%09return%20result.success%20%3F%20result.data%20as%20T%20%3A%20undefined%3B%0A%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Atest%2Fplugin-config.test.ts%3A220-264%0A**missing%20vitest%20coverage%20for%20%60salvageValidKeys%60%20path**%0A%0A%60plugin-config.test.ts%60%20covers%20json%20parse%20errors%20and%20missing%20files%20but%20has%20no%20test%20that%20supplies%20a%20config%20with%20one%20invalid%20field%20alongside%20valid%20ones%20%E2%80%94%20the%20new%20%60salvageValidKeys%60%20branch.%20the%20pr%20description%20calls%20this%20the%20key%20safety%20property%2C%20so%20it%20deserves%20an%20explicit%20case%3A%0A%0A%60%60%60ts%0Ait%28'salvages%20valid%20keys%20when%20one%20field%20fails%20schema%20validation'%2C%20%28%29%20%3D%3E%20%7B%0A%20%20mockReadFileSync.mockReturnValue%28%0A%20%20%20%20JSON.stringify%28%7B%20codexMode%3A%20false%2C%20fetchTimeoutMs%3A%20'not-a-number'%20%7D%29%0A%20%20%29%3B%0A%20%20const%20config%20%3D%20loadPluginConfig%28%29%3B%0A%20%20expect%28config.codexMode%29.toBe%28false%29%3B%20%20%20%20%20%20%20%2F%2F%20salvaged%0A%20%20expect%28config.fetchTimeoutMs%29.toBe%2860_000%29%3B%20%2F%2F%20default%20%28bad%20key%20discarded%29%0A%7D%29%3B%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: lib/auth/login-runner.ts
Line: 176-179

Comment:
**`parseAccountIdOverride` not wired up at the actual read site**

the pr describes `CODEX_AUTH_ACCOUNT_ID` as "now validated via `AccountIdOverrideSchema` / `parseAccountIdOverride`", but this file still uses ad-hoc `(process.env.CODEX_AUTH_ACCOUNT_ID ?? "").trim()`. the new helper is exported from `lib/schemas.ts` and unit-tested, but never imported here — so the 256-char cap and strict Zod validation are not applied at the real process boundary. a maliciously long override string passes through and gets forwarded to the api + partially logged.

you'll need to add `import { parseAccountIdOverride } from "../schemas.js";` at the top of this file, then:

```suggestion
	const override = parseAccountIdOverride(process.env.CODEX_AUTH_ACCOUNT_ID);
	if (override) {
		const suffix = override.length > 6 ? override.slice(-6) : override;
		logInfo(`Using account override from CODEX_AUTH_ACCOUNT_ID (id:${suffix})`);
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: lib/config.ts
Line: 189-196

Comment:
**`makeEnvEnumSchema` reconstructed on every call**

`makeEnvEnumSchema(allowed)` allocates a new zod schema object on every invocation of `parseEnumEnv`. all callers pass module-level `const` sets (`TUI_COLOR_PROFILES`, `FAST_SESSION_STRATEGIES`, etc.), so the schema could be built once alongside each set and passed in. not a correctness issue at startup frequency, but worth tightening before this pattern spreads to hot paths.

```suggestion
function parseEnumEnv<T extends string>(
	value: string | undefined,
	schema: ReturnType<typeof makeEnvEnumSchema>,
): T | undefined {
	const result = schema.safeParse(value);
	return result.success ? result.data as T : undefined;
}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: test/plugin-config.test.ts
Line: 220-264

Comment:
**missing vitest coverage for `salvageValidKeys` path**

`plugin-config.test.ts` covers json parse errors and missing files but has no test that supplies a config with one invalid field alongside valid ones — the new `salvageValidKeys` branch. the pr description calls this the key safety property, so it deserves an explicit case:

```ts
it('salvages valid keys when one field fails schema validation', () => {
  mockReadFileSync.mockReturnValue(
    JSON.stringify({ codexMode: false, fetchTimeoutMs: 'not-a-number' })
  );
  const config = loadPluginConfig();
  expect(config.codexMode).toBe(false);       // salvaged
  expect(config.fetchTimeoutMs).toBe(60_000); // default (bad key discarded)
});
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(rc-9): zod-validate remaining p..."](https://github.com/ndycode/oc-codex-multi-auth/commit/94a0d30d2a6f6311d0241c1af018ba523d822446) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28735911)</sub>

<!-- /greptile_comment -->