### PR TITLE
docs: Phase 3 Batch B - README badges + CONTRIBUTING + CHANGELOG + ARCHITECTURE refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,18 @@
-# changelog
+# Changelog
 
-all notable changes to this project. dates are ISO format (YYYY-MM-DD).
+All notable changes to this project will be documented in this file. Dates are ISO format (YYYY-MM-DD).
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- (placeholder for next release)
 
 ## [6.0.0] - 2026-04-06
 
-### added
+### Added
 
 - **beginner operations toolkit**: added `codex-help`, `codex-setup` (with `wizard` mode + fallback), `codex-doctor` (`fix` mode), and `codex-next` for guided onboarding and recovery.
 - **account metadata commands**: added `codex-tag` and `codex-note`, plus `codex-list` tag filtering.
@@ -14,7 +22,7 @@ all notable changes to this project. dates are ISO format (YYYY-MM-DD).
 - **startup preflight summary**: one-time startup health summary with recommended next action.
 - **breaking rebrand migration**: current runtime storage now uses package-aligned files (`oc-codex-multi-auth-accounts.json`, `oc-codex-multi-auth-flagged-accounts.json`) with automatic migration from legacy package-era and pre-package storage names on first load.
 
-### changed
+### Changed
 
 - **account storage schema**: V3 account metadata now includes optional `accountTags` and `accountNote`.
 - **docs refresh for operational flows**: README + docs portal/development guides updated to reflect beginner commands, safe mode, interactive picker behavior, and backup/import safeguards.
@@ -23,7 +31,7 @@ all notable changes to this project. dates are ISO format (YYYY-MM-DD).
 - **package line renamed**: the supported package, repo, plugin entry, installer surface, and docs now use `oc-codex-multi-auth` instead of `oc-chatgpt-multi-auth`.
 - **codex-first auth wording**: OAuth options, installer guidance, and onboarding docs now describe the Codex-first flow directly instead of the older MULTI-branded labels.
 
-### fixed
+### Fixed
 
 - **non-interactive command guidance**: optional-index commands provide explicit usage guidance when interactive menus are unavailable.
 - **doctor safe-fix edge path**: `codex-doctor fix` now reports a clear non-crashing message when no eligible account is available for auto-switch.
@@ -32,63 +40,63 @@ all notable changes to this project. dates are ISO format (YYYY-MM-DD).
 
 ## [5.4.8] - 2026-03-24
 
-### added
+### Added
 
 - **json codex-ops automation surfaces**: read-only Codex ops now support `format="json"` and expose routing visibility across status, metrics, dashboard, and doctor flows.
 - **device-code login flow**: added a first-party ChatGPT device-code auth path for SSH, WSL, and other headless environments.
 
-### changed
+### Changed
 
 - **login finalization parity**: regular OAuth, manual fallback, and device-code flows now share the same account-selection and persistence helpers.
 - **runtime contract parity hardening**: centralized timeout, deactivated-workspace, and OAuth callback constants with dedicated runtime/doc parity coverage.
 - **dependency audit cleanup**: refreshed the shipped dependency tree with updated `hono` and pinned audit overrides for deterministic audit resolution.
 
-### fixed
+### Fixed
 
 - **storage import contract drift**: preview and apply import flows now share one analysis path, keeping deduplication and count reporting aligned while preserving redacted backup failure reporting.
 - **deactivated workspace rotation**: grouped refresh-token variants are removed together, traversal restarts onto healthy accounts, and the zero-removal fallback cools down the affected account safely.
 
 ## [5.4.3] - 2026-03-06
 
-### added
+### Added
 
 - **gpt-5.4 snapshot alias normalization**: added support for `gpt-5.4-2026-03-05*` and `gpt-5.4-pro-2026-03-05*` model IDs (including effort suffix variants).
 
-### changed
+### Changed
 
 - **legacy GPT-5 alias target updated**: `gpt-5`, `gpt-5-mini`, and `gpt-5-nano` now normalize to `gpt-5.4` as the default general family.
 - **gpt-5.4-pro family isolation**: prompt-family detection now keeps `gpt-5.4-pro` separate from `gpt-5.4` for independent prompt/cache handling while preserving fallback policy behavior (`gpt-5.4-pro -> gpt-5.4`).
 - **OpenCode 5.4 template limits updated**: shipped OpenCode config templates now set `gpt-5.4*` context to `1,000,000` (output remains `128,000`) and docs now include optional `model_context_window` / `model_auto_compact_token_limit` tuning guidance.
 
-### fixed
+### Fixed
 
 - **5.4.3 regression/test coverage alignment**: expanded and corrected normalization, family-routing, and prompt-mapping tests for snapshot aliases, pro-family separation, and legacy alias behavior.
 
 ## [5.4.2] - 2026-03-05
 
-### added
+### Added
 
 - **gpt-5.4 + gpt-5.4-pro runtime support**: added model-map normalization and request-transform coverage for `gpt-5.4` (general) and optional `gpt-5.4-pro`.
 - **gpt-5.4-pro fallback edge**: default unsupported-model fallback chain now includes `gpt-5.4-pro -> gpt-5.4` when fallback policy is enabled.
 
-### changed
+### Changed
 
 - **template defaults updated to gpt-5.4**: modern + legacy config templates now use `gpt-5.4` variants as the default general-purpose family.
 - **docs refresh for 5.4 rollout**: README, getting-started, configuration, troubleshooting, docs index, and config docs now reflect `gpt-5.4` defaults and optional `gpt-5.4-pro` usage.
 - **test matrix expanded for 5.4**: unit, integration, and property tests now explicitly cover `gpt-5.4` and `gpt-5.4-pro` normalization/reasoning/fallback paths.
 
-### fixed
+### Fixed
 
 - **quota probe model order**: quota snapshot probing now includes `gpt-5.4` first before legacy Codex probe models.
 
 ## [5.4.0] - 2026-02-28
 
-### changed
+### Changed
 
 - **organization/account identity matching hardening**: org-scoped matching and collision pruning now enforce accountId-aware compatibility to preserve distinct same-org workspace identities.
 - **id-token organization binding source strictness**: id-token candidate org binding now prioritizes `idToken['https://api.openai.com/auth'].organizations[0].id`.
 
-### fixed
+### Fixed
 
 - **organization-scoped account preservation**: org-different variants sharing a refresh token now preserve distinct identity entries during storage collision resolution.
 - **no-org duplicate collapse alignment**: fallback no-org duplicates now collapse consistently across storage, authorize, and prune operations.
@@ -96,51 +104,51 @@ all notable changes to this project. dates are ISO format (YYYY-MM-DD).
 
 ## [5.3.0] - 2026-02-22
 
-### added
+### Added
 
 - **workspace-aware account persistence**: oauth workspace candidates are preserved as distinct account entries to keep per-workspace routing stable across multi-account sessions.
 
-### fixed
+### Fixed
 
 - **organization identity reconciliation**: account restoration now preserves organization/workspace identity across token refresh and flagged-account recovery paths.
 - **verify-flagged restore identity loss**: flagged-account restore no longer drops `organizationId` when an `accountId` already exists.
 
-### changed
+### Changed
 
 - **documentation alignment with current runtime structure**: refreshed README and docs portal/architecture guides to reflect native-vs-legacy request transforms, workspace-aware identity behavior, and current preset/test counts.
 
 ## [5.2.3] - 2026-02-21
 
-### fixed
+### Fixed
 
 - **tool-call compatibility with current OpenCode runtime**: default request handling now preserves native OpenCode payload/tool definitions, avoiding bridge-side alias rewrites that could trigger invalid tool-call schemas.
 - **bridge/tool-name drift failures**: Codex bridge instructions now anchor on the runtime-provided tool manifest and explicitly avoid translating/inventing tool names.
 
-### changed
+### Changed
 
 - **request transform mode control**: added `requestTransformMode` (`native` default, `legacy` opt-in) plus `CODEX_AUTH_REQUEST_TRANSFORM_MODE=legacy` for compatibility fallback.
 - **legacy codex-mode scope**: Codex compatibility rewrites and bridge prompt shaping are now legacy-mode behavior; native mode keeps host request shape unchanged.
 
 ## [5.2.1] - 2026-02-20
 
-### fixed
+### Fixed
 
 - **tool mapping conflicts in codex bridge/remap prompts**: removed contradictory guidance that treated `patch` as forbidden and aligned instructions so `apply_patch` intent maps to `patch` (preferred) or `edit` for targeted replacements.
 - **OpenCode codex prompt source brittleness**: prompt fetch now retries across multiple upstream source URLs instead of relying on a single path that could return 404.
 
-### changed
+### Changed
 
 - **prompt fetch configurability**: added `OPENCODE_CODEX_PROMPT_URL` override support and source-aware cache metadata so ETag conditional requests stay bound to the same source.
 - **regression coverage + docs wording**: updated prompt assertions/tests for the new `patch`+`edit` policy and refreshed architecture documentation text to match.
 
 ## [5.2.0] - 2026-02-13
 
-### added
+### Added
 
 - **gpt-5.3-codex-spark normalization + routing**: added internal model mapping/family support for `gpt-5.3-codex-spark` and Spark reasoning variants.
 - **generic unsupported-model fallback engine**: entitlement rejections now support configurable per-model fallback chains via `fallbackOnUnsupportedCodexModel` and `unsupportedCodexFallbackChain`.
 
-### changed
+### Changed
 
 - **unsupported-model policy defaults**: introduced `unsupportedCodexPolicy` (`strict`/`fallback`) with strict mode as default; legacy `fallbackOnUnsupportedCodexModel` now maps to policy behavior.
 - **entitlement handling flow**: on unsupported-model errors, plugin now tries remaining accounts/workspaces before model fallback, improving Spark entitlement discovery across multi-account setups.
@@ -150,75 +158,75 @@ all notable changes to this project. dates are ISO format (YYYY-MM-DD).
 
 ## [5.1.1] - 2026-02-08
 
-### fixed
+### Fixed
 
 - **provider-prefixed model config resolution**: `openai/<model>` ids now correctly resolve to their base model config instead of falling back to global defaults.
 - **codex variant option merging**: variant suffixes like `-xhigh` now apply `models.<base>.variants.<variant>` options during request transformation.
 
 ## [5.1.0] - 2026-02-08
 
-### changed
+### Changed
 
 - **workspace candidate selection hardened**: OAuth workspace auto-selection now prefers org defaults, id-token-selected workspace IDs, and non-personal org candidates before falling back to token-derived personal IDs.
 
-### fixed
+### Fixed
 
 - **business workspace routing**: explicit org/manual workspace bindings are now preserved at request time and no longer overwritten by token `chatgpt_account_id` values.
 - **gpt-5.3-codex on Business accounts**: fixed a dual-workspace path where requests could be routed to personal/free workspace IDs and fail with unsupported-model errors.
 
 ## [5.0.0] - 2026-02-08
 
-### breaking
+### Changed (BREAKING)
 
 - **auth login interaction redesigned**: `opencode auth login` now defaults to the Codex-style dashboard flow (actions/accounts/danger zone) instead of the legacy add/fresh-only prompt.
 - **styled codex tool output default**: `codex-list`, `codex-status`, `codex-health`, `codex-switch`, `codex-remove`, `codex-refresh`, `codex-export`, and `codex-import` now default to the new Codex TUI formatting; scripts parsing legacy plain output should update or set `codexTuiV2: false`.
 
-### added
+### Added
 
 - **codex tui runtime controls**: new config + env options for UI behavior: `codexTuiV2`, `codexTuiColorProfile`, `codexTuiGlyphMode`, `CODEX_TUI_V2`, `CODEX_TUI_COLOR_PROFILE`, and `CODEX_TUI_GLYPHS`.
 - **full account dashboard actions**: interactive login now supports add/check/deep-check/verify-flagged/start-fresh, plus account-level actions (enable/disable, refresh, delete).
 - **dedicated flagged storage**: introduced `openai-codex-flagged-accounts.json` with automatic migration from legacy `openai-codex-blocked-accounts.json`.
 - **ui architecture + coverage**: added shared terminal UI runtime/theme/format modules and parity documentation (`TUI_PARITY_CHECKLIST.md`) with focused tests.
 
-### fixed
+### Fixed
 
 - **disabled account safety**: disabled accounts are now excluded from active/current selection and rotation paths.
 - **enabled-flag migration**: `enabled` account state now survives v1->v3 storage migration and persists reliably across save/load cycles.
 
 ## [4.14.2] - 2026-02-08
 
-### changed
+### Changed
 
 - **gpt-5.3 fallback default**: fallback from `gpt-5.3-codex` to `gpt-5.2-codex` on ChatGPT entitlement rejection is now enabled by default for all users.
 - **strict-mode opt-out**: strict behavior is now opt-out via `fallbackToGpt52OnUnsupportedGpt53: false` or `CODEX_AUTH_FALLBACK_GPT53_TO_GPT52=0`.
 
-### fixed
+### Fixed
 
 - **unsupported-model handling**: normalized the upstream 400 (`"not supported when using Codex with a ChatGPT account"`) to a clear entitlement-style error instead of generic bad-request handling.
 
 ## [4.14.1] - 2026-02-07
 
-### added
+### Added
 
 - **fast session mode**: optional low-latency tuning (`fastSession`) with `hybrid`/`always` strategies and configurable history window (`fastSessionMaxInputItems`).
 
-### changed
+### Changed
 
 - **prompt caching**: codex + opencode bridge prompts now use stale-while-revalidate + in-memory caching; startup prewarms instruction caches to reduce first-turn latency.
 - **request parsing**: fetch pipeline now normalizes `Request` inputs and supports non-string bodies (Uint8Array/ArrayBuffer/Blob) without failing request transformations.
 
-### fixed
+### Fixed
 
 - **trivial-turn overhead**: in fast session mode, trivial one-liners can omit tool definitions and compact instructions to reduce roundtrip time.
 
 ## [4.14.0] - 2026-02-05
 
-### added
+### Added
 
 - **gpt-5.3-codex model support**: added end-to-end normalization and routing for `gpt-5.3-codex` with `low`, `medium`, `high`, and `xhigh` variants.
 - **new codex family key**: account rotation/storage now tracks `gpt-5.3-codex` independently in `activeIndexByFamily`.
 
-### changed
+### Changed
 
 - **reasoning defaults**: `gpt-5.3-codex` now defaults to `xhigh` effort (matching the current codex-family behavior), and `none`/`minimal` are normalized to supported codex levels.
 - **prompt fetch/cache mapping**: prompt family detection now recognizes `gpt-5.3-codex`; cache files are keyed to `gpt-5.3-codex-instructions.md`.
@@ -226,13 +234,13 @@ all notable changes to this project. dates are ISO format (YYYY-MM-DD).
 
 ## [4.13.0] - 2026-02-04
 
-### added
+### Added
 
 - **runtime metrics tool**: added `codex-metrics` to inspect live request/error/latency counters for the current plugin process.
 - **401 diagnostics payload**: normalized 401 errors now include `diagnostics` (for example `requestId`, `cfRay`, `correlationId`, `threadId`) to speed up debugging.
 - **stream watchdog controls**: new `fetchTimeoutMs` and `streamStallTimeoutMs` config options (and env overrides) for upstream timeout tuning.
 
-### changed
+### Changed
 
 - **request correlation**: each upstream fetch now sets a correlation id, reuses `CODEX_THREAD_ID`/`prompt_cache_key` when available, and clears scope after each request.
 - **plan-mode tool gating**: `request_user_input` is automatically stripped from tool definitions when collaboration mode is Default (kept in Plan mode).
@@ -240,28 +248,28 @@ all notable changes to this project. dates are ISO format (YYYY-MM-DD).
 - **gpt-5.2-codex default effort**: default reasoning now prefers `xhigh` when no explicit effort/variant is provided.
 - **gitignore hygiene**: local planning/release scratch artifacts are now ignored to keep working trees clean.
 
-### fixed
+### Fixed
 
 - **non-stream SSE hangs**: non-streaming SSE parsing now aborts stalled reads instead of waiting indefinitely.
 
 ## [4.12.5] - 2026-02-04
 
-### changed
+### Changed
 
 - **per-project storage location**: project-scoped account files now live under `~/.opencode/projects/<project-key>/openai-codex-accounts.json` instead of writing into `<project>/.opencode/`.
 
-### added
+### Added
 
 - **legacy migration**: when the new project-scoped path is empty, the plugin now auto-migrates legacy `<project>/.opencode/openai-codex-accounts.json` data on first load.
 
 ## [4.12.4] - 2026-02-03
 
-### added
+### Added
 
 - **Empty response retry** - Automatically retries when the API returns empty/malformed responses. Configurable via `emptyResponseMaxRetries` (default: 2) and `emptyResponseRetryDelayMs` (default: 1000ms)
 - **PID offset for parallel agents** - When multiple OpenCode instances run in parallel, each process now gets a deterministic offset for account selection, reducing contention. Enable with `pidOffsetEnabled: true`
 
-### changed
+### Changed
 
 ```json
 {
@@ -278,36 +286,36 @@ all notable changes to this project. dates are ISO format (YYYY-MM-DD).
 
 - **Test coverage** - 1516 tests across 49 files (up from 1498)
 
-### fixed
+### Fixed
 
 - **PID offset formula** - Fixed bug where all accounts received the same offset (now uses `account.index * 0.131 + pidBonus` for unique distribution)
 - **Empty response detection** - Hardened `isEmptyResponse()` to correctly identify empty choice objects (`[{}]`) and whitespace-only content as empty
 - **Test mocks** - Fixed `index.test.ts` mocks for `createLogger` and new config getters (55 tests were failing)
 
-### metadata
+### Notes
 - npm publish status: not published on npm (tag/release only).
 
 ## [4.12.3] - 2026-02-03
 
-### changed
+### Changed
 
 - **Test coverage** - Up to 89% coverage (1498 tests)
 - **Code quality** - Various improvements from audit
 
-### fixed
+### Fixed
 
 - **Account persistence fix** - Accounts were being saved to the wrong location when `perProjectAccounts` was enabled (default). The issue was that `setStoragePath()` only ran in the loader, but authorize runs before that. So accounts got written to the global path, then the loader looked in the per-project path and found nothing. Both OAuth methods (browser and manual URL paste) now init storage path before saving. (#19)
 
 ## [4.12.2] - 2026-01-30
 
-### fixed
+### Fixed
 
 - **TUI crash on workspace prompt** - Removed redundant workspace selection prompt (auto-selects default now). Added `isNonInteractiveMode()` to detect TUI/Desktop environments. (#17)
 - **Web UI validation error** - Added validate function to manual OAuth flow for proper error messages instead of `[object Object]`.
 
 ## [4.12.1] - 2026-01-30
 
-### changed
+### Changed
 
 - **Audit logging** - Rotating file audit log with structured entries
 - **Auth rate limiting** - Token bucket rate limiting (5 req/min/account) 
@@ -318,7 +326,7 @@ all notable changes to this project. dates are ISO format (YYYY-MM-DD).
 - **Tests**: 580 â†’ 631 (+51)
 - All passing on Windows with `--pool=forks`
 
-### fixed
+### Fixed
 
 - **Business plan workspace fix** - Fixed the "usage not included" errors some Business plan users were hitting. Turns out we were sending a stale stored accountId instead of pulling the fresh one from the token - problematic when you've got multiple workspaces. (#17, h/t @alanzchen for the detailed trace)
 - **Persistence errors actually visible now** - Storage failures used to fail silently unless you had debug mode on. Now you get a proper error toast with actionable hints (antivirus exclusions on Windows, chmod suggestions on Unix). (#19)
@@ -328,7 +336,7 @@ all notable changes to this project. dates are ISO format (YYYY-MM-DD).
 
 ## [4.12.0] - 2026-01-30
 
-### breaking
+### Changed (BREAKING)
 
 - **tool rename**: all `openai-accounts-*` tools renamed to shorter `codex-*` prefix:
   - `openai-accounts` → `codex-list`
@@ -338,20 +346,20 @@ all notable changes to this project. dates are ISO format (YYYY-MM-DD).
   - `openai-accounts-refresh` → `codex-refresh`
   - `openai-accounts-remove` → `codex-remove`
 
-### added
+### Added
 
 - **codex-export**: export all accounts to a portable JSON file for backup or migration
 - **codex-import**: import accounts from a JSON file, merges with existing accounts (skips duplicates)
 
 ## [4.11.2] - 2026-01-30
 
-### fixed
+### Fixed
 
 - **windows account persistence**: fixed silent failure when saving accounts on Windows. errors are now logged at WARN level with storage path in message, and a toast notification appears if persistence fails.
 
 ## [4.11.1] - 2026-01-29
 
-### changed
+### Changed
 
 - This plugin provides 6 built-in tools for managing your OpenAI accounts. Just ask the agent or type the tool name directly.
 
@@ -364,13 +372,13 @@ all notable changes to this project. dates are ISO format (YYYY-MM-DD).
 - | `openai-accounts-refresh` | Refresh & save tokens | "refresh my tokens" |
 - | `openai-accounts-remove` | Remove an account | "remove account 3" |
 
-### fixed
+### Fixed
 
 - **Zod validation error** - Fixed crash when calling `openai-accounts-status` with no accounts configured
 
 ## [4.11.0] - 2026-01-29
 
-### added
+### Added
 
 - **Subdirectory detection** - Per-project accounts now work from subdirectories. The plugin walks up the directory tree to find the project root (identified by `.git`, `package.json`, `pyproject.toml`, etc.)
 - **Live countdown timer** - Rate limit waits now show a live countdown that updates every 5 seconds: `Waiting for rate limit reset (2m 35s remaining)`
@@ -379,22 +387,22 @@ all notable changes to this project. dates are ISO format (YYYY-MM-DD).
 
 ## [4.10.0] - 2026-01-29
 
-### added
+### Added
 - **per-project accounts**: each project gets its own account storage now. no more conflicts when working across different repos with different chatgpt accounts. auto-detects project directories (looks for .git, package.json, etc). falls back to global storage if you're not in a project folder.
 - **configurable toast duration**: rate limit notifications stick around longer now (5s default). set `toastDurationMs` in config if you want them longer/shorter.
 - **account removal tool**: new `openai-accounts-remove` tool to delete accounts by index. finally.
 - **token masking in logs**: all tokens, api keys, and bearer headers are now masked in debug logs. no more accidentally leaking creds.
 
-### changed
+### Changed
 - **account limit bumped to 20**: was 10, now 20. add more accounts if you need them.
 - **per-project accounts default on**: `perProjectAccounts` defaults to `true` now. disable with `perProjectAccounts: false` in config if you want the old global behavior.
 
-### fixed
+### Fixed
 - **token refresh race condition**: added `tokenRotationMap` to prevent concurrent refresh requests from stepping on each other.
 - **rate limit retry jitter**: 20% jitter on retry delays to prevent thundering herd.
 - **apply_patch infinite loop**: removed apply_patch references from codex bridge that caused loops in some edge cases.
 
-### config
+### Notes
 new options in `~/.opencode/openai-codex-auth-config.json`:
 ```json
 {
@@ -409,45 +417,45 @@ env vars:
 
 ## [4.9.7] - 2026-01-29
 
-### fixed
+### Fixed
 - business/team workspace selection: detect multiple workspace account IDs from oauth tokens and prompt for the correct one.
 - prevent refresh/hydration from overwriting selected workspace ids (org/manual choices remain stable).
 - persist workspace labels and sources for clearer account listings.
 
-### added
+### Added
 - `CODEX_AUTH_ACCOUNT_ID` override to force a specific workspace id (non-interactive login).
 - troubleshooting guidance for "usage not included in your plan".
 
 ## [4.9.6] - 2026-01-27
 
-### changed
+### Changed
 
 - **tui auth gating**: non-tty/ui auth attempts now return a clear instruction to run `opencode auth login` in a terminal shell.
 - **error-mapping simplification**: consolidated entitlement/rate-limit mapping in fetch helpers for a single handling path.
 
 ## [4.9.5] - 2026-01-28
 
-### changed
+### Changed
 
 - When your ChatGPT subscription didn't include Codex access, the plugin kept rotating through all accounts and retrying forever because it thought it was a temporary rate limit.
 
 - You get an immediate, clear error: "This model is not included in your ChatGPT subscription."
 
-### fixed
+### Fixed
 
 - **Account error handling** - Fixes infinite retry loop when account doesn't have access to Codex models. `usage_not_included` errors now return 403 Forbidden instead of being treated as rate limits. Clear error message explaining the subscription issue. Prevents pointless account rotation for non-recoverable errors. (#16, thanks @rainmeter33-jpg!)
 
 ## [4.9.4] - 2026-01-27
 
-### added
+### Added
 
 - **TUI auth flow disabled** - We now strictly enforce using `opencode auth login` in the terminal for authentication. The UI-based 'Connect' flow is disabled with a clear message to prevent issues with non-interactive environments.
 
-### changed
+### Changed
 
 - **Strict tool schema validation** - Added filtering of required fields, flattening enums for compatibility with strict models like Claude/Gemini
 
-### fixed
+### Fixed
 
 - **Manual login fixed** - Parsing of OAuth URLs with fragments (`#code=`) is fixed
 - **Account switching** - Manual selection is now strictly prioritized over rotation logic
@@ -455,7 +463,7 @@ env vars:
 
 ## [4.9.3] - 2026-01-27
 
-### changed
+### Changed
 
 - **Strict schema validation** - Ported robust tool cleaning logic from `antigravity-auth`. Automatically normalizes tool definitions to prevent errors with strict models (like Claude or Gemini):
   - Filters out `required` fields that are not defined in `properties`
@@ -464,7 +472,7 @@ env vars:
   - Injects placeholder properties for empty object parameters
 - **Enabled apply_patch** - Updated the Codex bridge prompt to allow the `apply_patch` tool
 
-### fixed
+### Fixed
 
 - **Manual login fixed** - The plugin now correctly parses OAuth redirect URLs that use fragments (e.g., `#code=...`). Previously, it only looked for query parameters, which caused manual copy-paste logins to fail with a redirection error.
 - **Account switching logic** - Changed account selection logic to strictly respect your manual choice. Before this fix, the hybrid rotation algorithm would sometimes override your selection based on account health or token scores.
@@ -473,21 +481,21 @@ env vars:
 
 ## [4.9.2] - 2026-01-27
 
-### fixed
+### Fixed
 
 - **Auth prompts moved to TUI** - Avoids readline input conflicts
 - **Error payload normalization** - Improves rate-limit handling and rotation
 
-### metadata
+### Notes
 - npm publish status: not published on npm (tag/release only).
 
 ## [4.9.1] - 2026-01-26
 
-### changed
+### Changed
 
 - When `opencode auth login` called the authorize function, `inputs` was `undefined`. The code had a conditional check that only entered the multi-account while loop if `inputs` existed with keys. This caused only single-account flow to run.
 
-### fixed
+### Fixed
 
 - **Multi-account flow always runs** - authorize() now always uses multi-account flow regardless of inputs parameter. (#12)
 
@@ -497,16 +505,16 @@ env vars:
 
 **breaking: package renamed from `opencode-openai-codex-auth-multi` to `oc-chatgpt-multi-auth`**
 
-### changed
+### Changed
 - **package renamed** to bypass opencode's plugin blocking. opencode skips any plugin with `opencode-openai-codex-auth` in the name. the new name `oc-chatgpt-multi-auth` works correctly.
 - updated all documentation, configs, and references to use new package name.
 - added `multiAccount` flag check in loader to coexist with opencode's built-in auth.
 
-### fixed
+### Fixed
 - removed debug console.log statements from loader.
 - plugin now properly detects when it should handle auth vs deferring to built-in.
 
-### migration
+### Notes
 update your `~/.config/opencode/opencode.json`:
 ```json
 {
@@ -516,18 +524,18 @@ update your `~/.config/opencode/opencode.json`:
 
 ## Legacy 4.8.2 (Package-Only) - 2026-01-25
 
-### changed
+### Changed
 - fix node esm plugin load by importing tool from `@opencode-ai/plugin/tool` and ensuring runtime dependency is installed.
 - correct package metadata (repository links, update-check package name) and add troubleshooting guidance for plugin install/load.
 
-### metadata
+### Notes
 - npm package line: published under `opencode-openai-codex-auth-multi` (legacy package), not `oc-chatgpt-multi-auth`.
 
 ## [4.7.0] - 2026-01-25
 
 **feature release**: full session recovery system ported from opencode-antigravity-auth.
 
-### added
+### Added
 - **session recovery system**: automatic recovery from common api errors that would previously crash sessions:
   - `tool_result_missing`: handles interrupted tool executions (esc during tool run)
   - `thinking_block_order`: fixes corrupted thinking blocks in message history
@@ -548,19 +556,19 @@ update your `~/.config/opencode/opencode.json`:
   - environment variables: `CODEX_AUTH_SESSION_RECOVERY`, `CODEX_AUTH_AUTO_RESUME`
 - **26 new unit tests** for recovery system
 
-### changed
+### Changed
 - **account label format**: changed from `Account N (email)` to `N. email` for cleaner display
 - **error response handling**: `handleErrorResponse()` now returns `errorBody` for recovery detection
 - enhanced error logging with recoverable error detection in fetch flow
 
-### metadata
+### Notes
 - npm package line: published under `opencode-openai-codex-auth-multi` (legacy package), not `oc-chatgpt-multi-auth`.
 
 ## [4.6.0] - 2026-01-25
 
 **feature release**: context overflow handling and missing tool result injection.
 
-### added
+### Added
 - **context overflow handler**: gracefully handles "prompt too long" / context length exceeded errors:
   - returns synthetic sse response with helpful instructions instead of raw 400 error
   - suggests `/compact`, `/clear`, or `/undo` commands to reduce context size
@@ -573,46 +581,46 @@ update your `~/.config/opencode/opencode.json`:
   - new function: `injectMissingToolOutputs()` in `lib/request/helpers/input-utils.ts`
 - **34 new unit tests** for context overflow and tool injection
 
-### metadata
+### Notes
 - npm package line: published under `opencode-openai-codex-auth-multi` (legacy package), not `oc-chatgpt-multi-auth`.
 
 ## [4.5.0] - 2026-01-24
 
-### added
+### Added
 - **strict tool validation**: automatically cleans tool schemas for compatibility with strict models (claude, gemini)
 - **auto-update notifications**: get notified when a new version is available
 - **22 model presets**: full variant system with reasoning levels (none/low/medium/high/xhigh)
 
-### changed
+### Changed
 - health-aware account rotation with automatic failover
 - hybrid selection prefers healthy accounts with available tokens
 
-### metadata
+### Notes
 - npm package line: published under `opencode-openai-codex-auth-multi` (legacy package), not `oc-chatgpt-multi-auth`.
 
 ## Legacy 4.4.0 (Package-Only) - 2026-01-23
 
-### added
+### Added
 - **health scoring**: tracks success/failure per account
 - **token bucket**: prevents hitting rate limits
 - **always retries** when all accounts are rate-limited (waits for reset)
 
-### config
+### Notes
 new retry options:
 - `retryAllAccountsRateLimited` (default: `true`)
 - `retryAllAccountsMaxWaitMs` (default: `0` = unlimited)
 - `retryAllAccountsMaxRetries` (default: `Infinity`)
 
-### metadata
+### Notes
 - npm publish status: not published on npm (tag/release only).
 
 ## [4.3.1] - 2026-01-23
 
-### added
+### Added
 
 - **openai-accounts-status --json** - Scriptable status output with email/ID labels
 
-### changed
+### Changed
 
 - **Account labels** - Now prefer email and show ID suffix when available; list/status outputs are columnized for readability
 - **Email normalization** - Stored account emails are trimmed/lowercased when present
@@ -625,5 +633,5 @@ new retry options:
 
 - @andremxmx for reporting the multi-account ID issue (#4)
 
-### metadata
+### Notes
 - npm package line: published under `opencode-openai-codex-auth-multi` (legacy package), not `oc-chatgpt-multi-auth`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,6 +125,54 @@ We will decline features that:
 - Bypass authentication or rate limiting
 - Facilitate improper use
 
+## Local Development
+
+### Prerequisites
+- Node.js ≥ 18 (LTS recommended)
+- npm ≥ 9
+- Git
+
+### Setup
+```bash
+git clone https://github.com/ndycode/oc-codex-multi-auth.git
+cd oc-codex-multi-auth
+npm ci
+```
+
+### Run the quality gates locally
+```bash
+npm run typecheck  # strict TypeScript
+npm run lint       # ESLint (no warnings allowed)
+npm test           # Vitest full suite
+npm run build      # Compile to dist/
+```
+
+### Run a focused test file
+```bash
+npx vitest run test/circuit-breaker-wiring.test.ts
+```
+
+### Iterative test watch mode
+```bash
+npx vitest watch
+```
+
+### Husky hooks
+Commits go through:
+- `pre-commit` — lint-staged on changed files
+- `commit-msg` — Conventional Commits regex
+
+To skip hooks temporarily (discouraged):
+```bash
+git commit --no-verify -m "..."
+```
+
+### How to add a test
+Match the closest existing test file under `test/`. For a new `lib/<module>.ts`, add `test/<module>.test.ts`. Follow the Vitest + Zod + fake-timer conventions in existing tests (see `test/rotation.test.ts` for a mid-complexity example).
+
+### Debug OAuth flow locally
+Set `CODEX_DEBUG_AUTH=1` in your shell before running. See `docs/development/AUTH_FLOW.md` (if present) for protocol details.
+
 ## Code of Conduct
 
 All contributors are expected to follow [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md).

--- a/README.md
+++ b/README.md
@@ -1,8 +1,14 @@
 # oc-codex-multi-auth
 
+<!--
+Badges: CI + OpenSSF Scorecard will turn green once Phase 3 Batch A (CI workflow + Scorecard workflow) lands and runs its first job. Until then they may render as "no status" / 404 — that is expected and self-resolves automatically.
+-->
+[![CI](https://github.com/ndycode/oc-codex-multi-auth/actions/workflows/ci.yml/badge.svg)](https://github.com/ndycode/oc-codex-multi-auth/actions/workflows/ci.yml)
 [![npm version](https://img.shields.io/npm/v/oc-codex-multi-auth.svg)](https://www.npmjs.com/package/oc-codex-multi-auth)
 [![npm downloads](https://img.shields.io/npm/dw/oc-codex-multi-auth.svg)](https://www.npmjs.com/package/oc-codex-multi-auth)
+[![Node.js Version](https://img.shields.io/node/v/oc-codex-multi-auth.svg)](https://nodejs.org)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/ndycode/oc-codex-multi-auth/badge)](https://securityscorecards.dev/viewer/?uri=github.com/ndycode/oc-codex-multi-auth)
 
 Use your ChatGPT Plus/Pro subscription inside OpenCode with OAuth login, GPT-5/Codex model presets, and multi-account failover.
 

--- a/docs/development/ARCHITECTURE.md
+++ b/docs/development/ARCHITECTURE.md
@@ -1,6 +1,25 @@
 # Plugin Architecture & Technical Decisions
 
+> Reflects the codebase as of v6.0.0. Post-refactor structure after Phase 2 architecture work (see `docs/audits/07-refactoring-plan.md`). Individual section version markers refer to the release that introduced a feature and are retained for historical context only.
+
 This document explains the technical design decisions, architecture, and implementation details of the OpenAI Codex OAuth plugin for OpenCode.
+
+## Module Layout (v6.0.0)
+
+```
+index.ts              # plugin entry (~3200 lines): fetch pipeline + tool registration
+lib/
+├── accounts/         # state, persistence, rotation, rate-limits, recovery
+├── auth/             # OAuth flow, PKCE, callback server
+├── prompts/          # Codex bridge + tool-remap prompts, ETag cache
+├── recovery/         # session recovery (tool_result_missing, thinking blocks)
+├── request/          # transformer, fetch-helpers, response-handler
+├── storage/          # atomic writes, migrations, paths, flagged, backup/export/import
+├── tools/            # 19 OpenCode tools (codex-list, codex-switch, codex-doctor, ...)
+└── ui/               # terminal UI runtime, theme, formatting, beginner checklist
+```
+
+The single `index.ts` of earlier releases has been split: account management lives under `lib/accounts/`, storage under `lib/storage/`, and every `codex-*` tool is its own file under `lib/tools/`. `index.ts` now holds the plugin loader, request pipeline wiring, and tool registration only.
 
 ## Table of Contents
 - [Architecture Overview](#architecture-overview)
@@ -405,7 +424,7 @@ let include: Vec<String> = if reasoning.is_some() {
 
 ---
 
-## Multi-Account Rotation (v4.4.0+)
+## Multi-Account Rotation
 
 ### Health-Based Account Selection
 
@@ -443,7 +462,7 @@ Different rate limit reasons use different backoff multipliers:
 | `concurrent` | 0.5× | Concurrent request limit |
 | `unknown` | 1.0× | Default |
 
-### RefreshQueue (v4.5.0+)
+### RefreshQueue
 
 Prevents race conditions when multiple concurrent requests try to refresh the same token:
 


### PR DESCRIPTION
## Summary

Phase 3 Batch B: pure docs refresh. Zero source/test/scripts files touched. `npm test` (2131/2131) still passes untouched.

## Changes

### 1. README.md - badge row refresh
- Add CI status, Node >=18, OpenSSF Scorecard badges alongside existing npm version / downloads / license.
- Scorecard + CI badges will render `404` / `no status` until Phase 3 Batch A (CI workflow + Scorecard workflow) lands. Self-resolves automatically after first run. HTML comment at top of badge block documents this for maintainers reading the raw source.

### 2. CONTRIBUTING.md - new `## Local Development` section
- Prerequisites (Node >=18, npm >=9, Git).
- Setup (`git clone` + `npm ci`).
- Quality gates (`npm run typecheck` / `lint` / `test` / `build`).
- Focused + watch-mode test invocations.
- Husky hook reference (`pre-commit` = lint-staged, `commit-msg` = Conventional Commits).
- How to add a test (mirror existing file under `test/`, point at `test/rotation.test.ts` as a reference).
- OAuth debug flag (`CODEX_DEBUG_AUTH=1`).

### 3. CHANGELOG.md - Keep-a-Changelog v1.1.0 format
- Added standard preamble linking to [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and [SemVer](https://semver.org/spec/v2.0.0.html).
- Added `## [Unreleased]` block with placeholder `### Added` for the next release.
- Normalized all subsection headings to Title Case across every historical version block:
  - `### added` to `### Added`
  - `### changed` to `### Changed`
  - `### fixed` to `### Fixed`
  - `### breaking` to `### Changed (BREAKING)` (Keep-a-Changelog has no dedicated Breaking; flagging inside Changed is the convention)
  - informational non-standard sections (`metadata`, `config`, `migration`, `stats`) consolidated under `### Notes` so they keep their content without inventing new KaC sections.
- Historical entries preserved verbatim, only heading case normalized.

### 4. docs/development/ARCHITECTURE.md - v6.0.0 drift cleanup
- Top preamble: `> Reflects the codebase as of v6.0.0. Post-refactor structure after Phase 2 architecture work (see docs/audits/07-refactoring-plan.md).`
- New `## Module Layout (v6.0.0)` section near the top listing the real tree: `lib/accounts/`, `lib/auth/`, `lib/prompts/`, `lib/recovery/`, `lib/request/`, `lib/storage/`, `lib/tools/` (19 tools), `lib/ui/`. Documents that `index.ts` is now ~3200 lines (loader + pipeline + registration) rather than a monolith.
- Dropped stale version markers from stable-behavior section titles:
  - `## Multi-Account Rotation (v4.4.0+)` to `## Multi-Account Rotation`
  - `### RefreshQueue (v4.5.0+)` to `### RefreshQueue`
- Kept inline historical "since vX.Y" callouts that are genuinely historical and not drift.

## Out of scope (deliberate)
- No source code touched (`lib/**`, `index.ts`, `test/**`, `scripts/**`).
- No `docs/audits/` changes (immutable audit deliverables).
- No full-rewrite of ARCHITECTURE - drift cleanup only.

## Verification
- `npm test` - 66 files, 2131 tests passing, 3.22s duration.
- Markdown renders without parse errors (headings, code fences, table of contents links all intact).
- `package.json` name (`oc-codex-multi-auth`) matches badge URLs.

## Related
- Phase 3 Batch A (CI + Scorecard workflows) - separate PR, lands first for the new badges to light up.
- Phase 3 Batch C (UX / diagnostics) - separate PR, non-overlapping scope.

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

pure docs refresh — kac format normalization across changelog, new `## Local Development` section in contributing, badge row expansion in readme, and v6.0.0 module layout + drift cleanup in architecture. zero source/test/script files touched.

one minor issue worth fixing before merge: the `Legacy 4.4.0` block ends up with two consecutive `### Notes` headings because both `### config` and `### metadata` were renamed independently rather than merged into one section.

<h3>Confidence Score: 5/5</h3>

safe to merge — docs-only change with one trivial P2 heading fixup in CHANGELOG

all findings are P2 style suggestions; no source, test, or script files touched; npm test suite unaffected; duplicate `### Notes` is cosmetic and does not affect runtime behavior

CHANGELOG.md — `Legacy 4.4.0` block has duplicate `### Notes` headings that should be merged

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| CHANGELOG.md | KaC format normalization across all historical entries; duplicate `### Notes` headings in the `Legacy 4.4.0` block due to two non-standard sections both renamed to `### Notes` without merging |
| CONTRIBUTING.md | adds `## Local Development` section with setup, quality gates, test patterns, husky hooks, and OAuth debug flag; `test/rotation.test.ts` reference verified to exist |
| README.md | adds CI, Node.js version, and OpenSSF Scorecard badges; HTML comment correctly notes that CI/Scorecard badges will render as no-status until Phase 3 Batch A lands |
| docs/development/ARCHITECTURE.md | adds v6.0.0 preamble and module layout tree; removes stale version markers from section headers; no source code touched |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Phase 3 Batch B - Docs PR] --> B[README.md]
    A --> C[CONTRIBUTING.md]
    A --> D[CHANGELOG.md]
    A --> E[ARCHITECTURE.md]

    B --> B1[CI badge]
    B --> B2[Node.js version badge]
    B --> B3[OpenSSF Scorecard badge]
    B1 -.->|404 until Batch A lands| F[Phase 3 Batch A]

    C --> C1[Local Development section]
    C1 --> C2[Prerequisites and Setup]
    C1 --> C3[Quality gates]
    C1 --> C4[Test commands]
    C1 --> C5[Husky hooks reference]
    C1 --> C6[OAuth debug flag]

    D --> D1[Keep-a-Changelog preamble]
    D --> D2[Unreleased block]
    D --> D3[Heading case normalization]
    D --> D4[Non-standard sections to Notes]
    D4 -->|issue in Legacy 4.4.0| D5[Duplicate Notes headings]

    E --> E1[v6.0.0 preamble]
    E --> E2[Module Layout tree]
    E --> E3[Remove stale version markers]
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Foc-codex-multi-auth%22%20on%20the%20existing%20branch%20%22docs%2Fphase3-batch-b-docs-refresh%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22docs%2Fphase3-batch-b-docs-refresh%22.%0A%0AFix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACHANGELOG.md%3A608-615%0A**Duplicate%20%60%23%23%23%20Notes%60%20headings%20in%20same%20version%20block**%0A%0Athe%20%60Legacy%204.4.0%60%20block%20now%20has%20two%20consecutive%20%60%23%23%23%20Notes%60%20sections%20%E2%80%94%20one%20for%20the%20old%20%60%23%23%23%20config%60%20content%20and%20one%20for%20the%20old%20%60%23%23%23%20metadata%60%20content.%20the%20PR%20description%20says%20to%20*consolidate*%20non-standard%20sections%20under%20%60%23%23%23%20Notes%60%2C%20but%20the%20rename-without-merge%20produces%20duplicate%20h3%20headings%20inside%20the%20same%20release%20entry%2C%20which%20breaks%20strict%20KaC%20parsers%20and%20looks%20odd%20in%20rendered%20output.%20the%20two%20blocks%20should%20be%20merged%20into%20one.%0A%0A%60%60%60suggestion%0A%23%23%23%20Notes%0Anew%20retry%20options%3A%0A-%20%60retryAllAccountsRateLimited%60%20%28default%3A%20%60true%60%29%0A-%20%60retryAllAccountsMaxWaitMs%60%20%28default%3A%20%600%60%20%3D%20unlimited%29%0A-%20%60retryAllAccountsMaxRetries%60%20%28default%3A%20%60Infinity%60%29%0A-%20npm%20publish%20status%3A%20not%20published%20on%20npm%20%28tag%2Frelease%20only%29.%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: CHANGELOG.md
Line: 608-615

Comment:
**Duplicate `### Notes` headings in same version block**

the `Legacy 4.4.0` block now has two consecutive `### Notes` sections — one for the old `### config` content and one for the old `### metadata` content. the PR description says to *consolidate* non-standard sections under `### Notes`, but the rename-without-merge produces duplicate h3 headings inside the same release entry, which breaks strict KaC parsers and looks odd in rendered output. the two blocks should be merged into one.

```suggestion
### Notes
new retry options:
- `retryAllAccountsRateLimited` (default: `true`)
- `retryAllAccountsMaxWaitMs` (default: `0` = unlimited)
- `retryAllAccountsMaxRetries` (default: `Infinity`)
- npm publish status: not published on npm (tag/release only).
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(batch-b): README badges + CONTRIBUT..."](https://github.com/ndycode/oc-codex-multi-auth/commit/072ce90342722532a45a0b01130197223d2fa216) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28752411)</sub>

<!-- /greptile_comment -->