### PR TITLE
ci: Phase 3 Batch A - OSS hygiene (dependabot + scorecard + commit-msg + coverage floor)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,50 @@
+# Dependabot configuration
+# See https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+version: 2
+updates:
+  # npm (root package.json): group noisy dev-tool ecosystems, keep security-sensitive
+  # dependencies (runtime) as individual PRs so they are reviewed on their own.
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "npm"
+    groups:
+      typescript-eslint:
+        patterns:
+          - "@typescript-eslint/*"
+          - "eslint"
+          - "eslint-*"
+      vitest:
+        patterns:
+          - "vitest"
+          - "@vitest/*"
+      types:
+        patterns:
+          - "@types/*"
+    commit-message:
+      prefix: "deps"
+      prefix-development: "deps-dev"
+      include: "scope"
+
+  # GitHub Actions: keep pinned SHAs + version tags current (Scorecard / CI actions).
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "ci"
+      include: "scope"

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,56 @@
+# OpenSSF Scorecard supply-chain security analysis.
+# Results upload to the Code Scanning tab + the public OpenSSF REST API.
+# Action pins follow the same SHA-pinning discipline as .github/workflows/ci.yml.
+name: Scorecard supply-chain security
+
+on:
+  branch_protection_rule:
+  schedule:
+    # Weekly, Monday 01:30 UTC. Kept offset from other weekly jobs.
+    - cron: "30 1 * * 1"
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+# Declare default permissions as read-only for the workflow.
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    # Only publish scorecard results from the default branch; PRs and scheduled
+    # runs still execute so regressions surface in Code Scanning.
+    permissions:
+      # Needed to upload the SARIF results to the code-scanning dashboard.
+      security-events: write
+      # Needed for keyless signing of results via sigstore / OpenSSF publish.
+      id-token: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Run Scorecard analysis
+        uses: ossf/scorecard-action@f49aabe0b5af0936a0987cfb85d86b75731b0186 # v2.4.1
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # `publish_results` is only honored on the default branch; the action
+          # silently downgrades to `false` for PRs and forks.
+          publish_results: true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3
+        with:
+          sarif_file: results.sarif

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,32 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+# Enforce Conventional Commits 1.0.0 subject line.
+#   type(scope)!: description
+# Types align with common Conventional Commits usage and CONTRIBUTING.md.
+# Skips merge, revert, fixup!, and squash! commits so rebase / autosquash
+# flows keep working without `--no-verify`.
+
+msg_file="$1"
+first_line=$(head -n 1 "$msg_file")
+
+case "$first_line" in
+  "Merge "*|"Revert "*|"fixup! "*|"squash! "*|"amend! "*)
+    exit 0
+    ;;
+esac
+
+pattern='^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert|deps|deps-dev)(\([a-z0-9._-]+\))?!?: .{1,100}$'
+
+if ! printf '%s' "$first_line" | grep -qE "$pattern"; then
+  printf '\nCommit message does not follow Conventional Commits.\n' >&2
+  printf '\nExpected format:\n' >&2
+  printf '  type(scope): short description\n' >&2
+  printf '  type!: breaking change description\n' >&2
+  printf '\nAllowed types:\n' >&2
+  printf '  feat, fix, docs, style, refactor, perf, test, build,\n' >&2
+  printf '  ci, chore, revert, deps, deps-dev\n' >&2
+  printf '\nYour subject line was:\n' >&2
+  printf '  %s\n\n' "$first_line" >&2
+  exit 1
+fi

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -20,10 +20,27 @@ export default defineConfig({
       reporter: ['text', 'json', 'html'],
       exclude: ['node_modules/', 'dist/', 'test/'],
       thresholds: {
+        // Global coverage floor.
         statements: 80,
         branches: 80,
         functions: 80,
         lines: 80,
+        // Per-file coverage floor for the production source tree. Set below the
+        // global average so legitimate low-coverage utility files do not block
+        // work, while still catching regressions where a single file drops
+        // sharply. Raise these once individual modules stabilise.
+        'lib/**/*.ts': {
+          statements: 70,
+          branches: 70,
+          functions: 70,
+          lines: 70,
+        },
+        'index.ts': {
+          statements: 70,
+          branches: 70,
+          functions: 70,
+          lines: 70,
+        },
       },
     },
   },


### PR DESCRIPTION
## Summary

Phase 3 Batch A — OSS hygiene pack. Four independent hardening items delivered together because they share the same review surface (CI + repo config) and do not touch runtime source code (`index.ts`, `lib/**`, `test/**`).

Roadmap reference: Phase 3 items §3.1 (Dependabot), §3.2 (OpenSSF Scorecard), §3.3 (commit-msg hook), §3.4 (per-file coverage floor) in `docs/13-phased-roadmap.md`.

## What changes

### 1. `.github/dependabot.yml` (new)

- Weekly schedule (Monday 06:00 UTC) for both `npm` and `github-actions`.
- Groups noisy dev-tool ecosystems: `typescript-eslint` + `eslint*`, `vitest` + `@vitest/*`, `@types/*`.
- Runtime dependencies remain individual PRs so security-relevant updates are reviewed in isolation.
- Commit prefixes: `deps` / `deps-dev` for npm, `ci` for github-actions. Scoped per Conventional Commits.

### 2. `.github/workflows/scorecard.yml` (new)

- OpenSSF Scorecard runs on push to `main`, PRs to `main`, weekly cron (Monday 01:30 UTC), and branch-protection rule changes.
- All actions are SHA-pinned with trailing version comments matching the discipline in `.github/workflows/ci.yml`:
  - `actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2`
  - `ossf/scorecard-action@f49aabe0b5af0936a0987cfb85d86b75731b0186 # v2.4.1`
  - `actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1`
  - `github/codeql-action/upload-sarif@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3`
- Uploads SARIF to the Code Scanning dashboard and publishes results to the OpenSSF public REST API (badge-ready).
- `permissions: read-all` at workflow level; job grants only `security-events: write` + `id-token: write`.

### 3. `.husky/commit-msg` (new)

- Enforces Conventional Commits 1.0.0 subject line format: `type(scope)!: description`.
- Allowed types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`, `deps`, `deps-dev` (last two align with Dependabot commit prefixes).
- Skips `Merge`, `Revert`, `fixup!`, `squash!`, and `amend!` commits so rebase / autosquash flows do not require `--no-verify`.
- Sourcing pattern matches the existing `.husky/pre-commit` (husky v9 legacy-compat syntax).

### 4. `vitest.config.ts` (modified)

- Existing global coverage floor (`80 / 80 / 80 / 80` statements/branches/functions/lines) preserved.
- Added per-file floor of `70 / 70 / 70 / 70` for `lib/**/*.ts` and `index.ts`.
- Floor is deliberately below the global average so a single legitimately low-coverage utility file does not block unrelated work, while still catching regressions where a specific module drops sharply.
- Threshold is evaluated only when coverage is explicitly requested (`npm run coverage` / `npm run test:coverage`); `npm test` and current CI are unaffected.

## Testing

Local verification on branch `ci/phase3-batch-a-oss-hygiene` (Windows, Node 22):

```
npm run typecheck      # pass
npm run lint           # pass (eslint .ts + eslint scripts)
npm test               # 2131 tests passed across 66 files
npm run build          # tsc + copy-oauth-success.js pass
```

YAML validity check on both new workflow/config files via `yaml.parse` — both parse cleanly.

Conventional Commits regex dry-run against this PR's own subject line confirms the hook pattern matches `ci(batch-a): …`.

## Out of scope

- No changes to runtime source (`index.ts`, `lib/**`) or tests (`test/**`).
- No changes to existing CI workflows (`.github/workflows/ci.yml`, `.github/workflows/pr-quality.yml`).
- No existing coverage threshold lowered; only a new per-file floor added.
- Coordinated in parallel with Phase 3 Batch B (docs refresh) and Batch C (UX/diag) — file sets do not overlap.

## Follow-ups (future PRs)

- Remove legacy `. "$(dirname "$0")/_/husky.sh"` sourcing line ahead of husky v10 (tracked separately; Batch A deliberately matches existing `.husky/pre-commit` pattern to keep the diff minimal).
- Raise per-file coverage floor module-by-module as individual `lib/**` files stabilise.

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---


<h3>Greptile Summary</h3>

phase 3 batch a adds four independent ci/repo-hygiene items — dependabot, openssf scorecard, conventional-commit hook, and per-file coverage floors — none of which touch runtime source. the changes are well-structured and follow existing sha-pinning and husky patterns, with three minor p2 gaps worth addressing before the per-file coverage gate becomes load-bearing.

<h3>Confidence Score: 5/5</h3>

safe to merge — all findings are p2 style/hardening suggestions, no runtime source is touched.

three p2 findings (missing `all: true` in coverage, no concurrency in scorecard, windows crlf strip in commit-msg hook) are non-blocking quality improvements. no p0/p1 issues found.

vitest.config.ts (coverage `all: true` gap) and .husky/commit-msg (windows crlf hardening) are worth a follow-up but do not block merge.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/dependabot.yml | new file; weekly schedule for npm + github-actions, sensible grouping of noisy dev-tool ecosystems, runtime deps kept as individual PRs — looks correct. |
| .github/workflows/scorecard.yml | new scorecard workflow; all actions SHA-pinned, permissions correctly scoped — missing concurrency group unlike ci.yml (P2). |
| .husky/commit-msg | new conventional-commits hook; regex and skip cases look correct — potential Windows CRLF false-negative via `head -n 1` without `tr -d '\r'` (P2). |
| vitest.config.ts | adds per-file 70% floor for lib/**/*.ts and index.ts — effective only for executed files; missing `all: true` means uncovered new modules are silently skipped (P2). |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[git commit] --> B{commit-msg hook}
    B -->|Merge / fixup! / squash! / amend! / Revert| C[skip – exit 0]
    B -->|pattern match OK| D[commit accepted]
    B -->|pattern mismatch| E[exit 1 – show error]

    F[push to main / PR to main / weekly cron] --> G[scorecard.yml]
    G --> H[ossf/scorecard-action]
    H --> I[results.sarif]
    I --> J[upload-artifact]
    I --> K[codeql-action/upload-sarif → Code Scanning]
    H -->|publish_results: true, default branch only| L[OpenSSF public REST API]

    M[weekly Monday 06:00 UTC] --> N[dependabot]
    N -->|npm grouped| O[typescript-eslint / vitest / types PRs]
    N -->|npm individual| P[runtime dep PRs]
    N -->|github-actions| Q[action SHA update PRs]

    R[npm run coverage] --> S[vitest --coverage]
    S --> T{global thresholds 80/80/80/80}
    S --> U{per-file thresholds 70/70/70/70 – lib/**/*.ts + index.ts}
    T -->|fail| V[coverage gate fails]
    U -->|fail| V
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `vitest.config.ts`, line 18-21 ([link](https://github.com/ndycode/oc-codex-multi-auth/blob/653be631edf66b90b1b7b68fd91ef22f2bdfe668/vitest.config.ts#L18-L21)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Per-file thresholds silently skip unexecuted files**

   without `all: true`, the v8 coverage provider only emits entries for files that are actually imported during the test run. a brand-new `lib/` module with zero test coverage would never appear in the coverage report, so the 70% per-file floor wouldn't fire on it. the global 80% aggregate provides a backstop if the new file is large, but a small utility file could fly under the radar.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: vitest.config.ts
   Line: 18-21

   Comment:
   **Per-file thresholds silently skip unexecuted files**

   without `all: true`, the v8 coverage provider only emits entries for files that are actually imported during the test run. a brand-new `lib/` module with zero test coverage would never appear in the coverage report, so the 70% per-file floor wouldn't fire on it. the global 80% aggregate provides a backstop if the new file is large, but a small utility file could fly under the radar.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Foc-codex-multi-auth%22%20on%20the%20existing%20branch%20%22ci%2Fphase3-batch-a-oss-hygiene%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22ci%2Fphase3-batch-a-oss-hygiene%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20vitest.config.ts%0ALine%3A%2018-21%0A%0AComment%3A%0A**Per-file%20thresholds%20silently%20skip%20unexecuted%20files**%0A%0Awithout%20%60all%3A%20true%60%2C%20the%20v8%20coverage%20provider%20only%20emits%20entries%20for%20files%20that%20are%20actually%20imported%20during%20the%20test%20run.%20a%20brand-new%20%60lib%2F%60%20module%20with%20zero%20test%20coverage%20would%20never%20appear%20in%20the%20coverage%20report%2C%20so%20the%2070%25%20per-file%20floor%20wouldn't%20fire%20on%20it.%20the%20global%2080%25%20aggregate%20provides%20a%20backstop%20if%20the%20new%20file%20is%20large%2C%20but%20a%20small%20utility%20file%20could%20fly%20under%20the%20radar.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20provider%3A%20'v8'%2C%0A%20%20%20%20%20%20reporter%3A%20%5B'text'%2C%20'json'%2C%20'html'%5D%2C%0A%20%20%20%20%20%20all%3A%20true%2C%0A%20%20%20%20%20%20exclude%3A%20%5B'node_modules%2F'%2C%20'dist%2F'%2C%20'test%2F'%5D%2C%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Foc-codex-multi-auth%22%20on%20the%20existing%20branch%20%22ci%2Fphase3-batch-a-oss-hygiene%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22ci%2Fphase3-batch-a-oss-hygiene%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Avitest.config.ts%3A18-21%0A**Per-file%20thresholds%20silently%20skip%20unexecuted%20files**%0A%0Awithout%20%60all%3A%20true%60%2C%20the%20v8%20coverage%20provider%20only%20emits%20entries%20for%20files%20that%20are%20actually%20imported%20during%20the%20test%20run.%20a%20brand-new%20%60lib%2F%60%20module%20with%20zero%20test%20coverage%20would%20never%20appear%20in%20the%20coverage%20report%2C%20so%20the%2070%25%20per-file%20floor%20wouldn't%20fire%20on%20it.%20the%20global%2080%25%20aggregate%20provides%20a%20backstop%20if%20the%20new%20file%20is%20large%2C%20but%20a%20small%20utility%20file%20could%20fly%20under%20the%20radar.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20provider%3A%20'v8'%2C%0A%20%20%20%20%20%20reporter%3A%20%5B'text'%2C%20'json'%2C%20'html'%5D%2C%0A%20%20%20%20%20%20all%3A%20true%2C%0A%20%20%20%20%20%20exclude%3A%20%5B'node_modules%2F'%2C%20'dist%2F'%2C%20'test%2F'%5D%2C%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0A.github%2Fworkflows%2Fscorecard.yml%3A18%0A**No%20concurrency%20group%20unlike%20%60ci.yml%60**%0A%0A%60ci.yml%60%20uses%20a%20%60concurrency%60%20block%20to%20cancel%20superseded%20runs.%20scorecard%20lacks%20one%2C%20so%20several%20dependabot%20merges%20landing%20on%20%60main%60%20in%20quick%20succession%20would%20queue%20up%20multiple%20full%20scorecard%20runs.%20low%20impact%20given%20the%20infrequent%20cadence%2C%20but%20inconsistent%20with%20the%20rest%20of%20the%20workflow%20discipline.%0A%0A%60%60%60suggestion%0A%23%20Cancel%20superseded%20runs%3B%20keep%20%60cancel-in-progress%3A%20false%60%20so%20a%20scheduled%2F%0A%23%20branch-protection%20run%20is%20never%20silently%20dropped%20mid-upload.%0Aconcurrency%3A%0A%20%20group%3A%20scorecard-%24%7B%7B%20github.ref%20%7D%7D%0A%20%20cancel-in-progress%3A%20false%0A%0Apermissions%3A%20read-all%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0A.husky%2Fcommit-msg%3A11%0A**Windows%20CRLF%20risk%20with%20%60head%20-n%201%60**%0A%0Aon%20windows%2C%20if%20git%20writes%20%60COMMIT_EDITMSG%60%20with%20CRLF%20endings%20%28can%20happen%20with%20certain%20%60core.autocrlf%60%20configs%29%2C%20%60head%20-n%201%60%20captures%20a%20trailing%20%60%5Cr%60.%20the%20%60%24%60%20anchor%20in%20the%20grep%20pattern%20then%20fails%20to%20match%20because%20the%20line%20ends%20with%20%60%5Cr%60%20rather%20than%20the%20expected%20word%20boundary%2C%20causing%20a%20spurious%20hook%20failure.%20git%20for%20windows%20typically%20writes%20the%20file%20with%20LF%2C%20but%20this%20is%20worth%20hardening%20explicitly.%0A%0A%60%60%60suggestion%0Afirst_line%3D%24%28head%20-n%201%20%22%24msg_file%22%20%7C%20tr%20-d%20'%5Cr'%29%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: vitest.config.ts
Line: 18-21

Comment:
**Per-file thresholds silently skip unexecuted files**

without `all: true`, the v8 coverage provider only emits entries for files that are actually imported during the test run. a brand-new `lib/` module with zero test coverage would never appear in the coverage report, so the 70% per-file floor wouldn't fire on it. the global 80% aggregate provides a backstop if the new file is large, but a small utility file could fly under the radar.

```suggestion
      provider: 'v8',
      reporter: ['text', 'json', 'html'],
      all: true,
      exclude: ['node_modules/', 'dist/', 'test/'],
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: .github/workflows/scorecard.yml
Line: 18

Comment:
**No concurrency group unlike `ci.yml`**

`ci.yml` uses a `concurrency` block to cancel superseded runs. scorecard lacks one, so several dependabot merges landing on `main` in quick succession would queue up multiple full scorecard runs. low impact given the infrequent cadence, but inconsistent with the rest of the workflow discipline.

```suggestion
# Cancel superseded runs; keep `cancel-in-progress: false` so a scheduled/
# branch-protection run is never silently dropped mid-upload.
concurrency:
  group: scorecard-${{ github.ref }}
  cancel-in-progress: false

permissions: read-all
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: .husky/commit-msg
Line: 11

Comment:
**Windows CRLF risk with `head -n 1`**

on windows, if git writes `COMMIT_EDITMSG` with CRLF endings (can happen with certain `core.autocrlf` configs), `head -n 1` captures a trailing `\r`. the `$` anchor in the grep pattern then fails to match because the line ends with `\r` rather than the expected word boundary, causing a spurious hook failure. git for windows typically writes the file with LF, but this is worth hardening explicitly.

```suggestion
first_line=$(head -n 1 "$msg_file" | tr -d '\r')
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["ci(batch-a): dependabot + scorecard + co..."](https://github.com/ndycode/oc-codex-multi-auth/commit/653be631edf66b90b1b7b68fd91ef22f2bdfe668) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28752506)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->