### PR TITLE
refactor(rc-3): typed error hierarchy in lib/errors.ts

### DIFF
--- a/lib/circuit-breaker.ts
+++ b/lib/circuit-breaker.ts
@@ -1,3 +1,7 @@
+import { CircuitOpenError } from "./errors.js";
+
+export { CircuitOpenError };
+
 export interface CircuitBreakerConfig {
 	failureThreshold: number;
 	failureWindowMs: number;
@@ -13,13 +17,6 @@ export const DEFAULT_CIRCUIT_BREAKER_CONFIG: CircuitBreakerConfig = {
 };
 
 export type CircuitState = "closed" | "open" | "half-open";
-
-export class CircuitOpenError extends Error {
-	constructor(message = "Circuit is open") {
-		super(message);
-		this.name = "CircuitOpenError";
-	}
-}
 
 export class CircuitBreaker {
 	private state: CircuitState = "closed";

--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -1,10 +1,29 @@
 /**
  * Typed error hierarchy for the Codex plugin.
- * Provides structured error types with codes, causes, and context.
+ *
+ * Single source of truth for all domain error classes. `CodexError` plays the
+ * role of `BaseError`: every subclass inherits `code: string`, `cause?: unknown`,
+ * optional `context`, stack capture, and a stable `name`.
+ *
+ * Consolidated in RC-3 (docs/audits/07-refactoring-plan.md#rc-3):
+ * - `StorageError` moved here from `lib/storage/errors.ts` (that path stays as
+ *   a thin re-export so existing imports keep working).
+ * - `CircuitOpenError` moved here from `lib/circuit-breaker.ts` (same re-export
+ *   compatibility pattern).
+ * - New domain classes added: `RecoveryError`, `PromptError`, `RequestError`,
+ *   `ConfigError` — used by the throw-site port.
+ *
+ * All ad-hoc `throw new Error(...)` sites in `lib/**` should throw one of the
+ * classes in this file so callers can switch on `err.code` or `instanceof`
+ * instead of parsing message strings.
  */
 
 /**
  * Error codes for categorizing errors.
+ *
+ * These are the default codes attached to each domain class when no explicit
+ * `code` is passed. Sub-codes (e.g. `LOAD_FAILED`, `PARSE_JSON_FAILED`) flow
+ * through the `options.code` field and remain free-form strings.
  */
 export const ErrorCode = {
 	NETWORK_ERROR: "CODEX_NETWORK_ERROR",
@@ -13,6 +32,12 @@ export const ErrorCode = {
 	VALIDATION_ERROR: "CODEX_VALIDATION_ERROR",
 	RATE_LIMIT: "CODEX_RATE_LIMIT",
 	TIMEOUT: "CODEX_TIMEOUT",
+	STORAGE_ERROR: "CODEX_STORAGE_ERROR",
+	CIRCUIT_OPEN: "CODEX_CIRCUIT_OPEN",
+	RECOVERY_ERROR: "CODEX_RECOVERY_ERROR",
+	PROMPT_ERROR: "CODEX_PROMPT_ERROR",
+	REQUEST_ERROR: "CODEX_REQUEST_ERROR",
+	CONFIG_ERROR: "CODEX_CONFIG_ERROR",
 } as const;
 
 export type ErrorCodeType = (typeof ErrorCode)[keyof typeof ErrorCode];
@@ -162,5 +187,97 @@ export class CodexRateLimitError extends CodexError {
 		super(message, { ...options, code: options?.code ?? ErrorCode.RATE_LIMIT });
 		this.retryAfterMs = options?.retryAfterMs;
 		this.accountId = options?.accountId;
+	}
+}
+
+/**
+ * Error for storage/persistence failures.
+ *
+ * Positional constructor kept for backward compatibility with existing call
+ * sites and test assertions (the class was previously defined in
+ * `lib/storage/errors.ts` with this exact signature).
+ */
+export class StorageError extends CodexError {
+	override readonly name = "StorageError";
+	readonly path: string;
+	readonly hint: string;
+
+	constructor(message: string, code: string, path: string, hint: string, cause?: Error) {
+		super(message, { code, cause });
+		this.path = path;
+		this.hint = hint;
+	}
+}
+
+/**
+ * Error thrown when a circuit breaker is open (or half-open past its attempt
+ * budget) and further calls must short-circuit instead of hitting the
+ * protected dependency.
+ */
+export class CircuitOpenError extends CodexError {
+	override readonly name = "CircuitOpenError";
+
+	constructor(message = "Circuit is open") {
+		super(message, { code: ErrorCode.CIRCUIT_OPEN });
+	}
+}
+
+/**
+ * Error for session recovery failures (conversation state persistence, id
+ * validation, part/message storage integrity).
+ */
+export class RecoveryError extends CodexError {
+	override readonly name = "RecoveryError";
+
+	constructor(message: string, options?: CodexErrorOptions) {
+		super(message, {
+			...options,
+			code: options?.code ?? ErrorCode.RECOVERY_ERROR,
+		});
+	}
+}
+
+/**
+ * Error for prompt template fetching or cache failures (GitHub ETag cache,
+ * release tag resolution, upstream prompt source fetches).
+ */
+export class PromptError extends CodexError {
+	override readonly name = "PromptError";
+
+	constructor(message: string, options?: CodexErrorOptions) {
+		super(message, {
+			...options,
+			code: options?.code ?? ErrorCode.PROMPT_ERROR,
+		});
+	}
+}
+
+/**
+ * Error for request/response pipeline failures that are not auth, network,
+ * or rate-limit related (SSE stream shape, missing body, size limits).
+ */
+export class RequestError extends CodexError {
+	override readonly name = "RequestError";
+
+	constructor(message: string, options?: CodexErrorOptions) {
+		super(message, {
+			...options,
+			code: options?.code ?? ErrorCode.REQUEST_ERROR,
+		});
+	}
+}
+
+/**
+ * Error for configuration/environment failures (missing TTY, malformed CLI
+ * input, bad format flags, missing required options).
+ */
+export class ConfigError extends CodexError {
+	override readonly name = "ConfigError";
+
+	constructor(message: string, options?: CodexErrorOptions) {
+		super(message, {
+			...options,
+			code: options?.code ?? ErrorCode.CONFIG_ERROR,
+		});
 	}
 }

--- a/lib/prompts/codex.ts
+++ b/lib/prompts/codex.ts
@@ -2,6 +2,7 @@ import { promises as fs } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { PromptError } from "../errors.js";
 import type { CacheMetadata, GitHubRelease } from "../types.js";
 import { logWarn, logError, logDebug } from "../logger.js";
 
@@ -183,8 +184,12 @@ async function getLatestReleaseTag(): Promise<string> {
 
 	const htmlResponse = await fetch(GITHUB_HTML_RELEASES);
 	if (!htmlResponse.ok) {
-		throw new Error(
+		throw new PromptError(
 			`Failed to fetch latest release: ${htmlResponse.status}`,
+			{
+				code: "RELEASE_FETCH_FAILED",
+				context: { status: htmlResponse.status, url: GITHUB_HTML_RELEASES },
+			},
 		);
 	}
 
@@ -212,7 +217,9 @@ async function getLatestReleaseTag(): Promise<string> {
 		return tag;
 	}
 
-	throw new Error("Failed to determine latest release tag from GitHub");
+	throw new PromptError("Failed to determine latest release tag from GitHub", {
+		code: "RELEASE_TAG_UNKNOWN",
+	});
 }
 
 /**
@@ -360,7 +367,10 @@ async function fetchAndPersistInstructions(
 	}
 
 	if (!response.ok) {
-		throw new Error(`HTTP ${response.status}`);
+		throw new PromptError(`HTTP ${response.status}`, {
+			code: "HTTP_ERROR",
+			context: { status: response.status },
+		});
 	}
 
 	const instructions = await response.text();

--- a/lib/prompts/opencode-codex.ts
+++ b/lib/prompts/opencode-codex.ts
@@ -8,6 +8,7 @@
 import { join } from "node:path";
 import { homedir } from "node:os";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { PromptError } from "../errors.js";
 import { logDebug } from "../logger.js";
 
 const DEFAULT_OPENCODE_CODEX_URLS = [
@@ -181,8 +182,9 @@ async function refreshPrompt(
 		return content;
 	}
 
-	throw new Error(
+	throw new PromptError(
 		`Failed to fetch OpenCode codex prompt from all sources${lastFailure ? ` (${lastFailure})` : ""}`,
+		{ code: "FETCH_ALL_SOURCES_FAILED" },
 	);
 }
 
@@ -234,8 +236,9 @@ export async function getOpenCodeCodexPrompt(): Promise<string> {
 		if (staleContent) {
 			return staleContent;
 		}
-		throw new Error(
+		throw new PromptError(
 			`Failed to fetch OpenCode codex.txt and no cache available: ${error}`,
+			{ code: "FETCH_AND_NO_CACHE", cause: error },
 		);
 	}
 }

--- a/lib/recovery/storage.ts
+++ b/lib/recovery/storage.ts
@@ -6,6 +6,7 @@
 
 import { existsSync, mkdirSync, readdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { RecoveryError } from "../errors.js";
 import { MESSAGE_STORAGE, PART_STORAGE, THINKING_TYPES, META_TYPES } from "./constants.js";
 import type { StoredMessageMeta, StoredPart, StoredTextPart } from "./types.js";
 
@@ -13,7 +14,10 @@ const SAFE_ID_PATTERN = /^[a-zA-Z0-9_-]+$/;
 
 function validatePathId(id: string, name: string): void {
   if (!SAFE_ID_PATTERN.test(id)) {
-    throw new Error(`Invalid ${name}: contains unsafe characters`);
+    throw new RecoveryError(`Invalid ${name}: contains unsafe characters`, {
+      code: "INVALID_ID",
+      context: { field: name },
+    });
   }
 }
 

--- a/lib/request/response-handler.ts
+++ b/lib/request/response-handler.ts
@@ -1,3 +1,4 @@
+import { RequestError } from "../errors.js";
 import { createLogger, logRequest, LOGGING_ENABLED } from "../logger.js";
 
 import type { SSEEventData } from "../types.js";
@@ -155,7 +156,9 @@ export async function convertSseToJson(
 	options?: { streamStallTimeoutMs?: number },
 ): Promise<Response> {
 	if (!response.body) {
-		throw new Error('[openai-codex-plugin] Response has no body');
+		throw new RequestError('[openai-codex-plugin] Response has no body', {
+			code: 'NO_RESPONSE_BODY',
+		});
 	}
 	const reader = response.body.getReader();
 	const decoder = new TextDecoder();
@@ -172,7 +175,10 @@ export async function convertSseToJson(
 			if (done) break;
 			fullText += decoder.decode(value, { stream: true });
 			if (fullText.length > MAX_SSE_SIZE) {
-				throw new Error(`SSE response exceeds ${MAX_SSE_SIZE} bytes limit`);
+				throw new RequestError(`SSE response exceeds ${MAX_SSE_SIZE} bytes limit`, {
+					code: 'SSE_TOO_LARGE',
+					context: { maxBytes: MAX_SSE_SIZE, actualBytes: fullText.length },
+				});
 			}
 		}
 

--- a/lib/storage/errors.ts
+++ b/lib/storage/errors.ts
@@ -1,26 +1,16 @@
 /**
- * Storage error types and platform-aware error hint formatting.
+ * Storage-domain error re-export + platform-aware error hint formatting.
  *
- * Split out of `lib/storage.ts` in RC-2 so every storage submodule can import
- * the typed error without pulling in load/save/normalize transitively.
+ * RC-3 consolidation: `StorageError` now lives in `lib/errors.ts` alongside the
+ * rest of the typed error hierarchy. This module re-exports it so every
+ * existing import path (`./errors.js` from storage submodules,
+ * `lib/storage.ts` public re-export) continues to work without changes.
+ *
+ * `formatStorageErrorHint` stays here because it is storage-specific presentation
+ * and has no place in the generic error-class module.
  */
 
-/**
- * Custom error class for storage operations with platform-aware hints.
- */
-export class StorageError extends Error {
-  readonly code: string;
-  readonly path: string;
-  readonly hint: string;
-
-  constructor(message: string, code: string, path: string, hint: string, cause?: Error) {
-    super(message, { cause });
-    this.name = "StorageError";
-    this.code = code;
-    this.path = path;
-    this.hint = hint;
-  }
-}
+export { StorageError } from "../errors.js";
 
 /**
  * Generate platform-aware troubleshooting hint based on error code.

--- a/lib/storage/paths.ts
+++ b/lib/storage/paths.ts
@@ -7,6 +7,7 @@ import { existsSync } from "node:fs";
 import { createHash } from "node:crypto";
 import { basename, dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { homedir, tmpdir } from "node:os";
+import { StorageError } from "../errors.js";
 
 const PROJECT_MARKERS = [".git", "package.json", "Cargo.toml", "go.mod", "pyproject.toml", ".opencode"];
 const PROJECTS_DIR = "projects";
@@ -103,7 +104,12 @@ export function resolvePath(filePath: string): string {
 		!isWithinDirectory(cwd, resolved) &&
 		!isWithinDirectory(tmp, resolved)
 	) {
-		throw new Error(`Access denied: path must be within home directory, project directory, or temp directory`);
+		throw new StorageError(
+			`Access denied: path must be within home directory, project directory, or temp directory`,
+			"PATH_ACCESS_DENIED",
+			resolved,
+			"The requested path is outside the allowed roots (home, project, temp). Pick a path inside one of those directories.",
+		);
 	}
 
 	return resolved;

--- a/lib/ui/select.ts
+++ b/lib/ui/select.ts
@@ -1,3 +1,4 @@
+import { CodexValidationError, ConfigError } from "../errors.js";
 import { ANSI, isTTY, parseKey } from "./ansi.js";
 import type { UiTheme } from "./theme.js";
 
@@ -88,17 +89,25 @@ function codexColorCode(theme: UiTheme, color: MenuItem["color"]): string {
 
 export async function select<T>(items: MenuItem<T>[], options: SelectOptions): Promise<T | null> {
 	if (!isTTY()) {
-		throw new Error("Interactive select requires a TTY terminal");
+		throw new ConfigError("Interactive select requires a TTY terminal", {
+			code: "TTY_REQUIRED",
+		});
 	}
 	if (items.length === 0) {
-		throw new Error("No menu items provided");
+		throw new CodexValidationError("No menu items provided", {
+			code: "NO_MENU_ITEMS",
+			field: "items",
+		});
 	}
 
 	const isSelectable = (item: MenuItem<T>) =>
 		!item.disabled && !item.separator && item.kind !== "heading";
 	const selectable = items.filter(isSelectable);
 	if (selectable.length === 0) {
-		throw new Error("All menu items are disabled");
+		throw new CodexValidationError("All menu items are disabled", {
+			code: "ALL_ITEMS_DISABLED",
+			field: "items",
+		});
 	}
 	if (selectable.length === 1) {
 		return selectable[0]?.value ?? null;


### PR DESCRIPTION
## Summary

Consolidate every domain error class into `lib/errors.ts` as the single source of truth. `CodexError` takes the `BaseError` role (stable `name`, `code`, `cause`, optional `context`, `Error.captureStackTrace`) and every other class extends it.

Moved inline:
- `StorageError` (was in `lib/storage/errors.ts`) — old path kept as re-export shim
- `CircuitOpenError` (was in `lib/circuit-breaker.ts`) — same shim pattern

Added domain classes used at the ported throw sites:
- `RecoveryError` / `PromptError` / `RequestError` / `ConfigError`

Ported ad-hoc `throw new Error(...)` -> typed class at these call sites so callers can branch on `err.code` or `instanceof` instead of message parsing:
- `lib/circuit-breaker.ts`
- `lib/prompts/codex.ts`, `lib/prompts/opencode-codex.ts`
- `lib/recovery/storage.ts`
- `lib/request/response-handler.ts`
- `lib/storage/errors.ts`, `lib/storage/paths.ts`
- `lib/ui/select.ts`

## Scope

- 9 files, 181+/39-
- Import-compat shims keep `lib/storage/errors.ts` and `lib/circuit-breaker.ts` re-exporting their old public surface.
- No test churn: baseline 2121 passes unchanged.

## Verification

- `npm run typecheck` ✔
- `npm run lint` ✔
- `npm test` ✔ (2121 passed)
- `npm run build` ✔

## Follow-ups (separate PRs)

- RC-7: AccountManager split (depends on RC-3 error types)
- RC-8: breaker wiring (depends on RC-3 + RC-7)
- Remaining throw-site sweep across `lib/auth/`, `lib/accounts.ts` if any ad-hoc `throw new Error` remain after this PR lands.

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

consolidates all domain error classes into `lib/errors.ts` as a single source of truth, with `StorageError` and `CircuitOpenError` moved inline and import-compat re-export shims retained at their old paths. `RecoveryError`, `PromptError`, `RequestError`, and `ConfigError` are added and wired to their respective throw sites so callers can branch on `err.code` / `instanceof` instead of message parsing. the approach is clean and backward-compatible — no existing call sites or test counts are broken.

<h3>Confidence Score: 5/5</h3>

safe to merge — only p2 cleanup gaps remain, no correctness or data-integrity regressions

all remaining findings are p2: one missed throw site in readWithTimeout (functionally benign, caught and re-thrown correctly) and missing vitest coverage for the new classes. hierarchy, shim exports, and backward-compat are solid. typecheck, lint, and 2121 tests pass.

lib/request/response-handler.ts — one remaining plain new Error() at the stall-timeout rejection path

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/errors.ts | adds StorageError, CircuitOpenError, RecoveryError, PromptError, RequestError, ConfigError as CodexError subclasses; no new ErrorCode collisions; positional StorageError constructor preserved for compat |
| lib/circuit-breaker.ts | CircuitOpenError removed inline, imported from errors.js and re-exported; CircuitBreaker logic unchanged; import-compat shim correct |
| lib/storage/errors.ts | thin re-export shim for StorageError; formatStorageErrorHint stays here; non-standard EEMPTY case is pre-existing |
| lib/request/response-handler.ts | RequestError adopted at two throw sites; readWithTimeout still throws plain Error on stall — missed during port |
| lib/storage/paths.ts | StorageError import moved from ./errors.js to ../errors.js directly; path-safety logic unchanged; windows case-folding preserved |
| lib/recovery/storage.ts | RecoveryError used for INVALID_ID validation; file writes use 0o600 mode; no new concurrency concerns |
| lib/prompts/codex.ts | PromptError replaces plain Error at release-tag and HTTP error throw sites; stale-while-revalidate and background refresh logic unchanged |
| lib/prompts/opencode-codex.ts | PromptError used for all-sources-failed and no-cache cases; cache meta write lacks 0o600 mode but pre-existing |
| lib/ui/select.ts | ConfigError for missing TTY (correctly carries TTY_REQUIRED code), CodexValidationError for empty/all-disabled items — clean port |

</details>

<h3>Class Diagram</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
classDiagram
    class Error {
        +name: string
        +message: string
        +stack?: string
    }

    class CodexError {
        +name: string = "CodexError"
        +code: string
        +context?: Record
        +cause?: unknown
        +constructor(message, options?)
    }

    class StorageError {
        +name = "StorageError"
        +path: string
        +hint: string
    }

    class CircuitOpenError {
        +name = "CircuitOpenError"
        +code = CIRCUIT_OPEN
    }

    class RecoveryError {
        +name = "RecoveryError"
        +code = RECOVERY_ERROR
    }

    class PromptError {
        +name = "PromptError"
        +code = PROMPT_ERROR
    }

    class RequestError {
        +name = "RequestError"
        +code = REQUEST_ERROR
    }

    class ConfigError {
        +name = "ConfigError"
        +code = CONFIG_ERROR
    }

    Error <|-- CodexError
    CodexError <|-- StorageError
    CodexError <|-- CircuitOpenError
    CodexError <|-- RecoveryError
    CodexError <|-- PromptError
    CodexError <|-- RequestError
    CodexError <|-- ConfigError
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Foc-codex-multi-auth%22%20on%20the%20existing%20branch%20%22refactor%2Frc-3-error-hierarchy%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22refactor%2Frc-3-error-hierarchy%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Alib%2Frequest%2Fresponse-handler.ts%3A284-286%0A**Missed%20throw%20site%20in%20%60readWithTimeout%60**%0A%0Athe%20stall%20rejection%20is%20the%20only%20remaining%20%60new%20Error%28...%29%60%20in%20this%20file.%20callers%20catching%20%60instanceof%20RequestError%60%20%28the%20pattern%20this%20PR%20enables%29%20won't%20match%20a%20stream-stall%2C%20so%20they'd%20have%20to%20fall%20back%20to%20message%20parsing%20%E2%80%94%20exactly%20what%20the%20refactor%20is%20trying%20to%20eliminate.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20reject%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20new%20RequestError%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%60SSE%20stream%20stalled%20for%20%24%7BtimeoutMs%7Dms%20while%20waiting%20for%20response.done%60%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7B%20code%3A%20%22SSE_STALL_TIMEOUT%22%20%7D%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Alib%2Ferrors.ts%3A229-238%0A**No%20vitest%20coverage%20for%20new%20domain%20classes**%0A%0A%60RecoveryError%60%2C%20%60PromptError%60%2C%20%60RequestError%60%2C%20and%20%60ConfigError%60%20are%20all%20new%20public%20API%20but%20have%20no%20dedicated%20unit%20tests.%20the%20existing%202121%20pass%20because%20call-site%20smoke%20is%20covered%2C%20but%20constructor%20edge-cases%20%28default%20%60code%60%2C%20%60cause%60%20chaining%2C%20%60name%60%20stability%2C%20%60captureStackTrace%60%20presence%29%20have%20no%20assertions.%20worth%20adding%20a%20small%20vitest%20file%20alongside%20the%20class%20hierarchy%20%E2%80%94%20especially%20since%20downstream%20PRs%20%28RC-7%2C%20RC-8%29%20will%20depend%20on%20%60instanceof%60%20branches%20being%20reliable.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: lib/request/response-handler.ts
Line: 284-286

Comment:
**Missed throw site in `readWithTimeout`**

the stall rejection is the only remaining `new Error(...)` in this file. callers catching `instanceof RequestError` (the pattern this PR enables) won't match a stream-stall, so they'd have to fall back to message parsing — exactly what the refactor is trying to eliminate.

```suggestion
                    reject(
                        new RequestError(
                            `SSE stream stalled for ${timeoutMs}ms while waiting for response.done`,
                            { code: "SSE_STALL_TIMEOUT" },
                        ),
                    );
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: lib/errors.ts
Line: 229-238

Comment:
**No vitest coverage for new domain classes**

`RecoveryError`, `PromptError`, `RequestError`, and `ConfigError` are all new public API but have no dedicated unit tests. the existing 2121 pass because call-site smoke is covered, but constructor edge-cases (default `code`, `cause` chaining, `name` stability, `captureStackTrace` presence) have no assertions. worth adding a small vitest file alongside the class hierarchy — especially since downstream PRs (RC-7, RC-8) will depend on `instanceof` branches being reliable.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(rc-3): typed error hierarchy in..."](https://github.com/ndycode/oc-codex-multi-auth/commit/f5f2080cf21a28b9b42ac9bb1fcc207666ddef47) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28737205)</sub>

<!-- /greptile_comment -->