### PR TITLE
refactor(rc-8): wire circuit-breaker half-open state into request pipeline

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -155,6 +155,7 @@ import {
 	resetRateLimitBackoff,
 } from "./lib/request/rate-limit-backoff.js";
 import { isEmptyResponse } from "./lib/request/response-handler.js";
+import { getCircuitBreaker } from "./lib/circuit-breaker.js";
 import {
 	RetryBudgetTracker,
 	resolveRetryBudgetLimits,
@@ -1866,9 +1867,35 @@ while (attempted.size < Math.max(1, accountCount)) {
 									break;
 								}
 
+							// RC-8: per-(account, family) circuit-breaker key. The breaker gates
+							// upstream calls so that repeated failures short-circuit to the
+							// rotation path instead of hammering a degraded endpoint.
+							const circuitBreakerKey = `${accountId}:${modelFamily}`;
+							const circuitBreaker = getCircuitBreaker(circuitBreakerKey);
+
 							while (true) {
 								let response: Response;
 								const fetchStart = performance.now();
+
+								// RC-8: consult the breaker BEFORE firing upstream. When the gate is
+								// closed every call passes through unchanged. When the gate denies
+								// (open within cooldown, or half-open with a probe already in
+								// flight) we short-circuit to the rotation path instead of
+								// retrying here. We classify the short-circuit as `circuit-open`
+								// so observability traces and the runtime metrics agree with the
+								// `CircuitOpenError` type exported from `lib/errors.ts`.
+								const breakerCheck = circuitBreaker.canAttempt();
+								if (!breakerCheck.allowed) {
+									const shortCircuitMessage = `Circuit ${breakerCheck.state} for ${circuitBreakerKey}`;
+									logWarn(
+										`[circuit-breaker] ${shortCircuitMessage} (reason=${breakerCheck.reason ?? "denied"}). Rotating account.`,
+									);
+									accountManager.refundToken(account, modelFamily, model);
+									runtimeMetrics.accountRotations++;
+									runtimeMetrics.lastError = shortCircuitMessage;
+									runtimeMetrics.lastErrorCategory = "circuit-open";
+									break;
+								}
 
 								// Merge user AbortSignal with timeout (Node 18 compatible - no AbortSignal.any)
 								const fetchController = new AbortController();
@@ -1939,6 +1966,10 @@ while (attempted.size < Math.max(1, accountCount)) {
 								runtimeMetrics.lastErrorCategory = "network";
 								accountManager.refundToken(account, modelFamily, model);
 								accountManager.recordFailure(account, modelFamily, model);
+								// RC-8: network failures feed the breaker so a degraded upstream
+								// trips the gate for this (account, family) key after N hits
+								// inside the failure window.
+								circuitBreaker.recordFailure();
 								break;
 							} finally {
 								clearTimeout(fetchTimeoutId);
@@ -2195,6 +2226,11 @@ while (attempted.size < Math.max(1, accountCount)) {
 						runtimeMetrics.lastErrorCategory = "server";
 						accountManager.refundToken(account, modelFamily, model);
 						accountManager.recordFailure(account, modelFamily, model);
+						// RC-8: 5xx responses are treated the same as network failures by
+						// the breaker — they indicate an upstream fault rather than a
+						// client-side classifier decision (401/403/404/429 are handled
+						// upstream and do not feed the breaker).
+						circuitBreaker.recordFailure();
 						if (
 							!consumeRetryBudget(
 								"server",
@@ -2325,6 +2361,9 @@ while (attempted.size < Math.max(1, accountCount)) {
 					}
 
 					accountManager.recordSuccess(account, modelFamily, model);
+					// RC-8: closes a half-open gate or prunes the failure window so a
+					// sequence of successes keeps the breaker healthy.
+					circuitBreaker.recordSuccess();
 					runtimeMetrics.successfulRequests++;
 					runtimeMetrics.lastError = null;
 					runtimeMetrics.lastErrorCategory = null;

--- a/lib/circuit-breaker.ts
+++ b/lib/circuit-breaker.ts
@@ -18,6 +18,23 @@ export const DEFAULT_CIRCUIT_BREAKER_CONFIG: CircuitBreakerConfig = {
 
 export type CircuitState = "closed" | "open" | "half-open";
 
+/**
+ * Non-throwing gate check result returned by {@link CircuitBreaker.canAttempt}.
+ *
+ * Unlike {@link CircuitBreaker.canExecute} (which throws `CircuitOpenError`
+ * when the gate denies the call), `canAttempt` returns this result so the
+ * request pipeline can decide whether to short-circuit, rotate accounts,
+ * or emit typed errors without a try/catch around every upstream call.
+ */
+export interface CanAttemptResult {
+	/** True when the caller may proceed to the protected dependency. */
+	allowed: boolean;
+	/** Current breaker state at the time of the check. */
+	state: CircuitState;
+	/** Populated when `allowed` is false. Stable machine-readable reason. */
+	reason?: "open" | "probe-in-flight";
+}
+
 export class CircuitBreaker {
 	private state: CircuitState = "closed";
 	private failures: number[] = [];
@@ -27,6 +44,49 @@ export class CircuitBreaker {
 
 	constructor(config: Partial<CircuitBreakerConfig> = {}) {
 		this.config = { ...DEFAULT_CIRCUIT_BREAKER_CONFIG, ...config };
+	}
+
+	/**
+	 * Non-throwing gate check used by the request pipeline.
+	 *
+	 * Semantics parallel {@link canExecute} but the caller receives a
+	 * {@link CanAttemptResult} instead of an exception:
+	 * - `closed` → `{ allowed: true, state: "closed" }`
+	 * - `open` past cooldown → auto-transitions to `half-open` then admits a
+	 *   single probe; returns `{ allowed: true, state: "half-open" }`
+	 * - `open` within cooldown → `{ allowed: false, state: "open", reason: "open" }`
+	 * - `half-open` with in-flight probe → `{ allowed: false, state: "half-open", reason: "probe-in-flight" }`
+	 *
+	 * HALF-OPEN probe serialization: the first caller increments
+	 * `halfOpenAttempts` and proceeds; subsequent callers see the budget
+	 * exhausted and are denied with `probe-in-flight`. The probe slot is
+	 * released on the next {@link recordSuccess} (closes) or
+	 * {@link recordFailure} (reopens), which both reset `halfOpenAttempts`.
+	 */
+	canAttempt(): CanAttemptResult {
+		const now = Date.now();
+
+		if (this.state === "open") {
+			if (now - this.lastStateChange >= this.config.resetTimeoutMs) {
+				this.transitionToHalfOpen(now);
+			} else {
+				return { allowed: false, state: "open", reason: "open" };
+			}
+		}
+
+		if (this.state === "half-open") {
+			if (this.halfOpenAttempts >= this.config.halfOpenMaxAttempts) {
+				return {
+					allowed: false,
+					state: "half-open",
+					reason: "probe-in-flight",
+				};
+			}
+			this.halfOpenAttempts += 1;
+			return { allowed: true, state: "half-open" };
+		}
+
+		return { allowed: true, state: "closed" };
 	}
 
 	canExecute(): boolean {

--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -210,15 +210,39 @@ export class StorageError extends CodexError {
 }
 
 /**
+ * Options carried by {@link CircuitOpenError} when raised from the request
+ * pipeline so callers can classify the short-circuit without parsing the
+ * message string.
+ */
+export interface CircuitOpenErrorOptions {
+	/** The breaker key that denied the call, e.g. `account:modelFamily`. */
+	breakerKey?: string;
+	/** Snapshot of the breaker state at denial time (`open` | `half-open`). */
+	state?: "open" | "half-open";
+	/** Machine-readable denial reason from `CanAttemptResult`. */
+	reason?: "open" | "probe-in-flight";
+}
+
+/**
  * Error thrown when a circuit breaker is open (or half-open past its attempt
  * budget) and further calls must short-circuit instead of hitting the
  * protected dependency.
+ *
+ * When constructed from the request pipeline's gate check, {@link breakerKey},
+ * {@link state}, and {@link reason} carry the metadata needed by the rotation
+ * path to pick a different account/family without re-querying the breaker.
  */
 export class CircuitOpenError extends CodexError {
 	override readonly name = "CircuitOpenError";
+	readonly breakerKey?: string;
+	readonly state?: "open" | "half-open";
+	readonly reason?: "open" | "probe-in-flight";
 
-	constructor(message = "Circuit is open") {
+	constructor(message = "Circuit is open", options?: CircuitOpenErrorOptions) {
 		super(message, { code: ErrorCode.CIRCUIT_OPEN });
+		this.breakerKey = options?.breakerKey;
+		this.state = options?.state;
+		this.reason = options?.reason;
 	}
 }
 

--- a/test/circuit-breaker-wiring.test.ts
+++ b/test/circuit-breaker-wiring.test.ts
@@ -1,0 +1,178 @@
+/**
+ * RC-8 — wiring tests for the non-throwing `canAttempt` gate.
+ *
+ * These tests exercise the request-pipeline contract: `canAttempt` returns a
+ * `CanAttemptResult` without throwing, so the dispatcher in `index.ts` can
+ * short-circuit to the rotation path. State transitions (CLOSED → OPEN,
+ * OPEN → HALF_OPEN after cooldown, HALF_OPEN → CLOSED on probe success,
+ * HALF_OPEN → OPEN on probe failure, concurrent-probe rejection) are verified
+ * here — the existing `test/circuit-breaker.test.ts` keeps coverage for the
+ * legacy throwing `canExecute` surface.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+	CircuitBreaker,
+	CircuitOpenError,
+	DEFAULT_CIRCUIT_BREAKER_CONFIG,
+} from "../lib/circuit-breaker.js";
+
+const { failureThreshold, resetTimeoutMs } = DEFAULT_CIRCUIT_BREAKER_CONFIG;
+
+describe("circuit-breaker: wired gate (canAttempt)", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date(0));
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("CLOSED: allows the call and reports state=closed", () => {
+		const breaker = new CircuitBreaker();
+		const result = breaker.canAttempt();
+		expect(result.allowed).toBe(true);
+		expect(result.state).toBe("closed");
+		expect(result.reason).toBeUndefined();
+	});
+
+	it("CLOSED → OPEN: denies the call once failureThreshold reached within the window", () => {
+		const breaker = new CircuitBreaker();
+		for (let i = 0; i < failureThreshold; i++) {
+			breaker.recordFailure();
+		}
+		expect(breaker.getState()).toBe("open");
+
+		const result = breaker.canAttempt();
+		expect(result.allowed).toBe(false);
+		expect(result.state).toBe("open");
+		expect(result.reason).toBe("open");
+	});
+
+	it("OPEN → HALF_OPEN: auto-transitions after cooldown and admits a probe", () => {
+		const breaker = new CircuitBreaker();
+		for (let i = 0; i < failureThreshold; i++) {
+			breaker.recordFailure();
+		}
+		expect(breaker.getState()).toBe("open");
+
+		// Advance past the cooldown window.
+		vi.setSystemTime(new Date(resetTimeoutMs + 1));
+
+		const first = breaker.canAttempt();
+		expect(first.allowed).toBe(true);
+		expect(first.state).toBe("half-open");
+		expect(breaker.getState()).toBe("half-open");
+	});
+
+	it("HALF_OPEN: first probe allowed, concurrent probe rejected with probe-in-flight", () => {
+		const breaker = new CircuitBreaker();
+		for (let i = 0; i < failureThreshold; i++) {
+			breaker.recordFailure();
+		}
+		vi.setSystemTime(new Date(resetTimeoutMs + 1));
+
+		const first = breaker.canAttempt();
+		expect(first.allowed).toBe(true);
+		expect(first.state).toBe("half-open");
+
+		// A second concurrent caller (no recordSuccess / recordFailure yet) sees
+		// the probe slot already consumed and is denied without throwing.
+		const second = breaker.canAttempt();
+		expect(second.allowed).toBe(false);
+		expect(second.state).toBe("half-open");
+		expect(second.reason).toBe("probe-in-flight");
+	});
+
+	it("HALF_OPEN → CLOSED: probe success closes the gate and allows the next caller", () => {
+		const breaker = new CircuitBreaker();
+		for (let i = 0; i < failureThreshold; i++) {
+			breaker.recordFailure();
+		}
+		vi.setSystemTime(new Date(resetTimeoutMs + 1));
+
+		expect(breaker.canAttempt().allowed).toBe(true);
+		breaker.recordSuccess();
+		expect(breaker.getState()).toBe("closed");
+
+		const next = breaker.canAttempt();
+		expect(next.allowed).toBe(true);
+		expect(next.state).toBe("closed");
+	});
+
+	it("HALF_OPEN → OPEN: probe failure reopens and resets the cooldown", () => {
+		const breaker = new CircuitBreaker();
+		for (let i = 0; i < failureThreshold; i++) {
+			breaker.recordFailure();
+		}
+		vi.setSystemTime(new Date(resetTimeoutMs + 1));
+
+		// Admit the probe…
+		expect(breaker.canAttempt().allowed).toBe(true);
+
+		// …and fail it. The breaker must reopen with a fresh cooldown window
+		// so subsequent callers are denied until the timer elapses again.
+		breaker.recordFailure();
+		expect(breaker.getState()).toBe("open");
+
+		const immediate = breaker.canAttempt();
+		expect(immediate.allowed).toBe(false);
+		expect(immediate.state).toBe("open");
+		expect(immediate.reason).toBe("open");
+
+		// Cooldown advances relative to the reopen timestamp, not the original
+		// open transition.
+		vi.setSystemTime(new Date(resetTimeoutMs + 2 + resetTimeoutMs + 1));
+		const recovered = breaker.canAttempt();
+		expect(recovered.allowed).toBe(true);
+		expect(recovered.state).toBe("half-open");
+	});
+
+	it("respects a custom halfOpenMaxAttempts > 1 before denying with probe-in-flight", () => {
+		const breaker = new CircuitBreaker({ halfOpenMaxAttempts: 2 });
+		for (let i = 0; i < failureThreshold; i++) {
+			breaker.recordFailure();
+		}
+		vi.setSystemTime(new Date(resetTimeoutMs + 1));
+
+		expect(breaker.canAttempt().allowed).toBe(true);
+		expect(breaker.canAttempt().allowed).toBe(true);
+		const third = breaker.canAttempt();
+		expect(third.allowed).toBe(false);
+		expect(third.reason).toBe("probe-in-flight");
+	});
+
+	it("canAttempt does not regress existing canExecute behavior", () => {
+		// canExecute still throws on the denial paths so the legacy surface
+		// used by other call sites is preserved.
+		const breaker = new CircuitBreaker();
+		for (let i = 0; i < failureThreshold; i++) {
+			breaker.recordFailure();
+		}
+		expect(() => breaker.canExecute()).toThrow(CircuitOpenError);
+	});
+});
+
+describe("CircuitOpenError (typed short-circuit payload)", () => {
+	it("carries breakerKey, state, and reason when constructed from the pipeline", () => {
+		const error = new CircuitOpenError("Circuit open for acct:gpt-5", {
+			breakerKey: "acct:gpt-5",
+			state: "open",
+			reason: "open",
+		});
+		expect(error).toBeInstanceOf(CircuitOpenError);
+		expect(error.code).toBe("CODEX_CIRCUIT_OPEN");
+		expect(error.breakerKey).toBe("acct:gpt-5");
+		expect(error.state).toBe("open");
+		expect(error.reason).toBe("open");
+	});
+
+	it("preserves the zero-argument constructor for backward compatibility", () => {
+		const error = new CircuitOpenError();
+		expect(error.message).toBe("Circuit is open");
+		expect(error.breakerKey).toBeUndefined();
+		expect(error.state).toBeUndefined();
+		expect(error.reason).toBeUndefined();
+	});
+});


### PR DESCRIPTION
## Summary

Phase-2 refactor **RC-8** (final Phase 2 item). Wires the half-open gate from `lib/circuit-breaker.ts` into the request pipeline so the breaker actually modulates retries per `(account, family)` key.

## Problem

Prior to this PR, the breaker state machine existed but was **never consulted before firing upstream requests**. Open-state short-circuiting and half-open probe serialization were effectively dead code; the only consumer of `getCircuitBreaker()` was `lib/health.ts` (read-only reporting). As a result, during a cascading failure window the pipeline kept hammering dead accounts and retrying immediately, wasting retry budget and delaying recovery.

## Changes

- **`lib/circuit-breaker.ts`** - added non-throwing `canAttempt(): CanAttemptResult` alongside the existing throwing `canExecute()`. Returns `{ allowed, state, reason }` so the dispatcher can branch cleanly without a try/catch. HALF-OPEN probe serialization uses the existing `halfOpenAttempts` counter (one in-flight per key by default); subsequent callers receive `{ allowed: false, reason: "probe-in-flight" }`.
- **`lib/errors.ts`** - extended `CircuitOpenError` with optional `breakerKey`, `state`, and `reason`. Zero-arg and single-arg constructors preserved for backward compat.
- **`index.ts`** - inside the per-account retry loop (main dispatcher ~line 1871), compute `breakerKey = ${accountId}:${modelFamily}`, consult `canAttempt()` before every `fetch()`, and on denial emit a structured log + refund the local token + break to the rotation path with `lastErrorCategory = "circuit-open"`. After the fetch:
  - successful responses -> `circuitBreaker.recordSuccess()`
  - 5xx responses -> `circuitBreaker.recordFailure()`
  - network errors -> `circuitBreaker.recordFailure()`
  - 401/403/404/429 do **not** feed the breaker (handled by existing classifiers).
- **`test/circuit-breaker-wiring.test.ts`** - 10 new tests covering CLOSED->OPEN, OPEN->HALF_OPEN after cooldown, HALF_OPEN->CLOSED on probe success, HALF_OPEN->OPEN on probe failure (with cooldown reset), concurrent-probe rejection, customized `halfOpenMaxAttempts`, `canExecute` non-regression, and the `CircuitOpenError` payload.

## Compatibility

- Public signatures of existing breaker methods (`canExecute`, `recordSuccess`, `recordFailure`, `getState`, `reset`, `getFailureCount`, `getTimeUntilReset`) are unchanged.
- Existing retry-budget and rate-limit-backoff behavior compose unchanged; the breaker is additive.
- No `as any`, `@ts-ignore`, or `@ts-expect-error`.

## Audit refs

- `docs/audits/07-refactoring-plan.md#rc-8`
- `docs/audits/13-phased-roadmap.md` Section 2.6 (Phase 2 final)

## Verification

```
npm run typecheck   # clean
npm run lint        # clean
npm test            # 2131 passed (baseline 2121 + 10 new breaker tests)
npm run build       # clean
```

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---


<h3>Greptile Summary</h3>

this PR wires the existing `CircuitBreaker` into the request dispatcher via the new non-throwing `canAttempt()` gate, keyed per `(accountId, modelFamily)`. the breaker shape and backward compatibility look solid, but two error-exit paths in `index.ts` consume a half-open probe slot via `canAttempt()` yet never call `recordSuccess()` or `recordFailure()`, permanently locking that breaker key in `probe-in-flight` denial once hit.

- **context-overflow early return** (line 1992-1993): `return contextOverflowResult.response` exits the function without releasing the half-open probe slot — the server responded, so `circuitBreaker.recordSuccess()` should precede the return.
- **empty-response retry break** (lines 2351-2352): `accountManager.recordFailure()` is called but `circuitBreaker.recordFailure()` is not, same slot-leak consequence.

<h3>Confidence Score: 4/5</h3>

two P1 probe-slot leaks in index.ts must be fixed before merge; the breaker and error-class changes are solid

the canAttempt gate, state machine, and error-class extension are correct. two paths in the dispatcher (context-overflow early return and empty-response retry break) consume a half-open probe without releasing it, permanently locking that (account, family) key — these are present defects on changed code. fixes are one-liners in both cases

index.ts lines 1991-1993 (context-overflow return) and 2350-2354 (empty-response retry break)

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| index.ts | circuit-breaker gate wired correctly for network/5xx/success paths, but two error exits (context-overflow return, empty-response retry break) consume the half-open probe slot without calling any breaker record method, permanently locking the (account, family) pair in probe-in-flight denial |
| lib/circuit-breaker.ts | new `canAttempt()` / `CanAttemptResult` surface is clean and non-throwing; state machine transitions, halfOpenAttempts serialization, and the FIFO map-cap are all correct; minor coupling concern with `canExecute` sharing the same counter |
| lib/errors.ts | `CircuitOpenError` extended with `breakerKey`, `state`, and `reason` options; zero-arg and single-arg constructors preserved for backward compat; no issues |
| test/circuit-breaker-wiring.test.ts | 10 new vitest cases cover the main state-transition paths and canExecute non-regression well, but probe-slot-leak scenarios (canAttempt called, then neither recordSuccess nor recordFailure) and dispatcher-level integration are not covered |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant D as Dispatcher (index.ts)
    participant CB as CircuitBreaker
    participant AM as AccountManager
    participant API as Upstream API

    D->>CB: getCircuitBreaker(accountId:family)
    loop per-retry (while true)
        D->>CB: canAttempt()
        alt allowed: false (open / probe-in-flight)
            CB-->>D: {allowed:false, reason}
            D->>AM: refundToken()
            D-->>D: break → rotate account
        else allowed: true
            CB-->>D: {allowed:true, state}
            D->>API: fetch(request)
            alt network error
                API-->>D: throws
                D->>CB: recordFailure()
                D-->>D: break
            else 5xx
                API-->>D: 5xx response
                D->>CB: recordFailure()
                D-->>D: break
            else context overflow ⚠️
                API-->>D: error response
                D-->>D: return (NO breaker call — probe slot leaked)
            else empty response retry ⚠️
                API-->>D: 200 empty body
                D->>AM: recordFailure()
                D-->>D: break (NO circuitBreaker.recordFailure)
            else 401/403/404/429
                API-->>D: client error
                D-->>D: break (intentionally skips breaker)
            else success
                API-->>D: 200 OK
                D->>CB: recordSuccess()
                D-->>D: return response
            end
        end
    end
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `index.ts`, line 1991-1993 ([link](https://github.com/ndycode/oc-codex-multi-auth/blob/8b3ec8455bad6a494ac2f0986c9ae45928083e8d/index.ts#L1991-L1993)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **half-open probe slot leaked on context-overflow return**

   when `canAttempt()` transitions the breaker to `half-open` and increments `halfOpenAttempts`, this early return exits the function without ever calling `circuitBreaker.recordSuccess()` or `recordFailure()`. `halfOpenAttempts` stays at `1` and every subsequent `canAttempt()` for this `(accountId, modelFamily)` key returns `{allowed:false, reason:"probe-in-flight"}` indefinitely — no state transition can un-stick it. context-overflow means the server responded (infrastructure is healthy), so `recordSuccess()` is the correct call before returning.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: index.ts
   Line: 1991-1993

   Comment:
   **half-open probe slot leaked on context-overflow return**

   when `canAttempt()` transitions the breaker to `half-open` and increments `halfOpenAttempts`, this early return exits the function without ever calling `circuitBreaker.recordSuccess()` or `recordFailure()`. `halfOpenAttempts` stays at `1` and every subsequent `canAttempt()` for this `(accountId, modelFamily)` key returns `{allowed:false, reason:"probe-in-flight"}` indefinitely — no state transition can un-stick it. context-overflow means the server responded (infrastructure is healthy), so `recordSuccess()` is the correct call before returning.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Foc-codex-multi-auth%22%20on%20the%20existing%20branch%20%22refactor%2Frc-8-circuit-breaker-wiring%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22refactor%2Frc-8-circuit-breaker-wiring%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20index.ts%0ALine%3A%201991-1993%0A%0AComment%3A%0A**half-open%20probe%20slot%20leaked%20on%20context-overflow%20return**%0A%0Awhen%20%60canAttempt%28%29%60%20transitions%20the%20breaker%20to%20%60half-open%60%20and%20increments%20%60halfOpenAttempts%60%2C%20this%20early%20return%20exits%20the%20function%20without%20ever%20calling%20%60circuitBreaker.recordSuccess%28%29%60%20or%20%60recordFailure%28%29%60.%20%60halfOpenAttempts%60%20stays%20at%20%601%60%20and%20every%20subsequent%20%60canAttempt%28%29%60%20for%20this%20%60%28accountId%2C%20modelFamily%29%60%20key%20returns%20%60%7Ballowed%3Afalse%2C%20reason%3A%22probe-in-flight%22%7D%60%20indefinitely%20%E2%80%94%20no%20state%20transition%20can%20un-stick%20it.%20context-overflow%20means%20the%20server%20responded%20%28infrastructure%20is%20healthy%29%2C%20so%20%60recordSuccess%28%29%60%20is%20the%20correct%20call%20before%20returning.%0A%0A%60%60%60suggestion%0A%09%09%09%09%09const%20contextOverflowResult%20%3D%20await%20handleContextOverflow%28response%2C%20model%29%3B%0A%09%09%09%09%09if%20%28contextOverflowResult.handled%29%20%7B%0A%09%09%09%09%09%09circuitBreaker.recordSuccess%28%29%3B%0A%09%09%09%09%09%09return%20contextOverflowResult.response%3B%0A%09%09%09%09%09%7D%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>


2. `index.ts`, line 2350-2354 ([link](https://github.com/ndycode/oc-codex-multi-auth/blob/8b3ec8455bad6a494ac2f0986c9ae45928083e8d/index.ts#L2350-L2354)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **half-open probe slot leaked in empty-response retry path**

   `accountManager.recordFailure()` is called (correct for account state) but `circuitBreaker.recordFailure()` is not. if the breaker was in `half-open` when the probe was admitted, `halfOpenAttempts` stays at `1` and the gate is permanently stuck in `probe-in-flight` denial for this `(accountId, modelFamily)` key — same as the context-overflow path above. the server did respond (empty body is a server-side quirk, not infrastructure down), so `circuitBreaker.recordSuccess()` is arguably correct here too; at minimum `recordFailure()` must be called so `transitionToOpen()` resets `halfOpenAttempts`.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: index.ts
   Line: 2350-2354

   Comment:
   **half-open probe slot leaked in empty-response retry path**

   `accountManager.recordFailure()` is called (correct for account state) but `circuitBreaker.recordFailure()` is not. if the breaker was in `half-open` when the probe was admitted, `halfOpenAttempts` stays at `1` and the gate is permanently stuck in `probe-in-flight` denial for this `(accountId, modelFamily)` key — same as the context-overflow path above. the server did respond (empty body is a server-side quirk, not infrastructure down), so `circuitBreaker.recordSuccess()` is arguably correct here too; at minimum `recordFailure()` must be called so `transitionToOpen()` resets `halfOpenAttempts`.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Foc-codex-multi-auth%22%20on%20the%20existing%20branch%20%22refactor%2Frc-8-circuit-breaker-wiring%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22refactor%2Frc-8-circuit-breaker-wiring%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20index.ts%0ALine%3A%202350-2354%0A%0AComment%3A%0A**half-open%20probe%20slot%20leaked%20in%20empty-response%20retry%20path**%0A%0A%60accountManager.recordFailure%28%29%60%20is%20called%20%28correct%20for%20account%20state%29%20but%20%60circuitBreaker.recordFailure%28%29%60%20is%20not.%20if%20the%20breaker%20was%20in%20%60half-open%60%20when%20the%20probe%20was%20admitted%2C%20%60halfOpenAttempts%60%20stays%20at%20%601%60%20and%20the%20gate%20is%20permanently%20stuck%20in%20%60probe-in-flight%60%20denial%20for%20this%20%60%28accountId%2C%20modelFamily%29%60%20key%20%E2%80%94%20same%20as%20the%20context-overflow%20path%20above.%20the%20server%20did%20respond%20%28empty%20body%20is%20a%20server-side%20quirk%2C%20not%20infrastructure%20down%29%2C%20so%20%60circuitBreaker.recordSuccess%28%29%60%20is%20arguably%20correct%20here%20too%3B%20at%20minimum%20%60recordFailure%28%29%60%20must%20be%20called%20so%20%60transitionToOpen%28%29%60%20resets%20%60halfOpenAttempts%60.%0A%0A%60%60%60suggestion%0A%09%09%09%09%09%09%09%09%09emptyResponseRetries%2B%2B%3B%0A%09%09%09%09%09%09%09%09%09runtimeMetrics.emptyResponseRetries%2B%2B%3B%0A%09%09%09%09%09%09%09%09%09logWarn%28%60Empty%20response%20received%20%28attempt%20%24%7BemptyResponseRetries%7D%2F%24%7BemptyResponseMaxRetries%7D%29.%20Retrying...%60%29%3B%0A%09%09%09%09%09%09%09%09%09await%20showToast%28%0A%09%09%09%09%09%09%09%09%09%09%60Empty%20response.%20Retrying%20%28%24%7BemptyResponseRetries%7D%2F%24%7BemptyResponseMaxRetries%7D%29...%60%2C%0A%09%09%09%09%09%09%09%09%09%09%22warning%22%2C%0A%09%09%09%09%09%09%09%09%09%09%7B%20duration%3A%20toastDurationMs%20%7D%2C%0A%09%09%09%09%09%09%09%09%09%29%3B%0A%09%09%09%09%09%09%09%09%09accountManager.refundToken%28account%2C%20modelFamily%2C%20model%29%3B%0A%09%09%09%09%09%09%09%09%09accountManager.recordFailure%28account%2C%20modelFamily%2C%20model%29%3B%0A%09%09%09%09%09%09%09%09%09circuitBreaker.recordFailure%28%29%3B%0A%09%09%09%09%09%09%09%09%09await%20sleep%28addJitter%28emptyResponseRetryDelayMs%2C%200.2%29%29%3B%0A%09%09%09%09%09%09%09%09%09break%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>


3. `lib/circuit-breaker.ts`, line 92-112 ([link](https://github.com/ndycode/oc-codex-multi-auth/blob/8b3ec8455bad6a494ac2f0986c9ae45928083e8d/lib/circuit-breaker.ts#L92-L112)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`canExecute` and `canAttempt` share the same `halfOpenAttempts` counter**

   both methods increment `halfOpenAttempts` when in `half-open` state. the health reporter in `lib/health.ts` calls `getState()` (read-only, fine), but if any future call site invokes `canExecute()` on the same breaker instance that the dispatcher is using for `canAttempt()`, the two callers together can exhaust the probe budget in one shot — e.g. `halfOpenMaxAttempts: 2` would allow one probe from each path but deny a third before the upstream result is known. worth a comment noting that both consumers share the counter, or consider a private `_advanceHalfOpenCounter()` helper they both delegate to so the coupling is explicit.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: lib/circuit-breaker.ts
   Line: 92-112

   Comment:
   **`canExecute` and `canAttempt` share the same `halfOpenAttempts` counter**

   both methods increment `halfOpenAttempts` when in `half-open` state. the health reporter in `lib/health.ts` calls `getState()` (read-only, fine), but if any future call site invokes `canExecute()` on the same breaker instance that the dispatcher is using for `canAttempt()`, the two callers together can exhaust the probe budget in one shot — e.g. `halfOpenMaxAttempts: 2` would allow one probe from each path but deny a third before the upstream result is known. worth a comment noting that both consumers share the counter, or consider a private `_advanceHalfOpenCounter()` helper they both delegate to so the coupling is explicit.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Foc-codex-multi-auth%22%20on%20the%20existing%20branch%20%22refactor%2Frc-8-circuit-breaker-wiring%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22refactor%2Frc-8-circuit-breaker-wiring%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20lib%2Fcircuit-breaker.ts%0ALine%3A%2092-112%0A%0AComment%3A%0A**%60canExecute%60%20and%20%60canAttempt%60%20share%20the%20same%20%60halfOpenAttempts%60%20counter**%0A%0Aboth%20methods%20increment%20%60halfOpenAttempts%60%20when%20in%20%60half-open%60%20state.%20the%20health%20reporter%20in%20%60lib%2Fhealth.ts%60%20calls%20%60getState%28%29%60%20%28read-only%2C%20fine%29%2C%20but%20if%20any%20future%20call%20site%20invokes%20%60canExecute%28%29%60%20on%20the%20same%20breaker%20instance%20that%20the%20dispatcher%20is%20using%20for%20%60canAttempt%28%29%60%2C%20the%20two%20callers%20together%20can%20exhaust%20the%20probe%20budget%20in%20one%20shot%20%E2%80%94%20e.g.%20%60halfOpenMaxAttempts%3A%202%60%20would%20allow%20one%20probe%20from%20each%20path%20but%20deny%20a%20third%20before%20the%20upstream%20result%20is%20known.%20worth%20a%20comment%20noting%20that%20both%20consumers%20share%20the%20counter%2C%20or%20consider%20a%20private%20%60_advanceHalfOpenCounter%28%29%60%20helper%20they%20both%20delegate%20to%20so%20the%20coupling%20is%20explicit.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Foc-codex-multi-auth%22%20on%20the%20existing%20branch%20%22refactor%2Frc-8-circuit-breaker-wiring%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22refactor%2Frc-8-circuit-breaker-wiring%22.%0A%0AFix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Aindex.ts%3A1991-1993%0A**half-open%20probe%20slot%20leaked%20on%20context-overflow%20return**%0A%0Awhen%20%60canAttempt%28%29%60%20transitions%20the%20breaker%20to%20%60half-open%60%20and%20increments%20%60halfOpenAttempts%60%2C%20this%20early%20return%20exits%20the%20function%20without%20ever%20calling%20%60circuitBreaker.recordSuccess%28%29%60%20or%20%60recordFailure%28%29%60.%20%60halfOpenAttempts%60%20stays%20at%20%601%60%20and%20every%20subsequent%20%60canAttempt%28%29%60%20for%20this%20%60%28accountId%2C%20modelFamily%29%60%20key%20returns%20%60%7Ballowed%3Afalse%2C%20reason%3A%22probe-in-flight%22%7D%60%20indefinitely%20%E2%80%94%20no%20state%20transition%20can%20un-stick%20it.%20context-overflow%20means%20the%20server%20responded%20%28infrastructure%20is%20healthy%29%2C%20so%20%60recordSuccess%28%29%60%20is%20the%20correct%20call%20before%20returning.%0A%0A%60%60%60suggestion%0A%09%09%09%09%09const%20contextOverflowResult%20%3D%20await%20handleContextOverflow%28response%2C%20model%29%3B%0A%09%09%09%09%09if%20%28contextOverflowResult.handled%29%20%7B%0A%09%09%09%09%09%09circuitBreaker.recordSuccess%28%29%3B%0A%09%09%09%09%09%09return%20contextOverflowResult.response%3B%0A%09%09%09%09%09%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%204%0Aindex.ts%3A2350-2354%0A**half-open%20probe%20slot%20leaked%20in%20empty-response%20retry%20path**%0A%0A%60accountManager.recordFailure%28%29%60%20is%20called%20%28correct%20for%20account%20state%29%20but%20%60circuitBreaker.recordFailure%28%29%60%20is%20not.%20if%20the%20breaker%20was%20in%20%60half-open%60%20when%20the%20probe%20was%20admitted%2C%20%60halfOpenAttempts%60%20stays%20at%20%601%60%20and%20the%20gate%20is%20permanently%20stuck%20in%20%60probe-in-flight%60%20denial%20for%20this%20%60%28accountId%2C%20modelFamily%29%60%20key%20%E2%80%94%20same%20as%20the%20context-overflow%20path%20above.%20the%20server%20did%20respond%20%28empty%20body%20is%20a%20server-side%20quirk%2C%20not%20infrastructure%20down%29%2C%20so%20%60circuitBreaker.recordSuccess%28%29%60%20is%20arguably%20correct%20here%20too%3B%20at%20minimum%20%60recordFailure%28%29%60%20must%20be%20called%20so%20%60transitionToOpen%28%29%60%20resets%20%60halfOpenAttempts%60.%0A%0A%60%60%60suggestion%0A%09%09%09%09%09%09%09%09%09emptyResponseRetries%2B%2B%3B%0A%09%09%09%09%09%09%09%09%09runtimeMetrics.emptyResponseRetries%2B%2B%3B%0A%09%09%09%09%09%09%09%09%09logWarn%28%60Empty%20response%20received%20%28attempt%20%24%7BemptyResponseRetries%7D%2F%24%7BemptyResponseMaxRetries%7D%29.%20Retrying...%60%29%3B%0A%09%09%09%09%09%09%09%09%09await%20showToast%28%0A%09%09%09%09%09%09%09%09%09%09%60Empty%20response.%20Retrying%20%28%24%7BemptyResponseRetries%7D%2F%24%7BemptyResponseMaxRetries%7D%29...%60%2C%0A%09%09%09%09%09%09%09%09%09%09%22warning%22%2C%0A%09%09%09%09%09%09%09%09%09%09%7B%20duration%3A%20toastDurationMs%20%7D%2C%0A%09%09%09%09%09%09%09%09%09%29%3B%0A%09%09%09%09%09%09%09%09%09accountManager.refundToken%28account%2C%20modelFamily%2C%20model%29%3B%0A%09%09%09%09%09%09%09%09%09accountManager.recordFailure%28account%2C%20modelFamily%2C%20model%29%3B%0A%09%09%09%09%09%09%09%09%09circuitBreaker.recordFailure%28%29%3B%0A%09%09%09%09%09%09%09%09%09await%20sleep%28addJitter%28emptyResponseRetryDelayMs%2C%200.2%29%29%3B%0A%09%09%09%09%09%09%09%09%09break%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%204%0Atest%2Fcircuit-breaker-wiring.test.ts%3A1-11%0A**missing%20vitest%20coverage%20for%20probe-slot-leak%20scenarios**%0A%0Athe%20new%20test%20suite%20thoroughly%20covers%20%60canAttempt%60%20state%20transitions%20and%20the%20%60canExecute%60%20non-regression%2C%20but%20has%20no%20coverage%20for%20the%20two%20paths%20where%20the%20probe%20slot%20is%20consumed%20but%20never%20released%3A%0A%0A1.%20probe%20admitted%20%E2%86%92%20context-overflow%20early%20return%20%E2%86%92%20no%20breaker%20call%0A2.%20probe%20admitted%20%E2%86%92%20empty-response%20retry%20%E2%86%92%20only%20%60accountManager.recordFailure%60%2C%20no%20%60circuitBreaker%60%20call%0A%0Aadding%20these%20two%20cases%20would%20have%20caught%20the%20P1%20issues%20in%20%60index.ts%60%20before%20merge.%20there%20are%20also%20no%20dispatcher-level%20integration%20tests%20verifying%20that%20%60canAttempt%60%20is%20actually%20invoked%20at%20the%20correct%20point%20in%20the%20pipeline%20%28e.g.%20mocking%20%60getCircuitBreaker%60%20and%20asserting%20call%20order%20relative%20to%20%60fetch%60%29.%0A%0A%23%23%23%20Issue%204%20of%204%0Alib%2Fcircuit-breaker.ts%3A92-112%0A**%60canExecute%60%20and%20%60canAttempt%60%20share%20the%20same%20%60halfOpenAttempts%60%20counter**%0A%0Aboth%20methods%20increment%20%60halfOpenAttempts%60%20when%20in%20%60half-open%60%20state.%20the%20health%20reporter%20in%20%60lib%2Fhealth.ts%60%20calls%20%60getState%28%29%60%20%28read-only%2C%20fine%29%2C%20but%20if%20any%20future%20call%20site%20invokes%20%60canExecute%28%29%60%20on%20the%20same%20breaker%20instance%20that%20the%20dispatcher%20is%20using%20for%20%60canAttempt%28%29%60%2C%20the%20two%20callers%20together%20can%20exhaust%20the%20probe%20budget%20in%20one%20shot%20%E2%80%94%20e.g.%20%60halfOpenMaxAttempts%3A%202%60%20would%20allow%20one%20probe%20from%20each%20path%20but%20deny%20a%20third%20before%20the%20upstream%20result%20is%20known.%20worth%20a%20comment%20noting%20that%20both%20consumers%20share%20the%20counter%2C%20or%20consider%20a%20private%20%60_advanceHalfOpenCounter%28%29%60%20helper%20they%20both%20delegate%20to%20so%20the%20coupling%20is%20explicit.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: index.ts
Line: 1991-1993

Comment:
**half-open probe slot leaked on context-overflow return**

when `canAttempt()` transitions the breaker to `half-open` and increments `halfOpenAttempts`, this early return exits the function without ever calling `circuitBreaker.recordSuccess()` or `recordFailure()`. `halfOpenAttempts` stays at `1` and every subsequent `canAttempt()` for this `(accountId, modelFamily)` key returns `{allowed:false, reason:"probe-in-flight"}` indefinitely — no state transition can un-stick it. context-overflow means the server responded (infrastructure is healthy), so `recordSuccess()` is the correct call before returning.

```suggestion
					const contextOverflowResult = await handleContextOverflow(response, model);
					if (contextOverflowResult.handled) {
						circuitBreaker.recordSuccess();
						return contextOverflowResult.response;
					}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: index.ts
Line: 2350-2354

Comment:
**half-open probe slot leaked in empty-response retry path**

`accountManager.recordFailure()` is called (correct for account state) but `circuitBreaker.recordFailure()` is not. if the breaker was in `half-open` when the probe was admitted, `halfOpenAttempts` stays at `1` and the gate is permanently stuck in `probe-in-flight` denial for this `(accountId, modelFamily)` key — same as the context-overflow path above. the server did respond (empty body is a server-side quirk, not infrastructure down), so `circuitBreaker.recordSuccess()` is arguably correct here too; at minimum `recordFailure()` must be called so `transitionToOpen()` resets `halfOpenAttempts`.

```suggestion
									emptyResponseRetries++;
									runtimeMetrics.emptyResponseRetries++;
									logWarn(`Empty response received (attempt ${emptyResponseRetries}/${emptyResponseMaxRetries}). Retrying...`);
									await showToast(
										`Empty response. Retrying (${emptyResponseRetries}/${emptyResponseMaxRetries})...`,
										"warning",
										{ duration: toastDurationMs },
									);
									accountManager.refundToken(account, modelFamily, model);
									accountManager.recordFailure(account, modelFamily, model);
									circuitBreaker.recordFailure();
									await sleep(addJitter(emptyResponseRetryDelayMs, 0.2));
									break;
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: test/circuit-breaker-wiring.test.ts
Line: 1-11

Comment:
**missing vitest coverage for probe-slot-leak scenarios**

the new test suite thoroughly covers `canAttempt` state transitions and the `canExecute` non-regression, but has no coverage for the two paths where the probe slot is consumed but never released:

1. probe admitted → context-overflow early return → no breaker call
2. probe admitted → empty-response retry → only `accountManager.recordFailure`, no `circuitBreaker` call

adding these two cases would have caught the P1 issues in `index.ts` before merge. there are also no dispatcher-level integration tests verifying that `canAttempt` is actually invoked at the correct point in the pipeline (e.g. mocking `getCircuitBreaker` and asserting call order relative to `fetch`).

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: lib/circuit-breaker.ts
Line: 92-112

Comment:
**`canExecute` and `canAttempt` share the same `halfOpenAttempts` counter**

both methods increment `halfOpenAttempts` when in `half-open` state. the health reporter in `lib/health.ts` calls `getState()` (read-only, fine), but if any future call site invokes `canExecute()` on the same breaker instance that the dispatcher is using for `canAttempt()`, the two callers together can exhaust the probe budget in one shot — e.g. `halfOpenMaxAttempts: 2` would allow one probe from each path but deny a third before the upstream result is known. worth a comment noting that both consumers share the counter, or consider a private `_advanceHalfOpenCounter()` helper they both delegate to so the coupling is explicit.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(rc-8): wire circuit-breaker hal..."](https://github.com/ndycode/oc-codex-multi-auth/commit/8b3ec8455bad6a494ac2f0986c9ae45928083e8d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28751474)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->