### PR TITLE
refactor(rc-7): split AccountManager into domain services

### DIFF
--- a/lib/accounts.ts
+++ b/lib/accounts.ts
@@ -1,34 +1,36 @@
-import { existsSync, promises as fs } from "node:fs";
-import { homedir } from "node:os";
-import { join } from "node:path";
-import type { Auth } from "@opencode-ai/sdk";
-import { createLogger } from "./logger.js";
-import {
-	loadAccounts,
-	saveAccounts,
-	type AccountStorageV3,
-	type CooldownReason,
-	type RateLimitStateV3,
-} from "./storage.js";
-import type { AccountIdSource, OAuthAuthDetails } from "./types.js";
-import { MODEL_FAMILIES, type ModelFamily } from "./prompts/codex.js";
-import {
-	getHealthTracker,
-	getTokenTracker,
-	selectHybridAccount,
-	type AccountWithMetrics,
-	type HybridSelectionOptions,
-} from "./rotation.js";
-import { nowMs } from "./utils.js";
-import { decodeJWT } from "./auth/auth.js";
-import { registerCleanup, unregisterCleanup } from "./shutdown.js";
-import { CodexCliAccountsSchema } from "./schemas.js";
-
 /**
- * Upper bound the shutdown handler will wait for `flushPendingSave` so that a
- * jammed save cannot stall SIGINT/SIGTERM indefinitely.
+ * AccountManager — slim orchestrator that composes four domain services:
+ *
+ *  - {@link AccountState}       — in-memory account registry + per-family indices
+ *  - {@link AccountPersistence} — debounced disk saves, shutdown-flush lifecycle
+ *  - {@link AccountRotation}    — selection, rate-limit and cooldown management
+ *  - {@link AccountRecovery}    — auth-failure tracking, Codex CLI hydration,
+ *                                  merge-safe removal
+ *
+ * This module preserves the public API that existed before the RC-7 split so
+ * that `new AccountManager(...)` and every instance method keeps working for
+ * external callers (`index.ts`, `lib/tools/*`, `lib/parallel-probe.ts`, etc.).
  */
-const SHUTDOWN_FLUSH_TIMEOUT_MS = 5_000;
+
+import type { Auth } from "@opencode-ai/sdk";
+import { loadAccounts, type AccountStorageV3, type CooldownReason } from "./storage.js";
+import type { HybridSelectionOptions } from "./rotation.js";
+import type { OAuthAuthDetails } from "./types.js";
+import type { ModelFamily } from "./prompts/codex.js";
+import {
+	AccountPersistence,
+} from "./accounts/persistence.js";
+import { AccountRecovery } from "./accounts/recovery.js";
+import { AccountRotation } from "./accounts/rotation.js";
+import {
+	AccountState,
+	type AccountSelectionExplainability,
+	type ManagedAccount,
+} from "./accounts/state.js";
+import { formatWaitTime, type RateLimitReason } from "./accounts/rate-limits.js";
+import { nowMs } from "./utils.js";
+
+export type { AccountSelectionExplainability, ManagedAccount } from "./accounts/state.js";
 
 export {
 	extractAccountId,
@@ -56,388 +58,62 @@ export {
 	type RateLimitedEntity,
 } from "./accounts/rate-limits.js";
 
-import {
-	extractAccountId,
-	extractAccountEmail,
-	shouldUpdateAccountIdFromToken,
-	sanitizeEmail,
-} from "./auth/token-utils.js";
-import {
-	clampNonNegativeInt,
-	getQuotaKey,
-	clearExpiredRateLimits,
-	isRateLimitedForFamily,
-	formatWaitTime,
-	type RateLimitReason,
-} from "./accounts/rate-limits.js";
-
-const log = createLogger("accounts");
-
-export type CodexCliTokenCacheEntry = {
-	accessToken: string;
-	expiresAt?: number;
-	refreshToken?: string;
-	accountId?: string;
-};
-
-const CODEX_CLI_ACCOUNTS_PATH = join(homedir(), ".codex", "accounts.json");
-const CODEX_CLI_CACHE_TTL_MS = 5_000;
-let codexCliTokenCache: Map<string, CodexCliTokenCacheEntry> | null = null;
-let codexCliTokenCacheLoadedAt = 0;
-
-function extractExpiresAtFromAccessToken(accessToken: string): number | undefined {
-	const decoded = decodeJWT(accessToken);
-	const exp = decoded?.exp;
-	if (typeof exp === "number" && Number.isFinite(exp)) {
-		// JWT exp is in seconds since epoch.
-		return exp * 1000;
-	}
-	return undefined;
-}
-
-async function getCodexCliTokenCache(): Promise<Map<string, CodexCliTokenCacheEntry> | null> {
-	const syncEnabled = process.env.CODEX_AUTH_SYNC_CODEX_CLI !== "0";
-	const skip =
-		!syncEnabled ||
-		process.env.VITEST_WORKER_ID !== undefined ||
-		process.env.NODE_ENV === "test";
-	if (skip) return null;
-
-	const now = nowMs();
-	if (codexCliTokenCache && now - codexCliTokenCacheLoadedAt < CODEX_CLI_CACHE_TTL_MS) {
-		return codexCliTokenCache;
-	}
-	codexCliTokenCacheLoadedAt = now;
-
-	if (!existsSync(CODEX_CLI_ACCOUNTS_PATH)) {
-		codexCliTokenCache = null;
-		return null;
-	}
-
-	try {
-		const raw = await fs.readFile(CODEX_CLI_ACCOUNTS_PATH, "utf-8");
-		const rawParsed = JSON.parse(raw) as unknown;
-
-		// Cross-process trust boundary: the Codex CLI accounts file is produced
-		// by a separate process on disk and may be stale, truncated, tampered
-		// with, or produced by a version whose shape we do not recognise. We
-		// MUST validate through the Zod schema before reading any field; a
-		// parse failure is a warn+skip, never a throw (audit top-20 #11).
-		const validation = CodexCliAccountsSchema.safeParse(rawParsed);
-		if (!validation.success) {
-			log.warn("Codex CLI accounts cache failed validation; ignoring", {
-				issues: validation.error.issues.length,
-				firstPath: validation.error.issues[0]?.path.join(".") ?? "(root)",
-			});
-			codexCliTokenCache = null;
-			return null;
-		}
-
-		const validated = validation.data;
-		const entries = Array.isArray(validated.accounts) ? validated.accounts : [];
-
-		const next = new Map<string, CodexCliTokenCacheEntry>();
-		for (const entry of entries) {
-			const email = sanitizeEmail(typeof entry.email === "string" ? entry.email : undefined);
-			if (!email) continue;
-
-			const accountId =
-				typeof entry.accountId === "string" && entry.accountId.trim()
-					? entry.accountId.trim()
-					: undefined;
-
-			const tokens = entry.auth?.tokens;
-			const accessToken =
-				typeof tokens?.access_token === "string" && tokens.access_token.trim()
-					? tokens.access_token.trim()
-					: undefined;
-			const refreshToken =
-				typeof tokens?.refresh_token === "string" && tokens.refresh_token.trim()
-					? tokens.refresh_token.trim()
-					: undefined;
-
-			if (!accessToken) continue;
-
-			next.set(email, {
-				accessToken,
-				expiresAt: extractExpiresAtFromAccessToken(accessToken),
-				refreshToken,
-				accountId,
-			});
-		}
-
-		codexCliTokenCache = next;
-		return codexCliTokenCache;
-	} catch (error) {
-		log.debug("Failed to read Codex CLI accounts cache", { error: String(error) });
-		codexCliTokenCache = null;
-		return null;
-	}
-}
-
-export async function lookupCodexCliTokensByEmail(
-	email: string | undefined,
-): Promise<CodexCliTokenCacheEntry | null> {
-	const normalized = sanitizeEmail(email);
-	if (!normalized) return null;
-	const cache = await getCodexCliTokenCache();
-	const cached = cache?.get(normalized);
-	return cached ? { ...cached } : null;
-}
-
-function initFamilyState(defaultValue: number): Record<ModelFamily, number> {
-	return Object.fromEntries(
-		MODEL_FAMILIES.map((family) => [family, defaultValue]),
-	) as Record<ModelFamily, number>;
-}
-
-export interface ManagedAccount {
-	index: number;
-	accountId?: string;
-	organizationId?: string;
-	accountIdSource?: AccountIdSource;
-	accountLabel?: string;
-	accountTags?: string[];
-	accountNote?: string;
-	email?: string;
-	refreshToken: string;
-	enabled?: boolean;
-	access?: string;
-	expires?: number;
-	addedAt: number;
-	lastUsed: number;
-	lastSwitchReason?: "rate-limit" | "initial" | "rotation";
-	lastRateLimitReason?: RateLimitReason;
-	rateLimitResetTimes: RateLimitStateV3;
-	coolingDownUntil?: number;
-	cooldownReason?: CooldownReason;
-}
-
-export interface AccountSelectionExplainability {
-	index: number;
-	enabled: boolean;
-	isCurrentForFamily: boolean;
-	eligible: boolean;
-	reasons: string[];
-	healthScore: number;
-	tokensAvailable: number;
-	rateLimitedUntil?: number;
-	coolingDownUntil?: number;
-	cooldownReason?: CooldownReason;
-	lastUsed: number;
-}
+export {
+	lookupCodexCliTokensByEmail,
+	type CodexCliTokenCacheEntry,
+} from "./accounts/recovery.js";
 
 export class AccountManager {
-	private accounts: ManagedAccount[] = [];
-	private cursorByFamily: Record<ModelFamily, number> = initFamilyState(0);
-	private currentAccountIndexByFamily: Record<ModelFamily, number> = initFamilyState(-1);
-	private lastToastAccountIndex = -1;
-	private lastToastTime = 0;
-	private saveDebounceTimer: ReturnType<typeof setTimeout> | null = null;
-	private pendingSave: Promise<void> | null = null;
-	private authFailuresByRefreshToken: Map<string, number> = new Map();
+	private readonly state: AccountState;
+	private readonly persistence: AccountPersistence;
+	private readonly rotation: AccountRotation;
+	private readonly recovery: AccountRecovery;
+
 	/**
-	 * Per-refresh-token promise chain used to serialize concurrent
-	 * `incrementAuthFailures` calls. Prevents lost updates when two org-variant
-	 * accounts that share a refresh token observe an auth failure at once — see
-	 * audit finding `docs/audits/03-critical-issues.md` (ledger id `47`).
+	 * Alias to `state.authFailuresByRefreshToken`. Preserved as a property on
+	 * the orchestrator so that pre-split tests and diagnostics that reach in
+	 * via `Reflect.get(manager, "authFailuresByRefreshToken")` continue to see
+	 * the live map without edits. Internal use only.
 	 */
-	private incrementAuthFailuresChain: Map<string, Promise<number>> = new Map();
-	private shutdownHandler: (() => Promise<void>) | null = null;
+	private get authFailuresByRefreshToken(): Map<string, number> {
+		return this.state.authFailuresByRefreshToken;
+	}
+
+	constructor(authFallback?: OAuthAuthDetails, stored?: AccountStorageV3 | null) {
+		this.state = new AccountState();
+		this.persistence = new AccountPersistence(this.state);
+		this.rotation = new AccountRotation(this.state);
+		this.recovery = new AccountRecovery(this.state, this.persistence);
+		this.state.initializeFromStorage(authFallback, stored);
+	}
 
 	static async loadFromDisk(authFallback?: OAuthAuthDetails): Promise<AccountManager> {
 		const stored = await loadAccounts();
 		const manager = new AccountManager(authFallback, stored);
-		await manager.hydrateFromCodexCli();
+		await manager.recovery.hydrateFromCodexCli();
 		return manager;
 	}
 
+	// ----- state delegations -----
+
 	hasRefreshToken(refreshToken: string): boolean {
-		return this.accounts.some((account) => account.refreshToken === refreshToken);
-	}
-
-	private async hydrateFromCodexCli(): Promise<void> {
-		const cache = await getCodexCliTokenCache();
-		if (!cache || cache.size === 0) return;
-
-		const now = nowMs();
-		let changed = false;
-
-		for (const account of this.accounts) {
-			const email = sanitizeEmail(account.email);
-			if (!email) continue;
-
-			const cached = cache.get(email);
-			if (!cached) continue;
-
-			if (typeof cached.expiresAt === "number" && cached.expiresAt <= now) {
-				continue;
-			}
-
-			const missingOrExpired =
-				!account.access || account.expires === undefined || account.expires <= now;
-			if (missingOrExpired) {
-				account.access = cached.accessToken;
-				if (typeof cached.expiresAt === "number") {
-					account.expires = cached.expiresAt;
-				}
-				changed = true;
-			}
-
-			if (
-				!account.accountId &&
-				cached.accountId &&
-				shouldUpdateAccountIdFromToken(account.accountIdSource, account.accountId)
-			) {
-				account.accountId = cached.accountId;
-				account.accountIdSource = account.accountIdSource ?? "token";
-				changed = true;
-			}
-		}
-
-		if (!changed) return;
-
-		try {
-			await this.saveToDisk();
-		} catch (error) {
-			log.debug("Failed to persist Codex CLI cache hydration", { error: String(error) });
-		}
-	}
-
-	constructor(authFallback?: OAuthAuthDetails, stored?: AccountStorageV3 | null) {
-		const fallbackAccountId = extractAccountId(authFallback?.access);
-		const fallbackAccountEmail = sanitizeEmail(extractAccountEmail(authFallback?.access));
-
-		if (stored && stored.accounts.length > 0) {
-			const baseNow = nowMs();
-			this.accounts = stored.accounts
-				.map((account, index): ManagedAccount | null => {
-					if (!account.refreshToken || typeof account.refreshToken !== "string") {
-						return null;
-					}
-
-					const matchesFallback =
-						!!authFallback &&
-						((fallbackAccountId && account.accountId === fallbackAccountId) ||
-							account.refreshToken === authFallback.refresh ||
-							(!!fallbackAccountEmail &&
-								sanitizeEmail(account.email) === fallbackAccountEmail));
-
-					const refreshToken = matchesFallback && authFallback ? authFallback.refresh : account.refreshToken;
- 
-					return {
-						index,
-						accountId: matchesFallback ? fallbackAccountId ?? account.accountId : account.accountId,
-						organizationId: account.organizationId,
-						accountIdSource: account.accountIdSource,
-						accountLabel: account.accountLabel,
-						accountTags: account.accountTags,
-						accountNote: account.accountNote,
-						email: matchesFallback
-							? fallbackAccountEmail ?? sanitizeEmail(account.email)
-							: sanitizeEmail(account.email),
-						refreshToken,
-						enabled: account.enabled !== false,
-						access: matchesFallback && authFallback ? authFallback.access : account.accessToken,
-						expires: matchesFallback && authFallback ? authFallback.expires : account.expiresAt,
-						addedAt: clampNonNegativeInt(account.addedAt, baseNow),
-						lastUsed: clampNonNegativeInt(account.lastUsed, 0),
-						lastSwitchReason: account.lastSwitchReason,
-						rateLimitResetTimes: account.rateLimitResetTimes ?? {},
-						coolingDownUntil: account.coolingDownUntil,
-						cooldownReason: account.cooldownReason,
-					};
-				})
-				.filter((account): account is ManagedAccount => account !== null);
-
-			const hasMatchingFallback =
-				!!authFallback &&
-				this.accounts.some(
-					(account) =>
-						account.refreshToken === authFallback.refresh ||
-						(fallbackAccountId && account.accountId === fallbackAccountId) ||
-						(!!fallbackAccountEmail && account.email === fallbackAccountEmail),
-				);
-
-			if (authFallback && !hasMatchingFallback) {
-				const now = nowMs();
-				this.accounts.push({
-					index: this.accounts.length,
-					accountId: fallbackAccountId,
-					organizationId: undefined,
-					accountIdSource: fallbackAccountId ? "token" : undefined,
-					email: fallbackAccountEmail,
-					refreshToken: authFallback.refresh,
-					enabled: true,
-					access: authFallback.access,
-					expires: authFallback.expires,
-					addedAt: now,
-					lastUsed: now,
-					lastSwitchReason: "initial",
-					rateLimitResetTimes: {},
-				});
-			}
-
-			if (this.accounts.length > 0) {
-				const defaultIndex = clampNonNegativeInt(stored.activeIndex, 0) % this.accounts.length;
-
-				for (const family of MODEL_FAMILIES) {
-					const rawIndex = stored.activeIndexByFamily?.[family];
-					const nextIndex = clampNonNegativeInt(rawIndex, defaultIndex) % this.accounts.length;
-					this.currentAccountIndexByFamily[family] = nextIndex;
-					this.cursorByFamily[family] = nextIndex;
-				}
-			}
-			return;
-		}
-
-		if (authFallback) {
-			const now = nowMs();
-			this.accounts = [
-				{
-					index: 0,
-					accountId: fallbackAccountId,
-					organizationId: undefined,
-					accountIdSource: fallbackAccountId ? "token" : undefined,
-					email: fallbackAccountEmail,
-					refreshToken: authFallback.refresh,
-					enabled: true,
-					access: authFallback.access,
-					expires: authFallback.expires,
-					addedAt: now,
-					lastUsed: 0,
-					lastSwitchReason: "initial",
-					rateLimitResetTimes: {},
-				},
-			];
-			for (const family of MODEL_FAMILIES) {
-				this.currentAccountIndexByFamily[family] = 0;
-				this.cursorByFamily[family] = 0;
-			}
-		}
+		return this.state.hasRefreshToken(refreshToken);
 	}
 
 	getAccountCount(): number {
-		return this.accounts.length;
+		return this.state.getAccountCount();
 	}
 
 	getActiveIndex(): number {
-		return this.getActiveIndexForFamily("codex");
+		return this.state.getActiveIndexForFamily("codex");
 	}
 
 	getActiveIndexForFamily(family: ModelFamily): number {
-		const index = this.currentAccountIndexByFamily[family];
-		if (index < 0 || index >= this.accounts.length) {
-			return this.accounts.length > 0 ? 0 : -1;
-		}
-		return index;
+		return this.state.getActiveIndexForFamily(family);
 	}
 
 	getAccountsSnapshot(): ManagedAccount[] {
-		return this.accounts.map((account) => ({
-			...account,
-			rateLimitResetTimes: { ...account.rateLimitResetTimes },
-		}));
+		return this.state.getAccountsSnapshot();
 	}
 
 	getSelectionExplainability(
@@ -445,256 +121,137 @@ export class AccountManager {
 		model?: string | null,
 		now = nowMs(),
 	): AccountSelectionExplainability[] {
-		const quotaKey = model ? `${family}:${model}` : family;
-		const baseQuotaKey = getQuotaKey(family);
-		const modelQuotaKey = model ? getQuotaKey(family, model) : null;
-		const currentIndex = this.currentAccountIndexByFamily[family];
-		const healthTracker = getHealthTracker();
-		const tokenTracker = getTokenTracker();
-
-		return this.accounts.map((account) => {
-			clearExpiredRateLimits(account);
-			const enabled = account.enabled !== false;
-			const reasons: string[] = [];
-			let rateLimitedUntil: number | undefined;
-			const baseRateLimit = account.rateLimitResetTimes[baseQuotaKey];
-			const modelRateLimit = modelQuotaKey ? account.rateLimitResetTimes[modelQuotaKey] : undefined;
-			if (typeof baseRateLimit === "number" && baseRateLimit > now) {
-				rateLimitedUntil = baseRateLimit;
-			}
-			if (
-				typeof modelRateLimit === "number" &&
-				modelRateLimit > now &&
-				(rateLimitedUntil === undefined || modelRateLimit > rateLimitedUntil)
-			) {
-				rateLimitedUntil = modelRateLimit;
-			}
-
-			const coolingDownUntil =
-				typeof account.coolingDownUntil === "number" && account.coolingDownUntil > now
-					? account.coolingDownUntil
-					: undefined;
-
-			if (!enabled) reasons.push("disabled");
-			if (rateLimitedUntil !== undefined) reasons.push("rate-limited");
-			if (coolingDownUntil !== undefined) {
-				reasons.push(
-					account.cooldownReason ? `cooldown:${account.cooldownReason}` : "cooldown",
-				);
-			}
-
-			const tokensAvailable = tokenTracker.getTokens(account.index, quotaKey);
-			if (tokensAvailable < 1) reasons.push("token-bucket-empty");
-
-			const eligible =
-				enabled &&
-				rateLimitedUntil === undefined &&
-				coolingDownUntil === undefined &&
-				tokensAvailable >= 1;
-			if (reasons.length === 0) reasons.push("eligible");
-
-			return {
-				index: account.index,
-				enabled,
-				isCurrentForFamily: currentIndex === account.index,
-				eligible,
-				reasons,
-				healthScore: healthTracker.getScore(account.index, quotaKey),
-				tokensAvailable,
-				rateLimitedUntil,
-				coolingDownUntil,
-				cooldownReason: coolingDownUntil !== undefined ? account.cooldownReason : undefined,
-				lastUsed: account.lastUsed,
-			};
-		});
+		return this.state.getSelectionExplainability(family, model, now);
 	}
 
 	setActiveIndex(index: number): ManagedAccount | null {
-		if (!Number.isFinite(index)) return null;
-		if (index < 0 || index >= this.accounts.length) return null;
-		const account = this.accounts[index];
-		if (!account) return null;
-		if (account.enabled === false) return null;
-
-		for (const family of MODEL_FAMILIES) {
-			this.currentAccountIndexByFamily[family] = index;
-			this.cursorByFamily[family] = index;
-		}
-
-		account.lastUsed = nowMs();
-		account.lastSwitchReason = "rotation";
-		return account;
+		return this.state.setActiveIndex(index);
 	}
 
 	getCurrentAccount(): ManagedAccount | null {
-		return this.getCurrentAccountForFamily("codex");
+		return this.state.getCurrentAccountForFamily("codex");
 	}
 
 	getCurrentAccountForFamily(family: ModelFamily): ManagedAccount | null {
-		const index = this.currentAccountIndexByFamily[family];
-		if (index < 0 || index >= this.accounts.length) {
-			return null;
-		}
-		const account = this.accounts[index];
-		if (!account || account.enabled === false) {
-			return null;
-		}
-		return account;
+		return this.state.getCurrentAccountForFamily(family);
 	}
+
+	shouldShowAccountToast(accountIndex: number, debounceMs = 30000): boolean {
+		return this.state.shouldShowAccountToast(accountIndex, debounceMs);
+	}
+
+	markToastShown(accountIndex: number): void {
+		this.state.markToastShown(accountIndex);
+	}
+
+	updateFromAuth(account: ManagedAccount, auth: OAuthAuthDetails): void {
+		this.state.updateFromAuth(account, auth);
+	}
+
+	toAuthDetails(account: ManagedAccount): Auth {
+		return this.state.toAuthDetails(account);
+	}
+
+	markSwitched(
+		account: ManagedAccount,
+		reason: "rate-limit" | "initial" | "rotation",
+		family: ModelFamily,
+	): void {
+		this.state.markSwitched(account, reason, family);
+	}
+
+	removeAccount(account: ManagedAccount): boolean {
+		return this.state.removeAccount(account);
+	}
+
+	removeAccountByIndex(index: number): boolean {
+		return this.state.removeAccountByIndex(index);
+	}
+
+	setAccountEnabled(index: number, enabled: boolean): ManagedAccount | null {
+		return this.state.setAccountEnabled(index, enabled);
+	}
+
+	isAccountCoolingDown(account: ManagedAccount): boolean {
+		return this.state.isAccountCoolingDown(account);
+	}
+
+	clearAccountCooldown(account: ManagedAccount): void {
+		this.state.clearAccountCooldown(account);
+	}
+
+	// ----- rotation delegations -----
 
 	getCurrentOrNext(): ManagedAccount | null {
-		return this.getCurrentOrNextForFamily("codex");
+		return this.rotation.getCurrentOrNextForFamily("codex");
 	}
 
-	getCurrentOrNextForFamily(family: ModelFamily, model?: string | null): ManagedAccount | null {
-		const count = this.accounts.length;
-		if (count === 0) return null;
-
-		const cursor = this.cursorByFamily[family];
-		
-		for (let i = 0; i < count; i++) {
-			const idx = (cursor + i) % count;
-			const account = this.accounts[idx];
-			if (!account) continue;
-			if (account.enabled === false) continue;
-			
-			clearExpiredRateLimits(account);
-			if (isRateLimitedForFamily(account, family, model) || this.isAccountCoolingDown(account)) {
-				continue;
-			}
-			
-			this.cursorByFamily[family] = (idx + 1) % count;
-			this.currentAccountIndexByFamily[family] = idx;
-			account.lastUsed = nowMs();
-			return account;
-		}
-
-		return null;
+	getCurrentOrNextForFamily(
+		family: ModelFamily,
+		model?: string | null,
+	): ManagedAccount | null {
+		return this.rotation.getCurrentOrNextForFamily(family, model);
 	}
 
 	getNextForFamily(family: ModelFamily, model?: string | null): ManagedAccount | null {
-		const count = this.accounts.length;
-		if (count === 0) return null;
-
-		const cursor = this.cursorByFamily[family];
-		
-		for (let i = 0; i < count; i++) {
-			const idx = (cursor + i) % count;
-			const account = this.accounts[idx];
-			if (!account) continue;
-			if (account.enabled === false) continue;
-			
-			clearExpiredRateLimits(account);
-			if (isRateLimitedForFamily(account, family, model) || this.isAccountCoolingDown(account)) {
-				continue;
-			}
-			
-			this.cursorByFamily[family] = (idx + 1) % count;
-			account.lastUsed = nowMs();
-			return account;
-		}
-
-		return null;
+		return this.rotation.getNextForFamily(family, model);
 	}
 
-	getCurrentOrNextForFamilyHybrid(family: ModelFamily, model?: string | null, options?: HybridSelectionOptions): ManagedAccount | null {
-		const count = this.accounts.length;
-		if (count === 0) return null;
-
-		const currentIndex = this.currentAccountIndexByFamily[family];
-		if (currentIndex >= 0 && currentIndex < count) {
-			const currentAccount = this.accounts[currentIndex];
-			if (currentAccount) {
-				if (currentAccount.enabled === false) {
-					// Fall through to hybrid selection.
-				} else {
-				clearExpiredRateLimits(currentAccount);
-				if (
-					!isRateLimitedForFamily(currentAccount, family, model) &&
-					!this.isAccountCoolingDown(currentAccount)
-				) {
-					currentAccount.lastUsed = nowMs();
-					return currentAccount;
-				}
-				}
-			}
-		}
-
-		const quotaKey = model ? `${family}:${model}` : family;
-		const healthTracker = getHealthTracker();
-		const tokenTracker = getTokenTracker();
-
-		const accountsWithMetrics: AccountWithMetrics[] = this.accounts
-			.map((account): AccountWithMetrics | null => {
-				if (!account) return null;
-				if (account.enabled === false) return null;
-				clearExpiredRateLimits(account);
-				const isAvailable =
-					!isRateLimitedForFamily(account, family, model) && !this.isAccountCoolingDown(account);
-				return {
-					index: account.index,
-					isAvailable,
-					lastUsed: account.lastUsed,
-				};
-			})
-			.filter((a): a is AccountWithMetrics => a !== null);
-
-		const selected = selectHybridAccount(accountsWithMetrics, healthTracker, tokenTracker, quotaKey, {}, options);
-		if (!selected) return null;
-
-		const account = this.accounts[selected.index];
-		if (!account) return null;
-
-		this.currentAccountIndexByFamily[family] = account.index;
-		this.cursorByFamily[family] = (account.index + 1) % count;
-		account.lastUsed = nowMs();
-		return account;
+	getCurrentOrNextForFamilyHybrid(
+		family: ModelFamily,
+		model?: string | null,
+		options?: HybridSelectionOptions,
+	): ManagedAccount | null {
+		return this.rotation.getCurrentOrNextForFamilyHybrid(family, model, options);
 	}
 
-	recordSuccess(account: ManagedAccount, family: ModelFamily, model?: string | null): void {
-		const quotaKey = model ? `${family}:${model}` : family;
-		const healthTracker = getHealthTracker();
-		healthTracker.recordSuccess(account.index, quotaKey);
+	recordSuccess(
+		account: ManagedAccount,
+		family: ModelFamily,
+		model?: string | null,
+	): void {
+		this.rotation.recordSuccess(account, family, model);
 	}
 
-	recordRateLimit(account: ManagedAccount, family: ModelFamily, model?: string | null): void {
-		const quotaKey = model ? `${family}:${model}` : family;
-		const healthTracker = getHealthTracker();
-		const tokenTracker = getTokenTracker();
-		healthTracker.recordRateLimit(account.index, quotaKey);
-		tokenTracker.drain(account.index, quotaKey);
+	recordRateLimit(
+		account: ManagedAccount,
+		family: ModelFamily,
+		model?: string | null,
+	): void {
+		this.rotation.recordRateLimit(account, family, model);
 	}
 
-	recordFailure(account: ManagedAccount, family: ModelFamily, model?: string | null): void {
-		const quotaKey = model ? `${family}:${model}` : family;
-		const healthTracker = getHealthTracker();
-		healthTracker.recordFailure(account.index, quotaKey);
+	recordFailure(
+		account: ManagedAccount,
+		family: ModelFamily,
+		model?: string | null,
+	): void {
+		this.rotation.recordFailure(account, family, model);
 	}
 
-	consumeToken(account: ManagedAccount, family: ModelFamily, model?: string | null): boolean {
-		const quotaKey = model ? `${family}:${model}` : family;
-		const tokenTracker = getTokenTracker();
-		return tokenTracker.tryConsume(account.index, quotaKey);
+	consumeToken(
+		account: ManagedAccount,
+		family: ModelFamily,
+		model?: string | null,
+	): boolean {
+		return this.rotation.consumeToken(account, family, model);
 	}
 
-	/**
-	 * Refund a token consumed within the refund window (30 seconds).
-	 * Use this when a request fails due to network errors (not rate limits).
-	 * @returns true if refund was successful, false if no valid consumption found
-	 */
-	refundToken(account: ManagedAccount, family: ModelFamily, model?: string | null): boolean {
-		const quotaKey = model ? `${family}:${model}` : family;
-		const tokenTracker = getTokenTracker();
-		return tokenTracker.refundToken(account.index, quotaKey);
+	refundToken(
+		account: ManagedAccount,
+		family: ModelFamily,
+		model?: string | null,
+	): boolean {
+		return this.rotation.refundToken(account, family, model);
 	}
 
-	markSwitched(account: ManagedAccount, reason: "rate-limit" | "initial" | "rotation", family: ModelFamily): void {
-		account.lastSwitchReason = reason;
-		this.currentAccountIndexByFamily[family] = account.index;
-	}
-
-	markRateLimited(account: ManagedAccount, retryAfterMs: number, family: ModelFamily, model?: string | null): void {
-		this.markRateLimitedWithReason(account, retryAfterMs, family, "unknown", model);
+	markRateLimited(
+		account: ManagedAccount,
+		retryAfterMs: number,
+		family: ModelFamily,
+		model?: string | null,
+	): void {
+		this.rotation.markRateLimited(account, retryAfterMs, family, model);
 	}
 
 	markRateLimitedWithReason(
@@ -704,395 +261,71 @@ export class AccountManager {
 		reason: RateLimitReason,
 		model?: string | null,
 	): void {
-		const retryMs = Math.max(0, Math.floor(retryAfterMs));
-		const resetAt = nowMs() + retryMs;
-
-		const baseKey = getQuotaKey(family);
-		account.rateLimitResetTimes[baseKey] = resetAt;
-
-		if (model) {
-			const modelKey = getQuotaKey(family, model);
-			account.rateLimitResetTimes[modelKey] = resetAt;
-		}
-
-		account.lastRateLimitReason = reason;
+		this.rotation.markRateLimitedWithReason(account, retryAfterMs, family, reason, model);
 	}
 
-	markAccountCoolingDown(account: ManagedAccount, cooldownMs: number, reason: CooldownReason): void {
-		const ms = Math.max(0, Math.floor(cooldownMs));
-		account.coolingDownUntil = nowMs() + ms;
-		account.cooldownReason = reason;
+	markAccountCoolingDown(
+		account: ManagedAccount,
+		cooldownMs: number,
+		reason: CooldownReason,
+	): void {
+		this.rotation.markAccountCoolingDown(account, cooldownMs, reason);
 	}
 
-	/**
-	 * Mark every in-memory account sharing a refresh token as cooling down.
-	 * @returns Number of live accounts updated.
-	 */
 	markAccountsWithRefreshTokenCoolingDown(
 		refreshToken: string,
 		cooldownMs: number,
 		reason: CooldownReason,
 	): number {
-		const matches = this.accounts.filter((account) => account.refreshToken === refreshToken);
-		for (const account of matches) {
-			this.markAccountCoolingDown(account, cooldownMs, reason);
-		}
-		return matches.length;
-	}
-
-	isAccountCoolingDown(account: ManagedAccount): boolean {
-		if (account.coolingDownUntil === undefined) return false;
-		if (nowMs() >= account.coolingDownUntil) {
-			this.clearAccountCooldown(account);
-			return false;
-		}
-		return true;
-	}
-
-	clearAccountCooldown(account: ManagedAccount): void {
-		delete account.coolingDownUntil;
-		delete account.cooldownReason;
-	}
-
-	/**
-	 * Atomically increment the auth-failure counter for the account's refresh
-	 * token and return the post-increment value.
-	 *
-	 * The read-modify-write is serialized through a per-refresh-token promise
-	 * chain so that concurrent callers (for example, two org-variant accounts
-	 * sharing a refresh token that fail auth simultaneously) cannot lose an
-	 * increment. Without serialization both callers could read the same stale
-	 * value, both compute `+1`, and both write the same result — masking a hard
-	 * auth failure and causing the manager to keep hammering a dead token.
-	 *
-	 * Callers must `await` the returned promise before branching on the
-	 * threshold (see `index.ts` auth-refresh failure path).
-	 */
-	async incrementAuthFailures(account: ManagedAccount): Promise<number> {
-		const key = account.refreshToken;
-		const prev = this.incrementAuthFailuresChain.get(key) ?? Promise.resolve(0);
-		const next = prev.then(() => {
-			const currentFailures = this.authFailuresByRefreshToken.get(key) ?? 0;
-			const newFailures = currentFailures + 1;
-			this.authFailuresByRefreshToken.set(key, newFailures);
-			return newFailures;
-		});
-		this.incrementAuthFailuresChain.set(key, next);
-		try {
-			return await next;
-		} finally {
-			// Drop the chain entry only if no later caller has already replaced it.
-			if (this.incrementAuthFailuresChain.get(key) === next) {
-				this.incrementAuthFailuresChain.delete(key);
-			}
-		}
-	}
-
-	/**
-	 * Return the current auth-failure counter for the account's refresh token
-	 * without mutating state. Intended for tests and diagnostics.
-	 */
-	getAuthFailures(account: ManagedAccount): number {
-		return this.authFailuresByRefreshToken.get(account.refreshToken) ?? 0;
-	}
-
-	/**
-	 * Clear the authentication failure counter for the given account's refresh token.
-	 *
-	 * Notes:
-	 * - Failure counts are tracked per refresh token (not per account), so this clears
-	 *   shared failure state for all org variants that reuse the same token.
-	 * - Failure counts are in-memory only for the current AccountManager instance.
-	 */
-	clearAuthFailures(account: ManagedAccount): void {
-		this.authFailuresByRefreshToken.delete(account.refreshToken);
-	}
-
-	shouldShowAccountToast(accountIndex: number, debounceMs = 30000): boolean {
-		const now = nowMs();
-		if (accountIndex === this.lastToastAccountIndex && now - this.lastToastTime < debounceMs) {
-			return false;
-		}
-		return true;
-	}
-
-	markToastShown(accountIndex: number): void {
-		this.lastToastAccountIndex = accountIndex;
-		this.lastToastTime = nowMs();
-	}
-
-	updateFromAuth(account: ManagedAccount, auth: OAuthAuthDetails): void {
-		const previousRefreshToken = account.refreshToken;
-		account.refreshToken = auth.refresh;
-		account.access = auth.access;
-		account.expires = auth.expires;
-		if (previousRefreshToken !== account.refreshToken) {
-			this.authFailuresByRefreshToken.delete(previousRefreshToken);
-		}
-		const tokenAccountId = extractAccountId(auth.access);
-		if (
-			tokenAccountId &&
-			(shouldUpdateAccountIdFromToken(account.accountIdSource, account.accountId))
-		) {
-			account.accountId = tokenAccountId;
-			account.accountIdSource = "token";
-		}
-		account.email = sanitizeEmail(extractAccountEmail(auth.access)) ?? account.email;
-	}
-
-	toAuthDetails(account: ManagedAccount): Auth {
-		return {
-			type: "oauth",
-			access: account.access ?? "",
-			refresh: account.refreshToken,
-			expires: account.expires ?? 0,
-		};
+		return this.rotation.markAccountsWithRefreshTokenCoolingDown(
+			refreshToken,
+			cooldownMs,
+			reason,
+		);
 	}
 
 	getMinWaitTime(): number {
-		return this.getMinWaitTimeForFamily("codex");
+		return this.rotation.getMinWaitTimeForFamily("codex");
 	}
 
 	getMinWaitTimeForFamily(family: ModelFamily, model?: string | null): number {
-		const now = nowMs();
-		const enabledAccounts = this.accounts.filter((account) => account.enabled !== false);
-		const available = enabledAccounts.filter((account) => {
-			clearExpiredRateLimits(account);
-			return !isRateLimitedForFamily(account, family, model) && !this.isAccountCoolingDown(account);
-		});
-		if (available.length > 0) return 0;
-		if (enabledAccounts.length === 0) return 0;
-
-		const waitTimes: number[] = [];
-		const baseKey = getQuotaKey(family);
-		const modelKey = model ? getQuotaKey(family, model) : null;
-
-		for (const account of enabledAccounts) {
-			const baseResetAt = account.rateLimitResetTimes[baseKey];
-			if (typeof baseResetAt === "number") {
-				waitTimes.push(Math.max(0, baseResetAt - now));
-			}
-
-			if (modelKey) {
-				const modelResetAt = account.rateLimitResetTimes[modelKey];
-				if (typeof modelResetAt === "number") {
-					waitTimes.push(Math.max(0, modelResetAt - now));
-				}
-			}
-
-			if (typeof account.coolingDownUntil === "number") {
-				waitTimes.push(Math.max(0, account.coolingDownUntil - now));
-			}
-		}
-
-		return waitTimes.length > 0 ? Math.min(...waitTimes) : 0;
+		return this.rotation.getMinWaitTimeForFamily(family, model);
 	}
 
-	removeAccount(account: ManagedAccount): boolean {
-		const idx = this.accounts.indexOf(account);
-		if (idx < 0) {
-			return false;
-		}
-
-		this.accounts.splice(idx, 1);
-		this.accounts.forEach((acc, index) => {
-			acc.index = index;
-		});
-
-		if (this.accounts.length === 0) {
-			for (const family of MODEL_FAMILIES) {
-				this.cursorByFamily[family] = 0;
-				this.currentAccountIndexByFamily[family] = -1;
-			}
-			return true;
-		}
-
-		for (const family of MODEL_FAMILIES) {
-			if (this.cursorByFamily[family] > idx) {
-				this.cursorByFamily[family] = Math.max(0, this.cursorByFamily[family] - 1);
-			}
-		}
-		for (const family of MODEL_FAMILIES) {
-			this.cursorByFamily[family] = this.cursorByFamily[family] % this.accounts.length;
-		}
-
-		for (const family of MODEL_FAMILIES) {
-			if (this.currentAccountIndexByFamily[family] > idx) {
-				this.currentAccountIndexByFamily[family] -= 1;
-			}
-			if (this.currentAccountIndexByFamily[family] >= this.accounts.length) {
-				this.currentAccountIndexByFamily[family] = -1;
-			}
-		}
-
-		return true;
-	}
-
-	removeAccountByIndex(index: number): boolean {
-		if (!Number.isFinite(index)) return false;
-		if (index < 0 || index >= this.accounts.length) return false;
-		const account = this.accounts[index];
-		if (!account) return false;
-		return this.removeAccount(account);
-	}
-
-	/**
-	 * Remove all accounts that share the same refreshToken as the given account.
-	 * This is used when auth refresh fails to remove all org variants together.
-	 * @returns Number of accounts removed
-	 */
-	removeAccountsWithSameRefreshToken(account: ManagedAccount): number {
-		const refreshToken = account.refreshToken;
-		// Snapshot first because removeAccount mutates this.accounts.
-		const accountsToRemove = this.accounts.filter((acc) => acc.refreshToken === refreshToken);
-		let removedCount = 0;
-
-		for (const accountToRemove of accountsToRemove) {
-			if (this.removeAccount(accountToRemove)) {
-				removedCount++;
-			}
-		}
-
-		// Clear stale auth failure state for this refresh token
-		this.authFailuresByRefreshToken.delete(refreshToken);
-
-		return removedCount;
-	}
-
-	setAccountEnabled(index: number, enabled: boolean): ManagedAccount | null {
-		if (!Number.isFinite(index)) return null;
-		if (index < 0 || index >= this.accounts.length) return null;
-		const account = this.accounts[index];
-		if (!account) return null;
-		account.enabled = enabled;
-		return account;
-	}
+	// ----- persistence delegations -----
 
 	async saveToDisk(): Promise<void> {
-		const activeIndexByFamily: Partial<Record<ModelFamily, number>> = {};
-		for (const family of MODEL_FAMILIES) {
-			const raw = this.currentAccountIndexByFamily[family];
-			activeIndexByFamily[family] = clampNonNegativeInt(raw, 0);
-		}
-
-		const activeIndex = clampNonNegativeInt(activeIndexByFamily.codex, 0);
-
-		const storage: AccountStorageV3 = {
-			version: 3,
-			accounts: this.accounts.map((account) => ({
-				accountId: account.accountId,
-				organizationId: account.organizationId,
-				accountIdSource: account.accountIdSource,
-				accountLabel: account.accountLabel,
-				accountTags: account.accountTags,
-				accountNote: account.accountNote,
-				email: account.email,
-				refreshToken: account.refreshToken,
-				accessToken: account.access,
-				expiresAt: account.expires,
-				enabled: account.enabled === false ? false : undefined,
-				addedAt: account.addedAt,
-				lastUsed: account.lastUsed,
-				lastSwitchReason: account.lastSwitchReason,
-				rateLimitResetTimes:
-					Object.keys(account.rateLimitResetTimes).length > 0 ? account.rateLimitResetTimes : undefined,
-				coolingDownUntil: account.coolingDownUntil,
-				cooldownReason: account.cooldownReason,
-			})),
-			activeIndex,
-			activeIndexByFamily,
-		};
-
-		await saveAccounts(storage);
+		await this.persistence.saveToDisk();
 	}
 
 	saveToDiskDebounced(delayMs = 500): void {
-		this.ensureShutdownFlushRegistered();
-		if (this.saveDebounceTimer) {
-			clearTimeout(this.saveDebounceTimer);
-		}
-		this.saveDebounceTimer = setTimeout(() => {
-			this.saveDebounceTimer = null;
-			const doSave = async () => {
-				try {
-					if (this.pendingSave) {
-						await this.pendingSave;
-					}
-					this.pendingSave = this.saveToDisk().finally(() => {
-						this.pendingSave = null;
-					});
-					await this.pendingSave;
-				} catch (error) {
-					log.warn("Debounced save failed", { error: error instanceof Error ? error.message : String(error) });
-				}
-			};
-			void doSave();
-		}, delayMs);
+		this.persistence.saveToDiskDebounced(delayMs);
 	}
 
 	async flushPendingSave(): Promise<void> {
-		if (this.saveDebounceTimer) {
-			clearTimeout(this.saveDebounceTimer);
-			this.saveDebounceTimer = null;
-			await this.saveToDisk();
-		}
-		if (this.pendingSave) {
-			await this.pendingSave;
-		}
+		await this.persistence.flushPendingSave();
 	}
 
-	/**
-	 * Registers a process-shutdown cleanup that awaits any pending debounced
-	 * save. Without this, a rotation queued inside the 500ms debounce window
-	 * would be lost when SIGINT/SIGTERM fires before the timer resolves.
-	 * Registration is lazy (only when `saveToDiskDebounced` is first invoked)
-	 * so idle managers do not leak handlers into the shutdown queue.
-	 */
-	private ensureShutdownFlushRegistered(): void {
-		if (this.shutdownHandler) return;
-		const handler = async (): Promise<void> => {
-			// One-shot: clear the slot first so that if `runCleanup()` fires
-			// externally (e.g. tests reusing a manager across cycles, or any
-			// other caller that drains the global cleanup queue), a subsequent
-			// `saveToDiskDebounced()` can re-register a fresh handler. Without
-			// this the guard above returns early and the next pending save
-			// goes unprotected on shutdown.
-			this.shutdownHandler = null;
-			let timeoutTimer: ReturnType<typeof setTimeout> | null = null;
-			try {
-				await Promise.race([
-					this.flushPendingSave(),
-					new Promise<void>((_resolve, reject) => {
-						timeoutTimer = setTimeout(() => {
-							reject(
-								new Error(
-									`flushPendingSave timed out after ${SHUTDOWN_FLUSH_TIMEOUT_MS}ms`,
-								),
-							);
-						}, SHUTDOWN_FLUSH_TIMEOUT_MS);
-					}),
-				]);
-			} catch (error) {
-				log.warn("Shutdown flush failed", {
-					error: error instanceof Error ? error.message : String(error),
-				});
-			} finally {
-				if (timeoutTimer) clearTimeout(timeoutTimer);
-			}
-		};
-		this.shutdownHandler = handler;
-		registerCleanup(handler);
-	}
-
-	/**
-	 * Removes this manager's shutdown cleanup registration. Call this when
-	 * replacing an `AccountManager` instance (e.g., on cache invalidation)
-	 * to avoid unbounded growth of the global cleanup queue.
-	 */
 	disposeShutdownHandler(): void {
-		if (!this.shutdownHandler) return;
-		unregisterCleanup(this.shutdownHandler);
-		this.shutdownHandler = null;
+		this.persistence.disposeShutdownHandler();
+	}
+
+	// ----- recovery delegations -----
+
+	async incrementAuthFailures(account: ManagedAccount): Promise<number> {
+		return this.recovery.incrementAuthFailures(account);
+	}
+
+	getAuthFailures(account: ManagedAccount): number {
+		return this.recovery.getAuthFailures(account);
+	}
+
+	clearAuthFailures(account: ManagedAccount): void {
+		this.recovery.clearAuthFailures(account);
+	}
+
+	removeAccountsWithSameRefreshToken(account: ManagedAccount): number {
+		return this.recovery.removeAccountsWithSameRefreshToken(account);
 	}
 }
 
@@ -1103,7 +336,11 @@ export function formatAccountLabel(
 	const accountLabel = account?.accountLabel?.trim();
 	const email = account?.email?.trim();
 	const accountId = account?.accountId?.trim();
-	const idSuffix = accountId ? (accountId.length > 6 ? accountId.slice(-6) : accountId) : null;
+	const idSuffix = accountId
+		? accountId.length > 6
+			? accountId.slice(-6)
+			: accountId
+		: null;
 
 	if (accountLabel && email && idSuffix) {
 		return `Account ${index + 1} (${accountLabel}, ${email}, id:${idSuffix})`;

--- a/lib/accounts/persistence.ts
+++ b/lib/accounts/persistence.ts
@@ -1,0 +1,162 @@
+/**
+ * Persistence surface for {@link AccountManager}: debounced disk saves,
+ * pending-save coalescing, and shutdown-flush registration.
+ *
+ * All on-disk format concerns live in `lib/storage.ts`. This module owns the
+ * *lifecycle* (when to save, how to flush before exit, how to dispose the
+ * shutdown hook) rather than the serialization shape itself.
+ */
+
+import { createLogger } from "../logger.js";
+import { MODEL_FAMILIES, type ModelFamily } from "../prompts/codex.js";
+import { registerCleanup, unregisterCleanup } from "../shutdown.js";
+import { saveAccounts, type AccountStorageV3 } from "../storage.js";
+import { clampNonNegativeInt } from "./rate-limits.js";
+import type { AccountState } from "./state.js";
+
+const log = createLogger("accounts");
+
+/**
+ * Upper bound the shutdown handler will wait for `flushPendingSave` so that a
+ * jammed save cannot stall SIGINT/SIGTERM indefinitely.
+ */
+const SHUTDOWN_FLUSH_TIMEOUT_MS = 5_000;
+
+export class AccountPersistence {
+	private saveDebounceTimer: ReturnType<typeof setTimeout> | null = null;
+	private pendingSave: Promise<void> | null = null;
+	private shutdownHandler: (() => Promise<void>) | null = null;
+
+	constructor(private readonly state: AccountState) {}
+
+	async saveToDisk(): Promise<void> {
+		const activeIndexByFamily: Partial<Record<ModelFamily, number>> = {};
+		for (const family of MODEL_FAMILIES) {
+			const raw = this.state.currentAccountIndexByFamily[family];
+			activeIndexByFamily[family] = clampNonNegativeInt(raw, 0);
+		}
+
+		const activeIndex = clampNonNegativeInt(activeIndexByFamily.codex, 0);
+
+		const storage: AccountStorageV3 = {
+			version: 3,
+			accounts: this.state.accounts.map((account) => ({
+				accountId: account.accountId,
+				organizationId: account.organizationId,
+				accountIdSource: account.accountIdSource,
+				accountLabel: account.accountLabel,
+				accountTags: account.accountTags,
+				accountNote: account.accountNote,
+				email: account.email,
+				refreshToken: account.refreshToken,
+				accessToken: account.access,
+				expiresAt: account.expires,
+				enabled: account.enabled === false ? false : undefined,
+				addedAt: account.addedAt,
+				lastUsed: account.lastUsed,
+				lastSwitchReason: account.lastSwitchReason,
+				rateLimitResetTimes:
+					Object.keys(account.rateLimitResetTimes).length > 0
+						? account.rateLimitResetTimes
+						: undefined,
+				coolingDownUntil: account.coolingDownUntil,
+				cooldownReason: account.cooldownReason,
+			})),
+			activeIndex,
+			activeIndexByFamily,
+		};
+
+		await saveAccounts(storage);
+	}
+
+	saveToDiskDebounced(delayMs = 500): void {
+		this.ensureShutdownFlushRegistered();
+		if (this.saveDebounceTimer) {
+			clearTimeout(this.saveDebounceTimer);
+		}
+		this.saveDebounceTimer = setTimeout(() => {
+			this.saveDebounceTimer = null;
+			const doSave = async () => {
+				try {
+					if (this.pendingSave) {
+						await this.pendingSave;
+					}
+					this.pendingSave = this.saveToDisk().finally(() => {
+						this.pendingSave = null;
+					});
+					await this.pendingSave;
+				} catch (error) {
+					log.warn("Debounced save failed", {
+						error: error instanceof Error ? error.message : String(error),
+					});
+				}
+			};
+			void doSave();
+		}, delayMs);
+	}
+
+	async flushPendingSave(): Promise<void> {
+		if (this.saveDebounceTimer) {
+			clearTimeout(this.saveDebounceTimer);
+			this.saveDebounceTimer = null;
+			await this.saveToDisk();
+		}
+		if (this.pendingSave) {
+			await this.pendingSave;
+		}
+	}
+
+	/**
+	 * Registers a process-shutdown cleanup that awaits any pending debounced
+	 * save. Without this, a rotation queued inside the 500ms debounce window
+	 * would be lost when SIGINT/SIGTERM fires before the timer resolves.
+	 * Registration is lazy (only when `saveToDiskDebounced` is first invoked)
+	 * so idle managers do not leak handlers into the shutdown queue.
+	 */
+	private ensureShutdownFlushRegistered(): void {
+		if (this.shutdownHandler) return;
+		const handler = async (): Promise<void> => {
+			// One-shot: clear the slot first so that if `runCleanup()` fires
+			// externally (e.g. tests reusing a manager across cycles, or any
+			// other caller that drains the global cleanup queue), a subsequent
+			// `saveToDiskDebounced()` can re-register a fresh handler. Without
+			// this the guard above returns early and the next pending save
+			// goes unprotected on shutdown.
+			this.shutdownHandler = null;
+			let timeoutTimer: ReturnType<typeof setTimeout> | null = null;
+			try {
+				await Promise.race([
+					this.flushPendingSave(),
+					new Promise<void>((_resolve, reject) => {
+						timeoutTimer = setTimeout(() => {
+							reject(
+								new Error(
+									`flushPendingSave timed out after ${SHUTDOWN_FLUSH_TIMEOUT_MS}ms`,
+								),
+							);
+						}, SHUTDOWN_FLUSH_TIMEOUT_MS);
+					}),
+				]);
+			} catch (error) {
+				log.warn("Shutdown flush failed", {
+					error: error instanceof Error ? error.message : String(error),
+				});
+			} finally {
+				if (timeoutTimer) clearTimeout(timeoutTimer);
+			}
+		};
+		this.shutdownHandler = handler;
+		registerCleanup(handler);
+	}
+
+	/**
+	 * Removes this manager's shutdown cleanup registration. Call this when
+	 * replacing an `AccountManager` instance (e.g., on cache invalidation)
+	 * to avoid unbounded growth of the global cleanup queue.
+	 */
+	disposeShutdownHandler(): void {
+		if (!this.shutdownHandler) return;
+		unregisterCleanup(this.shutdownHandler);
+		this.shutdownHandler = null;
+	}
+}

--- a/lib/accounts/recovery.ts
+++ b/lib/accounts/recovery.ts
@@ -1,0 +1,274 @@
+/**
+ * Recovery + hydration surface for {@link AccountManager}.
+ *
+ * Covers:
+ *  - auth-failure counter bookkeeping (per refresh token, serialized)
+ *  - cross-process hydration from the Codex CLI `~/.codex/accounts.json`
+ *  - merge-safe removal of all accounts sharing a refresh token
+ */
+
+import { existsSync, promises as fs } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import {
+	sanitizeEmail,
+	shouldUpdateAccountIdFromToken,
+} from "../auth/token-utils.js";
+import { decodeJWT } from "../auth/auth.js";
+import { createLogger } from "../logger.js";
+import { CodexCliAccountsSchema } from "../schemas.js";
+import { nowMs } from "../utils.js";
+import type { AccountPersistence } from "./persistence.js";
+import type { AccountState, ManagedAccount } from "./state.js";
+
+const log = createLogger("accounts");
+
+export type CodexCliTokenCacheEntry = {
+	accessToken: string;
+	expiresAt?: number;
+	refreshToken?: string;
+	accountId?: string;
+};
+
+const CODEX_CLI_ACCOUNTS_PATH = join(homedir(), ".codex", "accounts.json");
+const CODEX_CLI_CACHE_TTL_MS = 5_000;
+let codexCliTokenCache: Map<string, CodexCliTokenCacheEntry> | null = null;
+let codexCliTokenCacheLoadedAt = 0;
+
+function extractExpiresAtFromAccessToken(accessToken: string): number | undefined {
+	const decoded = decodeJWT(accessToken);
+	const exp = decoded?.exp;
+	if (typeof exp === "number" && Number.isFinite(exp)) {
+		// JWT exp is in seconds since epoch.
+		return exp * 1000;
+	}
+	return undefined;
+}
+
+async function getCodexCliTokenCache(): Promise<Map<string, CodexCliTokenCacheEntry> | null> {
+	const syncEnabled = process.env.CODEX_AUTH_SYNC_CODEX_CLI !== "0";
+	const skip =
+		!syncEnabled ||
+		process.env.VITEST_WORKER_ID !== undefined ||
+		process.env.NODE_ENV === "test";
+	if (skip) return null;
+
+	const now = nowMs();
+	if (codexCliTokenCache && now - codexCliTokenCacheLoadedAt < CODEX_CLI_CACHE_TTL_MS) {
+		return codexCliTokenCache;
+	}
+	codexCliTokenCacheLoadedAt = now;
+
+	if (!existsSync(CODEX_CLI_ACCOUNTS_PATH)) {
+		codexCliTokenCache = null;
+		return null;
+	}
+
+	try {
+		const raw = await fs.readFile(CODEX_CLI_ACCOUNTS_PATH, "utf-8");
+		const rawParsed = JSON.parse(raw) as unknown;
+
+		// Cross-process trust boundary: the Codex CLI accounts file is produced
+		// by a separate process on disk and may be stale, truncated, tampered
+		// with, or produced by a version whose shape we do not recognise. We
+		// MUST validate through the Zod schema before reading any field; a
+		// parse failure is a warn+skip, never a throw (audit top-20 #11).
+		const validation = CodexCliAccountsSchema.safeParse(rawParsed);
+		if (!validation.success) {
+			log.warn("Codex CLI accounts cache failed validation; ignoring", {
+				issues: validation.error.issues.length,
+				firstPath: validation.error.issues[0]?.path.join(".") ?? "(root)",
+			});
+			codexCliTokenCache = null;
+			return null;
+		}
+
+		const validated = validation.data;
+		const entries = Array.isArray(validated.accounts) ? validated.accounts : [];
+
+		const next = new Map<string, CodexCliTokenCacheEntry>();
+		for (const entry of entries) {
+			const email = sanitizeEmail(
+				typeof entry.email === "string" ? entry.email : undefined,
+			);
+			if (!email) continue;
+
+			const accountId =
+				typeof entry.accountId === "string" && entry.accountId.trim()
+					? entry.accountId.trim()
+					: undefined;
+
+			const tokens = entry.auth?.tokens;
+			const accessToken =
+				typeof tokens?.access_token === "string" && tokens.access_token.trim()
+					? tokens.access_token.trim()
+					: undefined;
+			const refreshToken =
+				typeof tokens?.refresh_token === "string" && tokens.refresh_token.trim()
+					? tokens.refresh_token.trim()
+					: undefined;
+
+			if (!accessToken) continue;
+
+			next.set(email, {
+				accessToken,
+				expiresAt: extractExpiresAtFromAccessToken(accessToken),
+				refreshToken,
+				accountId,
+			});
+		}
+
+		codexCliTokenCache = next;
+		return codexCliTokenCache;
+	} catch (error) {
+		log.debug("Failed to read Codex CLI accounts cache", { error: String(error) });
+		codexCliTokenCache = null;
+		return null;
+	}
+}
+
+export async function lookupCodexCliTokensByEmail(
+	email: string | undefined,
+): Promise<CodexCliTokenCacheEntry | null> {
+	const normalized = sanitizeEmail(email);
+	if (!normalized) return null;
+	const cache = await getCodexCliTokenCache();
+	const cached = cache?.get(normalized);
+	return cached ? { ...cached } : null;
+}
+
+export class AccountRecovery {
+	constructor(
+		private readonly state: AccountState,
+		private readonly persistence: AccountPersistence,
+	) {}
+
+	async hydrateFromCodexCli(): Promise<void> {
+		const cache = await getCodexCliTokenCache();
+		if (!cache || cache.size === 0) return;
+
+		const now = nowMs();
+		let changed = false;
+
+		for (const account of this.state.accounts) {
+			const email = sanitizeEmail(account.email);
+			if (!email) continue;
+
+			const cached = cache.get(email);
+			if (!cached) continue;
+
+			if (typeof cached.expiresAt === "number" && cached.expiresAt <= now) {
+				continue;
+			}
+
+			const missingOrExpired =
+				!account.access || account.expires === undefined || account.expires <= now;
+			if (missingOrExpired) {
+				account.access = cached.accessToken;
+				if (typeof cached.expiresAt === "number") {
+					account.expires = cached.expiresAt;
+				}
+				changed = true;
+			}
+
+			if (
+				!account.accountId &&
+				cached.accountId &&
+				shouldUpdateAccountIdFromToken(account.accountIdSource, account.accountId)
+			) {
+				account.accountId = cached.accountId;
+				account.accountIdSource = account.accountIdSource ?? "token";
+				changed = true;
+			}
+		}
+
+		if (!changed) return;
+
+		try {
+			await this.persistence.saveToDisk();
+		} catch (error) {
+			log.debug("Failed to persist Codex CLI cache hydration", {
+				error: String(error),
+			});
+		}
+	}
+
+	/**
+	 * Atomically increment the auth-failure counter for the account's refresh
+	 * token and return the post-increment value.
+	 *
+	 * The read-modify-write is serialized through a per-refresh-token promise
+	 * chain so that concurrent callers (for example, two org-variant accounts
+	 * sharing a refresh token that fail auth simultaneously) cannot lose an
+	 * increment. Without serialization both callers could read the same stale
+	 * value, both compute `+1`, and both write the same result — masking a hard
+	 * auth failure and causing the manager to keep hammering a dead token.
+	 *
+	 * Callers must `await` the returned promise before branching on the
+	 * threshold (see `index.ts` auth-refresh failure path).
+	 */
+	async incrementAuthFailures(account: ManagedAccount): Promise<number> {
+		const key = account.refreshToken;
+		const prev = this.state.incrementAuthFailuresChain.get(key) ?? Promise.resolve(0);
+		const next = prev.then(() => {
+			const currentFailures = this.state.authFailuresByRefreshToken.get(key) ?? 0;
+			const newFailures = currentFailures + 1;
+			this.state.authFailuresByRefreshToken.set(key, newFailures);
+			return newFailures;
+		});
+		this.state.incrementAuthFailuresChain.set(key, next);
+		try {
+			return await next;
+		} finally {
+			// Drop the chain entry only if no later caller has already replaced it.
+			if (this.state.incrementAuthFailuresChain.get(key) === next) {
+				this.state.incrementAuthFailuresChain.delete(key);
+			}
+		}
+	}
+
+	/**
+	 * Return the current auth-failure counter for the account's refresh token
+	 * without mutating state. Intended for tests and diagnostics.
+	 */
+	getAuthFailures(account: ManagedAccount): number {
+		return this.state.authFailuresByRefreshToken.get(account.refreshToken) ?? 0;
+	}
+
+	/**
+	 * Clear the authentication failure counter for the given account's refresh token.
+	 *
+	 * Notes:
+	 * - Failure counts are tracked per refresh token (not per account), so this clears
+	 *   shared failure state for all org variants that reuse the same token.
+	 * - Failure counts are in-memory only for the current AccountManager instance.
+	 */
+	clearAuthFailures(account: ManagedAccount): void {
+		this.state.authFailuresByRefreshToken.delete(account.refreshToken);
+	}
+
+	/**
+	 * Remove all accounts that share the same refreshToken as the given account.
+	 * This is used when auth refresh fails to remove all org variants together.
+	 * @returns Number of accounts removed
+	 */
+	removeAccountsWithSameRefreshToken(account: ManagedAccount): number {
+		const refreshToken = account.refreshToken;
+		// Snapshot first because removeAccount mutates the accounts array.
+		const accountsToRemove = this.state.accounts.filter(
+			(acc) => acc.refreshToken === refreshToken,
+		);
+		let removedCount = 0;
+
+		for (const accountToRemove of accountsToRemove) {
+			if (this.state.removeAccount(accountToRemove)) {
+				removedCount++;
+			}
+		}
+
+		// Clear stale auth failure state for this refresh token
+		this.state.authFailuresByRefreshToken.delete(refreshToken);
+
+		return removedCount;
+	}
+}

--- a/lib/accounts/rotation.ts
+++ b/lib/accounts/rotation.ts
@@ -1,0 +1,305 @@
+/**
+ * Rotation + rate-limit + cooldown surface for {@link AccountManager}.
+ *
+ * Pure logic module: all state mutations land on a shared {@link AccountState}
+ * reference. Integrates with the health and token-bucket trackers in
+ * `lib/rotation.ts` (note: that file is the hybrid selection algorithm; this
+ * module is the manager-facing wrapper that wires it to `AccountState`).
+ */
+
+import type { ModelFamily } from "../prompts/codex.js";
+import {
+	getHealthTracker,
+	getTokenTracker,
+	selectHybridAccount,
+	type AccountWithMetrics,
+	type HybridSelectionOptions,
+} from "../rotation.js";
+import type { CooldownReason } from "../storage.js";
+import { nowMs } from "../utils.js";
+import {
+	clearExpiredRateLimits,
+	getQuotaKey,
+	isRateLimitedForFamily,
+	type RateLimitReason,
+} from "./rate-limits.js";
+import type { AccountState, ManagedAccount } from "./state.js";
+
+export class AccountRotation {
+	constructor(private readonly state: AccountState) {}
+
+	getCurrentOrNextForFamily(
+		family: ModelFamily,
+		model?: string | null,
+	): ManagedAccount | null {
+		const count = this.state.accounts.length;
+		if (count === 0) return null;
+
+		const cursor = this.state.cursorByFamily[family];
+
+		for (let i = 0; i < count; i++) {
+			const idx = (cursor + i) % count;
+			const account = this.state.accounts[idx];
+			if (!account) continue;
+			if (account.enabled === false) continue;
+
+			clearExpiredRateLimits(account);
+			if (
+				isRateLimitedForFamily(account, family, model) ||
+				this.state.isAccountCoolingDown(account)
+			) {
+				continue;
+			}
+
+			this.state.cursorByFamily[family] = (idx + 1) % count;
+			this.state.currentAccountIndexByFamily[family] = idx;
+			account.lastUsed = nowMs();
+			return account;
+		}
+
+		return null;
+	}
+
+	getNextForFamily(family: ModelFamily, model?: string | null): ManagedAccount | null {
+		const count = this.state.accounts.length;
+		if (count === 0) return null;
+
+		const cursor = this.state.cursorByFamily[family];
+
+		for (let i = 0; i < count; i++) {
+			const idx = (cursor + i) % count;
+			const account = this.state.accounts[idx];
+			if (!account) continue;
+			if (account.enabled === false) continue;
+
+			clearExpiredRateLimits(account);
+			if (
+				isRateLimitedForFamily(account, family, model) ||
+				this.state.isAccountCoolingDown(account)
+			) {
+				continue;
+			}
+
+			this.state.cursorByFamily[family] = (idx + 1) % count;
+			account.lastUsed = nowMs();
+			return account;
+		}
+
+		return null;
+	}
+
+	getCurrentOrNextForFamilyHybrid(
+		family: ModelFamily,
+		model?: string | null,
+		options?: HybridSelectionOptions,
+	): ManagedAccount | null {
+		const count = this.state.accounts.length;
+		if (count === 0) return null;
+
+		const currentIndex = this.state.currentAccountIndexByFamily[family];
+		if (currentIndex >= 0 && currentIndex < count) {
+			const currentAccount = this.state.accounts[currentIndex];
+			if (currentAccount) {
+				if (currentAccount.enabled === false) {
+					// Fall through to hybrid selection.
+				} else {
+					clearExpiredRateLimits(currentAccount);
+					if (
+						!isRateLimitedForFamily(currentAccount, family, model) &&
+						!this.state.isAccountCoolingDown(currentAccount)
+					) {
+						currentAccount.lastUsed = nowMs();
+						return currentAccount;
+					}
+				}
+			}
+		}
+
+		const quotaKey = model ? `${family}:${model}` : family;
+		const healthTracker = getHealthTracker();
+		const tokenTracker = getTokenTracker();
+
+		const accountsWithMetrics: AccountWithMetrics[] = this.state.accounts
+			.map((account): AccountWithMetrics | null => {
+				if (!account) return null;
+				if (account.enabled === false) return null;
+				clearExpiredRateLimits(account);
+				const isAvailable =
+					!isRateLimitedForFamily(account, family, model) &&
+					!this.state.isAccountCoolingDown(account);
+				return {
+					index: account.index,
+					isAvailable,
+					lastUsed: account.lastUsed,
+				};
+			})
+			.filter((a): a is AccountWithMetrics => a !== null);
+
+		const selected = selectHybridAccount(
+			accountsWithMetrics,
+			healthTracker,
+			tokenTracker,
+			quotaKey,
+			{},
+			options,
+		);
+		if (!selected) return null;
+
+		const account = this.state.accounts[selected.index];
+		if (!account) return null;
+
+		this.state.currentAccountIndexByFamily[family] = account.index;
+		this.state.cursorByFamily[family] = (account.index + 1) % count;
+		account.lastUsed = nowMs();
+		return account;
+	}
+
+	recordSuccess(
+		account: ManagedAccount,
+		family: ModelFamily,
+		model?: string | null,
+	): void {
+		const quotaKey = model ? `${family}:${model}` : family;
+		getHealthTracker().recordSuccess(account.index, quotaKey);
+	}
+
+	recordRateLimit(
+		account: ManagedAccount,
+		family: ModelFamily,
+		model?: string | null,
+	): void {
+		const quotaKey = model ? `${family}:${model}` : family;
+		getHealthTracker().recordRateLimit(account.index, quotaKey);
+		getTokenTracker().drain(account.index, quotaKey);
+	}
+
+	recordFailure(
+		account: ManagedAccount,
+		family: ModelFamily,
+		model?: string | null,
+	): void {
+		const quotaKey = model ? `${family}:${model}` : family;
+		getHealthTracker().recordFailure(account.index, quotaKey);
+	}
+
+	consumeToken(
+		account: ManagedAccount,
+		family: ModelFamily,
+		model?: string | null,
+	): boolean {
+		const quotaKey = model ? `${family}:${model}` : family;
+		return getTokenTracker().tryConsume(account.index, quotaKey);
+	}
+
+	/**
+	 * Refund a token consumed within the refund window (30 seconds).
+	 * Use this when a request fails due to network errors (not rate limits).
+	 * @returns true if refund was successful, false if no valid consumption found
+	 */
+	refundToken(
+		account: ManagedAccount,
+		family: ModelFamily,
+		model?: string | null,
+	): boolean {
+		const quotaKey = model ? `${family}:${model}` : family;
+		return getTokenTracker().refundToken(account.index, quotaKey);
+	}
+
+	markRateLimited(
+		account: ManagedAccount,
+		retryAfterMs: number,
+		family: ModelFamily,
+		model?: string | null,
+	): void {
+		this.markRateLimitedWithReason(account, retryAfterMs, family, "unknown", model);
+	}
+
+	markRateLimitedWithReason(
+		account: ManagedAccount,
+		retryAfterMs: number,
+		family: ModelFamily,
+		reason: RateLimitReason,
+		model?: string | null,
+	): void {
+		const retryMs = Math.max(0, Math.floor(retryAfterMs));
+		const resetAt = nowMs() + retryMs;
+
+		const baseKey = getQuotaKey(family);
+		account.rateLimitResetTimes[baseKey] = resetAt;
+
+		if (model) {
+			const modelKey = getQuotaKey(family, model);
+			account.rateLimitResetTimes[modelKey] = resetAt;
+		}
+
+		account.lastRateLimitReason = reason;
+	}
+
+	markAccountCoolingDown(
+		account: ManagedAccount,
+		cooldownMs: number,
+		reason: CooldownReason,
+	): void {
+		const ms = Math.max(0, Math.floor(cooldownMs));
+		account.coolingDownUntil = nowMs() + ms;
+		account.cooldownReason = reason;
+	}
+
+	/**
+	 * Mark every in-memory account sharing a refresh token as cooling down.
+	 * @returns Number of live accounts updated.
+	 */
+	markAccountsWithRefreshTokenCoolingDown(
+		refreshToken: string,
+		cooldownMs: number,
+		reason: CooldownReason,
+	): number {
+		const matches = this.state.accounts.filter(
+			(account) => account.refreshToken === refreshToken,
+		);
+		for (const account of matches) {
+			this.markAccountCoolingDown(account, cooldownMs, reason);
+		}
+		return matches.length;
+	}
+
+	getMinWaitTimeForFamily(family: ModelFamily, model?: string | null): number {
+		const now = nowMs();
+		const enabledAccounts = this.state.accounts.filter(
+			(account) => account.enabled !== false,
+		);
+		const available = enabledAccounts.filter((account) => {
+			clearExpiredRateLimits(account);
+			return (
+				!isRateLimitedForFamily(account, family, model) &&
+				!this.state.isAccountCoolingDown(account)
+			);
+		});
+		if (available.length > 0) return 0;
+		if (enabledAccounts.length === 0) return 0;
+
+		const waitTimes: number[] = [];
+		const baseKey = getQuotaKey(family);
+		const modelKey = model ? getQuotaKey(family, model) : null;
+
+		for (const account of enabledAccounts) {
+			const baseResetAt = account.rateLimitResetTimes[baseKey];
+			if (typeof baseResetAt === "number") {
+				waitTimes.push(Math.max(0, baseResetAt - now));
+			}
+
+			if (modelKey) {
+				const modelResetAt = account.rateLimitResetTimes[modelKey];
+				if (typeof modelResetAt === "number") {
+					waitTimes.push(Math.max(0, modelResetAt - now));
+				}
+			}
+
+			if (typeof account.coolingDownUntil === "number") {
+				waitTimes.push(Math.max(0, account.coolingDownUntil - now));
+			}
+		}
+
+		return waitTimes.length > 0 ? Math.min(...waitTimes) : 0;
+	}
+}

--- a/lib/accounts/state.ts
+++ b/lib/accounts/state.ts
@@ -1,0 +1,478 @@
+/**
+ * In-memory account registry for {@link AccountManager}.
+ *
+ * Owns the mutable account list, per-family cursors/active indices, and
+ * auxiliary in-memory state (toast debounce, auth-failure counters).
+ * Other account services (persistence, rotation, recovery) receive a reference
+ * to an `AccountState` instance and mutate it through this narrow surface.
+ */
+
+import type { Auth } from "@opencode-ai/sdk";
+import { MODEL_FAMILIES, type ModelFamily } from "../prompts/codex.js";
+import type { AccountIdSource, OAuthAuthDetails } from "../types.js";
+import { nowMs } from "../utils.js";
+import {
+	clampNonNegativeInt,
+	clearExpiredRateLimits,
+	getQuotaKey,
+	isRateLimitedForFamily,
+	type RateLimitReason,
+} from "./rate-limits.js";
+import type { AccountStorageV3, CooldownReason, RateLimitStateV3 } from "../storage.js";
+import {
+	extractAccountEmail,
+	extractAccountId,
+	sanitizeEmail,
+	shouldUpdateAccountIdFromToken,
+} from "../auth/token-utils.js";
+import { getHealthTracker, getTokenTracker } from "../rotation.js";
+
+export interface ManagedAccount {
+	index: number;
+	accountId?: string;
+	organizationId?: string;
+	accountIdSource?: AccountIdSource;
+	accountLabel?: string;
+	accountTags?: string[];
+	accountNote?: string;
+	email?: string;
+	refreshToken: string;
+	enabled?: boolean;
+	access?: string;
+	expires?: number;
+	addedAt: number;
+	lastUsed: number;
+	lastSwitchReason?: "rate-limit" | "initial" | "rotation";
+	lastRateLimitReason?: RateLimitReason;
+	rateLimitResetTimes: RateLimitStateV3;
+	coolingDownUntil?: number;
+	cooldownReason?: CooldownReason;
+}
+
+export interface AccountSelectionExplainability {
+	index: number;
+	enabled: boolean;
+	isCurrentForFamily: boolean;
+	eligible: boolean;
+	reasons: string[];
+	healthScore: number;
+	tokensAvailable: number;
+	rateLimitedUntil?: number;
+	coolingDownUntil?: number;
+	cooldownReason?: CooldownReason;
+	lastUsed: number;
+}
+
+function initFamilyState(defaultValue: number): Record<ModelFamily, number> {
+	return Object.fromEntries(
+		MODEL_FAMILIES.map((family) => [family, defaultValue]),
+	) as Record<ModelFamily, number>;
+}
+
+export class AccountState {
+	accounts: ManagedAccount[] = [];
+	cursorByFamily: Record<ModelFamily, number> = initFamilyState(0);
+	currentAccountIndexByFamily: Record<ModelFamily, number> = initFamilyState(-1);
+	lastToastAccountIndex = -1;
+	lastToastTime = 0;
+	authFailuresByRefreshToken: Map<string, number> = new Map();
+	/**
+	 * Per-refresh-token promise chain used to serialize concurrent
+	 * `incrementAuthFailures` calls. Prevents lost updates when two org-variant
+	 * accounts that share a refresh token observe an auth failure at once — see
+	 * audit finding `docs/audits/03-critical-issues.md` (ledger id `47`).
+	 */
+	incrementAuthFailuresChain: Map<string, Promise<number>> = new Map();
+
+	initializeFromStorage(
+		authFallback: OAuthAuthDetails | undefined,
+		stored: AccountStorageV3 | null | undefined,
+	): void {
+		const fallbackAccountId = extractAccountId(authFallback?.access);
+		const fallbackAccountEmail = sanitizeEmail(extractAccountEmail(authFallback?.access));
+
+		if (stored && stored.accounts.length > 0) {
+			const baseNow = nowMs();
+			this.accounts = stored.accounts
+				.map((account, index): ManagedAccount | null => {
+					if (!account.refreshToken || typeof account.refreshToken !== "string") {
+						return null;
+					}
+
+					const matchesFallback =
+						!!authFallback &&
+						((fallbackAccountId && account.accountId === fallbackAccountId) ||
+							account.refreshToken === authFallback.refresh ||
+							(!!fallbackAccountEmail &&
+								sanitizeEmail(account.email) === fallbackAccountEmail));
+
+					const refreshToken =
+						matchesFallback && authFallback ? authFallback.refresh : account.refreshToken;
+
+					return {
+						index,
+						accountId: matchesFallback
+							? fallbackAccountId ?? account.accountId
+							: account.accountId,
+						organizationId: account.organizationId,
+						accountIdSource: account.accountIdSource,
+						accountLabel: account.accountLabel,
+						accountTags: account.accountTags,
+						accountNote: account.accountNote,
+						email: matchesFallback
+							? fallbackAccountEmail ?? sanitizeEmail(account.email)
+							: sanitizeEmail(account.email),
+						refreshToken,
+						enabled: account.enabled !== false,
+						access:
+							matchesFallback && authFallback ? authFallback.access : account.accessToken,
+						expires:
+							matchesFallback && authFallback ? authFallback.expires : account.expiresAt,
+						addedAt: clampNonNegativeInt(account.addedAt, baseNow),
+						lastUsed: clampNonNegativeInt(account.lastUsed, 0),
+						lastSwitchReason: account.lastSwitchReason,
+						rateLimitResetTimes: account.rateLimitResetTimes ?? {},
+						coolingDownUntil: account.coolingDownUntil,
+						cooldownReason: account.cooldownReason,
+					};
+				})
+				.filter((account): account is ManagedAccount => account !== null);
+
+			const hasMatchingFallback =
+				!!authFallback &&
+				this.accounts.some(
+					(account) =>
+						account.refreshToken === authFallback.refresh ||
+						(fallbackAccountId && account.accountId === fallbackAccountId) ||
+						(!!fallbackAccountEmail && account.email === fallbackAccountEmail),
+				);
+
+			if (authFallback && !hasMatchingFallback) {
+				const now = nowMs();
+				this.accounts.push({
+					index: this.accounts.length,
+					accountId: fallbackAccountId,
+					organizationId: undefined,
+					accountIdSource: fallbackAccountId ? "token" : undefined,
+					email: fallbackAccountEmail,
+					refreshToken: authFallback.refresh,
+					enabled: true,
+					access: authFallback.access,
+					expires: authFallback.expires,
+					addedAt: now,
+					lastUsed: now,
+					lastSwitchReason: "initial",
+					rateLimitResetTimes: {},
+				});
+			}
+
+			if (this.accounts.length > 0) {
+				const defaultIndex =
+					clampNonNegativeInt(stored.activeIndex, 0) % this.accounts.length;
+
+				for (const family of MODEL_FAMILIES) {
+					const rawIndex = stored.activeIndexByFamily?.[family];
+					const nextIndex =
+						clampNonNegativeInt(rawIndex, defaultIndex) % this.accounts.length;
+					this.currentAccountIndexByFamily[family] = nextIndex;
+					this.cursorByFamily[family] = nextIndex;
+				}
+			}
+			return;
+		}
+
+		if (authFallback) {
+			const now = nowMs();
+			this.accounts = [
+				{
+					index: 0,
+					accountId: fallbackAccountId,
+					organizationId: undefined,
+					accountIdSource: fallbackAccountId ? "token" : undefined,
+					email: fallbackAccountEmail,
+					refreshToken: authFallback.refresh,
+					enabled: true,
+					access: authFallback.access,
+					expires: authFallback.expires,
+					addedAt: now,
+					lastUsed: 0,
+					lastSwitchReason: "initial",
+					rateLimitResetTimes: {},
+				},
+			];
+			for (const family of MODEL_FAMILIES) {
+				this.currentAccountIndexByFamily[family] = 0;
+				this.cursorByFamily[family] = 0;
+			}
+		}
+	}
+
+	hasRefreshToken(refreshToken: string): boolean {
+		return this.accounts.some((account) => account.refreshToken === refreshToken);
+	}
+
+	getAccountCount(): number {
+		return this.accounts.length;
+	}
+
+	getActiveIndexForFamily(family: ModelFamily): number {
+		const index = this.currentAccountIndexByFamily[family];
+		if (index < 0 || index >= this.accounts.length) {
+			return this.accounts.length > 0 ? 0 : -1;
+		}
+		return index;
+	}
+
+	getAccountsSnapshot(): ManagedAccount[] {
+		return this.accounts.map((account) => ({
+			...account,
+			rateLimitResetTimes: { ...account.rateLimitResetTimes },
+		}));
+	}
+
+	getSelectionExplainability(
+		family: ModelFamily,
+		model?: string | null,
+		now = nowMs(),
+	): AccountSelectionExplainability[] {
+		const quotaKey = model ? `${family}:${model}` : family;
+		const baseQuotaKey = getQuotaKey(family);
+		const modelQuotaKey = model ? getQuotaKey(family, model) : null;
+		const currentIndex = this.currentAccountIndexByFamily[family];
+		const healthTracker = getHealthTracker();
+		const tokenTracker = getTokenTracker();
+
+		return this.accounts.map((account) => {
+			clearExpiredRateLimits(account);
+			const enabled = account.enabled !== false;
+			const reasons: string[] = [];
+			let rateLimitedUntil: number | undefined;
+			const baseRateLimit = account.rateLimitResetTimes[baseQuotaKey];
+			const modelRateLimit = modelQuotaKey
+				? account.rateLimitResetTimes[modelQuotaKey]
+				: undefined;
+			if (typeof baseRateLimit === "number" && baseRateLimit > now) {
+				rateLimitedUntil = baseRateLimit;
+			}
+			if (
+				typeof modelRateLimit === "number" &&
+				modelRateLimit > now &&
+				(rateLimitedUntil === undefined || modelRateLimit > rateLimitedUntil)
+			) {
+				rateLimitedUntil = modelRateLimit;
+			}
+
+			const coolingDownUntil =
+				typeof account.coolingDownUntil === "number" && account.coolingDownUntil > now
+					? account.coolingDownUntil
+					: undefined;
+
+			if (!enabled) reasons.push("disabled");
+			if (rateLimitedUntil !== undefined) reasons.push("rate-limited");
+			if (coolingDownUntil !== undefined) {
+				reasons.push(
+					account.cooldownReason ? `cooldown:${account.cooldownReason}` : "cooldown",
+				);
+			}
+
+			const tokensAvailable = tokenTracker.getTokens(account.index, quotaKey);
+			if (tokensAvailable < 1) reasons.push("token-bucket-empty");
+
+			const eligible =
+				enabled &&
+				rateLimitedUntil === undefined &&
+				coolingDownUntil === undefined &&
+				tokensAvailable >= 1;
+			if (reasons.length === 0) reasons.push("eligible");
+
+			return {
+				index: account.index,
+				enabled,
+				isCurrentForFamily: currentIndex === account.index,
+				eligible,
+				reasons,
+				healthScore: healthTracker.getScore(account.index, quotaKey),
+				tokensAvailable,
+				rateLimitedUntil,
+				coolingDownUntil,
+				cooldownReason: coolingDownUntil !== undefined ? account.cooldownReason : undefined,
+				lastUsed: account.lastUsed,
+			};
+		});
+	}
+
+	setActiveIndex(index: number): ManagedAccount | null {
+		if (!Number.isFinite(index)) return null;
+		if (index < 0 || index >= this.accounts.length) return null;
+		const account = this.accounts[index];
+		if (!account) return null;
+		if (account.enabled === false) return null;
+
+		for (const family of MODEL_FAMILIES) {
+			this.currentAccountIndexByFamily[family] = index;
+			this.cursorByFamily[family] = index;
+		}
+
+		account.lastUsed = nowMs();
+		account.lastSwitchReason = "rotation";
+		return account;
+	}
+
+	getCurrentAccountForFamily(family: ModelFamily): ManagedAccount | null {
+		const index = this.currentAccountIndexByFamily[family];
+		if (index < 0 || index >= this.accounts.length) {
+			return null;
+		}
+		const account = this.accounts[index];
+		if (!account || account.enabled === false) {
+			return null;
+		}
+		return account;
+	}
+
+	shouldShowAccountToast(accountIndex: number, debounceMs = 30000): boolean {
+		const now = nowMs();
+		if (
+			accountIndex === this.lastToastAccountIndex &&
+			now - this.lastToastTime < debounceMs
+		) {
+			return false;
+		}
+		return true;
+	}
+
+	markToastShown(accountIndex: number): void {
+		this.lastToastAccountIndex = accountIndex;
+		this.lastToastTime = nowMs();
+	}
+
+	updateFromAuth(account: ManagedAccount, auth: OAuthAuthDetails): void {
+		const previousRefreshToken = account.refreshToken;
+		account.refreshToken = auth.refresh;
+		account.access = auth.access;
+		account.expires = auth.expires;
+		if (previousRefreshToken !== account.refreshToken) {
+			this.authFailuresByRefreshToken.delete(previousRefreshToken);
+		}
+		const tokenAccountId = extractAccountId(auth.access);
+		if (
+			tokenAccountId &&
+			shouldUpdateAccountIdFromToken(account.accountIdSource, account.accountId)
+		) {
+			account.accountId = tokenAccountId;
+			account.accountIdSource = "token";
+		}
+		account.email = sanitizeEmail(extractAccountEmail(auth.access)) ?? account.email;
+	}
+
+	toAuthDetails(account: ManagedAccount): Auth {
+		return {
+			type: "oauth",
+			access: account.access ?? "",
+			refresh: account.refreshToken,
+			expires: account.expires ?? 0,
+		};
+	}
+
+	markSwitched(
+		account: ManagedAccount,
+		reason: "rate-limit" | "initial" | "rotation",
+		family: ModelFamily,
+	): void {
+		account.lastSwitchReason = reason;
+		this.currentAccountIndexByFamily[family] = account.index;
+	}
+
+	removeAccount(account: ManagedAccount): boolean {
+		const idx = this.accounts.indexOf(account);
+		if (idx < 0) {
+			return false;
+		}
+
+		this.accounts.splice(idx, 1);
+		this.accounts.forEach((acc, index) => {
+			acc.index = index;
+		});
+
+		if (this.accounts.length === 0) {
+			for (const family of MODEL_FAMILIES) {
+				this.cursorByFamily[family] = 0;
+				this.currentAccountIndexByFamily[family] = -1;
+			}
+			return true;
+		}
+
+		for (const family of MODEL_FAMILIES) {
+			if (this.cursorByFamily[family] > idx) {
+				this.cursorByFamily[family] = Math.max(0, this.cursorByFamily[family] - 1);
+			}
+		}
+		for (const family of MODEL_FAMILIES) {
+			this.cursorByFamily[family] = this.cursorByFamily[family] % this.accounts.length;
+		}
+
+		for (const family of MODEL_FAMILIES) {
+			if (this.currentAccountIndexByFamily[family] > idx) {
+				this.currentAccountIndexByFamily[family] -= 1;
+			}
+			if (this.currentAccountIndexByFamily[family] >= this.accounts.length) {
+				this.currentAccountIndexByFamily[family] = -1;
+			}
+		}
+
+		return true;
+	}
+
+	removeAccountByIndex(index: number): boolean {
+		if (!Number.isFinite(index)) return false;
+		if (index < 0 || index >= this.accounts.length) return false;
+		const account = this.accounts[index];
+		if (!account) return false;
+		return this.removeAccount(account);
+	}
+
+	setAccountEnabled(index: number, enabled: boolean): ManagedAccount | null {
+		if (!Number.isFinite(index)) return null;
+		if (index < 0 || index >= this.accounts.length) return null;
+		const account = this.accounts[index];
+		if (!account) return null;
+		account.enabled = enabled;
+		return account;
+	}
+
+	/**
+	 * Check whether a cooldown window is still active for the given account.
+	 * Clears expired cooldowns as a side-effect so that stale `coolingDownUntil`
+	 * timestamps do not leak into snapshots or persistence.
+	 */
+	isAccountCoolingDown(account: ManagedAccount): boolean {
+		if (account.coolingDownUntil === undefined) return false;
+		if (nowMs() >= account.coolingDownUntil) {
+			this.clearAccountCooldown(account);
+			return false;
+		}
+		return true;
+	}
+
+	clearAccountCooldown(account: ManagedAccount): void {
+		delete account.coolingDownUntil;
+		delete account.cooldownReason;
+	}
+
+	/**
+	 * Shared predicate used by rotation and diagnostic paths: is this account
+	 * usable for the given family/model right now? Combines enabled flag,
+	 * rate-limit expiry, and cooldown.
+	 */
+	isEligibleForFamily(
+		account: ManagedAccount,
+		family: ModelFamily,
+		model?: string | null,
+	): boolean {
+		if (account.enabled === false) return false;
+		clearExpiredRateLimits(account);
+		if (isRateLimitedForFamily(account, family, model)) return false;
+		if (this.isAccountCoolingDown(account)) return false;
+		return true;
+	}
+}


### PR DESCRIPTION
## Summary

Phase-2 architecture refactor RC-7. Splits the 40+-method `AccountManager` god-class in `lib/accounts.ts` into four cohesive domain services:

- **`lib/accounts/state.ts`** — `AccountState`: in-memory account registry, per-family cursors and active indices, toast debounce, and auth-failure counters. Owns `initializeFromStorage`, `getAccountsSnapshot`, `removeAccount`, `isAccountCoolingDown`, `updateFromAuth`, `setActiveIndex`, and the shared `isEligibleForFamily` predicate.
- **`lib/accounts/persistence.ts`** — `AccountPersistence`: debounced disk saves via `lib/storage`, `pendingSave` coalescing, and the one-shot shutdown-flush registration. Lifecycle semantics from PR #110 (handler clears its own slot before flushing) preserved exactly.
- **`lib/accounts/rotation.ts`** — `AccountRotation`: round-robin and hybrid selection, integration with `HealthScoreTracker` and `TokenBucketTracker`, rate-limit and cooldown bookkeeping, and `getMinWaitTimeForFamily`.
- **`lib/accounts/recovery.ts`** — `AccountRecovery`: per-refresh-token auth-failure ledger with the serialized promise chain from PR #108, Codex CLI cross-process hydration (`hydrateFromCodexCli`, `lookupCodexCliTokensByEmail`), and merge-safe `removeAccountsWithSameRefreshToken`.

`lib/accounts.ts` becomes a slim orchestrator (308 lines, down from 1129) that composes the four services via constructor injection and delegates every existing method to the right service.

## Motivation

`docs/audits/16-code-health.md` flagged `AccountManager` as the second god-class in the codebase after `index.ts`, with 40+ methods spanning four unrelated concerns. Splitting along domain lines:

- Lets future work (unit tests, diagnostic tools, RC-8 circuit-breaker wiring) target one service at a time instead of mocking the whole manager.
- Localises the rotation logic so that RC-8 can wire a per-account circuit breaker into `AccountRotation` without touching persistence or recovery paths.
- Makes the auth-failure serialization guarantee (PR #108) and shutdown-flush guarantee (PR #110) easier to read because each lives in a module that only does that thing.

## Public API

Unchanged. Every method currently on `AccountManager` is still callable with the same signature and behavior:

- State: `hasRefreshToken`, `getAccountCount`, `getActiveIndex`, `getActiveIndexForFamily`, `getAccountsSnapshot`, `getSelectionExplainability`, `setActiveIndex`, `getCurrentAccount`, `getCurrentAccountForFamily`, `shouldShowAccountToast`, `markToastShown`, `updateFromAuth`, `toAuthDetails`, `markSwitched`, `removeAccount`, `removeAccountByIndex`, `setAccountEnabled`, `isAccountCoolingDown`, `clearAccountCooldown`
- Rotation: `getCurrentOrNext`, `getCurrentOrNextForFamily`, `getNextForFamily`, `getCurrentOrNextForFamilyHybrid`, `recordSuccess`, `recordRateLimit`, `recordFailure`, `consumeToken`, `refundToken`, `markRateLimited`, `markRateLimitedWithReason`, `markAccountCoolingDown`, `markAccountsWithRefreshTokenCoolingDown`, `getMinWaitTime`, `getMinWaitTimeForFamily`
- Persistence: `saveToDisk`, `saveToDiskDebounced`, `flushPendingSave`, `disposeShutdownHandler`, static `loadFromDisk`
- Recovery: `incrementAuthFailures`, `getAuthFailures`, `clearAuthFailures`, `removeAccountsWithSameRefreshToken`
- Top-level helpers re-exported verbatim: `formatAccountLabel`, `formatCooldown`, `lookupCodexCliTokensByEmail`, plus all token-utils and rate-limits re-exports.

Two accounts tests read the private `authFailuresByRefreshToken` field via `Reflect.get(manager, ...)`. To keep the refactor test-edit-free, the orchestrator exposes a private getter of the same name that proxies to `state.authFailuresByRefreshToken`, so those reflection reads keep returning the live map.

## Verification

- `npm run typecheck` — clean
- `npm run lint` — clean
- `npm test` — 65 files, 2121/2121 tests pass
- `npm run build` — clean

Line counts (before → after):

| File | Lines |
| --- | --- |
| `lib/accounts.ts` | 1129 → 308 |
| `lib/accounts/state.ts` | 0 → 432 |
| `lib/accounts/persistence.ts` | 0 → 149 |
| `lib/accounts/rotation.ts` | 0 → 266 |
| `lib/accounts/recovery.ts` | 0 → 239 |
| `lib/accounts/rate-limits.ts` (unchanged) | 85 |

## Out of scope

- `lib/accounts/rate-limits.ts` was left untouched (scope of RC-7 is the god-class split; rate-limits was already extracted in Phase 1).
- No tests were added or modified. Each new service is exercised through `AccountManager`'s existing test surface, which is unchanged.

## Audit refs

- `docs/audits/07-refactoring-plan.md#rc-7`
- `docs/audits/16-code-health.md`
- `docs/audits/13-phased-roadmap.md` §2.4
- Plan: `.sisyphus/plans/repo-audit-phase2.md` PR G

## Depends on / unblocks

- Depends on RC-3 typed errors (merged).
- Unblocks RC-8 (per-account circuit-breaker wiring), which can now target `AccountRotation` directly.

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

clean RC-7 god-class split: `AccountManager` drops from 1129 to 308 lines by extracting `AccountState`, `AccountPersistence`, `AccountRotation`, and `AccountRecovery` as constructor-injected domain services. public API is fully preserved with zero test edits, and the PR #108 serialization guarantee and PR #110 shutdown-flush lifecycle are both carried over intact.

all remaining findings are P2 — two encapsulation/cleanup concerns in `AccountState`/`AccountRecovery` and a missing direct vitest surface for the four new services.

<h3>Confidence Score: 5/5</h3>

safe to merge — all findings are P2 cleanup/encapsulation suggestions with no runtime impact

no P0/P1 issues introduced; public API is preserved; the PR #108 serialization and PR #110 shutdown-flush guarantees both survive the split; 2121/2121 tests pass; P2 findings (chain placement, ghost write, missing unit tests) are addressable in a follow-up without blocking RC-8

lib/accounts/state.ts and lib/accounts/recovery.ts — minor encapsulation issues around incrementAuthFailuresChain placement and cleanup

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/accounts.ts | slim orchestrator (308 lines) that composes four services via constructor injection and delegates every public method; public API fully preserved, including the Reflect.get-compatible authFailuresByRefreshToken getter |
| lib/accounts/state.ts | in-memory account registry; incrementAuthFailuresChain belongs on AccountRecovery not here; cursor/index fixup logic in removeAccount is correct; all fields are public (intentional for service access) |
| lib/accounts/persistence.ts | debounce + pendingSave coalescing + shutdown-flush lifecycle preserved exactly from PR #110; SHUTDOWN_FLUSH_TIMEOUT_MS prevents indefinite SIGTERM stall |
| lib/accounts/rotation.ts | round-robin and hybrid selection wired to health/token-bucket trackers; duplicate loop bodies in getCurrentOrNextForFamily vs getNextForFamily is pre-existing but could be extracted |
| lib/accounts/recovery.ts | auth-failure serialization chain (PR #108) and Codex CLI hydration preserved; ghost write issue when removeAccountsWithSameRefreshToken doesn't clear incrementAuthFailuresChain; module-level cache is process-wide |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller as index.ts / lib/tools/*
    participant AM as AccountManager (orchestrator)
    participant AS as AccountState
    participant AP as AccountPersistence
    participant AR as AccountRotation
    participant ARC as AccountRecovery

    Caller->>AM: new AccountManager(authFallback, stored)
    AM->>AS: new AccountState()
    AM->>AP: new AccountPersistence(state)
    AM->>AR: new AccountRotation(state)
    AM->>ARC: new AccountRecovery(state, persistence)
    AM->>AS: initializeFromStorage(authFallback, stored)

    Caller->>AM: getCurrentOrNextForFamily(family, model)
    AM->>AR: getCurrentOrNextForFamily(family, model)
    AR->>AS: read accounts, cursorByFamily
    AR-->>AM: ManagedAccount | null

    Caller->>AM: incrementAuthFailures(account)
    AM->>ARC: incrementAuthFailures(account)
    ARC->>AS: incrementAuthFailuresChain (serialize)
    ARC->>AS: authFailuresByRefreshToken.set(key, n)
    ARC-->>AM: number

    Caller->>AM: saveToDiskDebounced()
    AM->>AP: saveToDiskDebounced()
    AP->>AS: read accounts snapshot
    AP->>AP: debounce + pendingSave coalesce
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Foc-codex-multi-auth%22%20on%20the%20existing%20branch%20%22refactor%2Frc-7-account-manager-split%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22refactor%2Frc-7-account-manager-split%22.%0A%0AFix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Alib%2Faccounts%2Fstate.ts%3A85%0A**%60incrementAuthFailuresChain%60%20belongs%20on%20%60AccountRecovery%60%2C%20not%20%60AccountState%60**%0A%0A%60AccountState%60%20is%20documented%20as%20a%20%22narrow%20surface%22%20for%20mutation%20%E2%80%94%20only%20%60AccountRecovery%60%20ever%20reads%20or%20writes%20%60incrementAuthFailuresChain%60.%20putting%20this%20promise-chain%20map%20on%20the%20shared%20state%20object%20exposes%20the%20serialization%20internals%20to%20%60AccountPersistence%60%20and%20%60AccountRotation%60%2C%20which%20have%20no%20business%20touching%20it.%20moving%20it%20to%20%60AccountRecovery%60%20tightens%20the%20invariant%20and%20makes%20the%20PR%20%23108%20guarantee%20self-contained%20in%20the%20module%20that%20owns%20it.%0A%0A%60%60%60ts%0A%2F%2F%20in%20AccountRecovery%3A%0Aprivate%20readonly%20incrementAuthFailuresChain%3A%20Map%3Cstring%2C%20Promise%3Cnumber%3E%3E%20%3D%20new%20Map%28%29%3B%0A%60%60%60%0A%0Athen%20all%20three%20reads%2Fwrites%20in%20%60incrementAuthFailures%60%20move%20from%20%60this.state.incrementAuthFailuresChain%60%20to%20%60this.incrementAuthFailuresChain%60%20%E2%80%94%20no%20other%20callers%20are%20affected.%0A%0A%23%23%23%20Issue%202%20of%204%0Alib%2Faccounts%2Frecovery.ts%3A255-272%0A**Ghost%20write%20after%20%60removeAccountsWithSameRefreshToken%60**%0A%0Athe%20function%20deletes%20%60authFailuresByRefreshToken%5Bkey%5D%60%20synchronously%2C%20but%20it%20does%20not%20clear%20%60incrementAuthFailuresChain%5Bkey%5D%60.%20any%20in-flight%20%60incrementAuthFailures%60%20promise%20that%20resolves%20after%20this%20deletion%20will%20re-set%20the%20key%20to%20%601%60%2C%20leaving%20a%20stale%20failure%20entry%20for%20a%20refresh%20token%20that%20no%20longer%20has%20any%20associated%20account.%20the%20entry%20persists%20until%20the%20%60AccountManager%60%20is%20GC'd.%20functionally%20harmless%20today%20%28no%20account%20reads%20this%20key%20after%20removal%29%2C%20but%20it's%20a%20ghost%20write%20that%20violates%20the%20cleanup%20contract.%0A%0Aadd%20one%20line%20before%20the%20%60return%60%3A%0A%0A%60%60%60ts%0Athis.state.authFailuresByRefreshToken.delete%28refreshToken%29%3B%0Athis.state.incrementAuthFailuresChain.delete%28refreshToken%29%3B%20%2F%2F%20cancel%20any%20in-flight%20chain%0Areturn%20removedCount%3B%0A%60%60%60%0A%0A%28or%20colocate%20the%20chain%20on%20%60AccountRecovery%60%20as%20suggested%20above%2C%20which%20eliminates%20the%20issue%20entirely.%29%0A%0A%23%23%23%20Issue%203%20of%204%0Alib%2Faccounts%2Frecovery.ts%3A35-36%0A**Module-level%20mutable%20cache%20is%20process-wide%20state**%0A%0A%60codexCliTokenCache%60%20and%20%60codexCliTokenCacheLoadedAt%60%20are%20module%20singletons.%20creating%20a%20second%20%60AccountManager%60%20%28e.g.%2C%20during%20cache%20invalidation%29%20silently%20shares%20this%20cache%20with%20the%20replaced%20instance.%20the%20%60VITEST_WORKER_ID%60%20guard%20prevents%20this%20from%20biting%20tests%2C%20but%20if%20a%20test%20ever%20synthesizes%20a%20non-test%20env%20%28e.g.%2C%20%60delete%20process.env.VITEST_WORKER_ID%60%29%2C%20it%20will%20hit%20a%20stale%20cross-instance%20cache.%20worth%20noting%20on%20windows%20specifically%3A%20a%20locked%20%60accounts.json%60%20write%20from%20another%20process%20will%20leave%20the%20cache%20%60null%60%20for%20up%20to%205%20s%20of%20TTL%20%E2%80%94%20this%20is%20caught%20and%20debug-logged%2C%20but%20the%20silent%20null-return%20could%20mask%20a%20transient%20disk-lock%20error%20on%20windows%20as%20a%20missing%20cache%20entry.%0A%0A%23%23%23%20Issue%204%20of%204%0Alib%2Faccounts%2Fstate.ts%3A72-85%0A**No%20direct%20vitest%20unit%20tests%20for%20any%20of%20the%20four%20new%20services**%0A%0A%60AccountState%60%2C%20%60AccountPersistence%60%2C%20%60AccountRotation%60%2C%20and%20%60AccountRecovery%60%20are%20exercised%20only%20through%20%60AccountManager%60's%20existing%20test%20surface.%20each%20service%20now%20has%20clear%2C%20testable%20boundaries%20%28e.g.%2C%20%60AccountState.removeAccount%60%20cursor-fixup%20paths%2C%20%60AccountPersistence.flushPendingSave%60%20race%20window%2C%20%60AccountRecovery.incrementAuthFailures%60%20serialization%29.%20isolating%20them%20in%20vitest%20would%20make%20the%20PR%20%23108%20and%20PR%20%23110%20guarantees%20machine-verifiable%20and%20protect%20against%20regressions%20in%20future%20RC-8%20wiring.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: lib/accounts/state.ts
Line: 85

Comment:
**`incrementAuthFailuresChain` belongs on `AccountRecovery`, not `AccountState`**

`AccountState` is documented as a "narrow surface" for mutation — only `AccountRecovery` ever reads or writes `incrementAuthFailuresChain`. putting this promise-chain map on the shared state object exposes the serialization internals to `AccountPersistence` and `AccountRotation`, which have no business touching it. moving it to `AccountRecovery` tightens the invariant and makes the PR #108 guarantee self-contained in the module that owns it.

```ts
// in AccountRecovery:
private readonly incrementAuthFailuresChain: Map<string, Promise<number>> = new Map();
```

then all three reads/writes in `incrementAuthFailures` move from `this.state.incrementAuthFailuresChain` to `this.incrementAuthFailuresChain` — no other callers are affected.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: lib/accounts/recovery.ts
Line: 255-272

Comment:
**Ghost write after `removeAccountsWithSameRefreshToken`**

the function deletes `authFailuresByRefreshToken[key]` synchronously, but it does not clear `incrementAuthFailuresChain[key]`. any in-flight `incrementAuthFailures` promise that resolves after this deletion will re-set the key to `1`, leaving a stale failure entry for a refresh token that no longer has any associated account. the entry persists until the `AccountManager` is GC'd. functionally harmless today (no account reads this key after removal), but it's a ghost write that violates the cleanup contract.

add one line before the `return`:

```ts
this.state.authFailuresByRefreshToken.delete(refreshToken);
this.state.incrementAuthFailuresChain.delete(refreshToken); // cancel any in-flight chain
return removedCount;
```

(or colocate the chain on `AccountRecovery` as suggested above, which eliminates the issue entirely.)

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: lib/accounts/recovery.ts
Line: 35-36

Comment:
**Module-level mutable cache is process-wide state**

`codexCliTokenCache` and `codexCliTokenCacheLoadedAt` are module singletons. creating a second `AccountManager` (e.g., during cache invalidation) silently shares this cache with the replaced instance. the `VITEST_WORKER_ID` guard prevents this from biting tests, but if a test ever synthesizes a non-test env (e.g., `delete process.env.VITEST_WORKER_ID`), it will hit a stale cross-instance cache. worth noting on windows specifically: a locked `accounts.json` write from another process will leave the cache `null` for up to 5 s of TTL — this is caught and debug-logged, but the silent null-return could mask a transient disk-lock error on windows as a missing cache entry.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: lib/accounts/state.ts
Line: 72-85

Comment:
**No direct vitest unit tests for any of the four new services**

`AccountState`, `AccountPersistence`, `AccountRotation`, and `AccountRecovery` are exercised only through `AccountManager`'s existing test surface. each service now has clear, testable boundaries (e.g., `AccountState.removeAccount` cursor-fixup paths, `AccountPersistence.flushPendingSave` race window, `AccountRecovery.incrementAuthFailures` serialization). isolating them in vitest would make the PR #108 and PR #110 guarantees machine-verifiable and protect against regressions in future RC-8 wiring.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(rc-7): split AccountManager int..."](https://github.com/ndycode/oc-codex-multi-auth/commit/e79194dca99b25fbf5b26f8e8fa3f9adc8bad0b0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28740535)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->