### PR TITLE
feat: Phase 3 Batch C - NO_COLOR + codex-diag diagnostics snapshot

### DIFF
--- a/lib/circuit-breaker.ts
+++ b/lib/circuit-breaker.ts
@@ -208,3 +208,45 @@ export function resetAllCircuitBreakers(): void {
 export function clearCircuitBreakers(): void {
 	circuitBreakers.clear();
 }
+
+/**
+ * Aggregate state counts across all registered circuit breakers, grouped by
+ * the key prefix (substring before the first `:`). Today the only prefix is
+ * `account`, but the grouping is forward-compatible with future per-family
+ * breakers. The returned object intentionally contains NO account IDs or
+ * identifying keys — only aggregated counters — so it is safe to embed in
+ * diagnostic snapshots.
+ */
+export interface CircuitBreakerStateCounts {
+	closed: number;
+	open: number;
+	halfOpen: number;
+}
+
+export interface CircuitBreakerSummary {
+	total: CircuitBreakerStateCounts;
+	byGroup: Record<string, CircuitBreakerStateCounts>;
+}
+
+export function getCircuitBreakerSummary(): CircuitBreakerSummary {
+	const total: CircuitBreakerStateCounts = { closed: 0, open: 0, halfOpen: 0 };
+	const byGroup: Record<string, CircuitBreakerStateCounts> = {};
+	for (const [key, breaker] of circuitBreakers.entries()) {
+		const group = key.includes(":") ? key.slice(0, key.indexOf(":")) : key;
+		const bucket =
+			byGroup[group] ??
+			(byGroup[group] = { closed: 0, open: 0, halfOpen: 0 });
+		const state = breaker.getState();
+		if (state === "closed") {
+			total.closed += 1;
+			bucket.closed += 1;
+		} else if (state === "open") {
+			total.open += 1;
+			bucket.open += 1;
+		} else {
+			total.halfOpen += 1;
+			bucket.halfOpen += 1;
+		}
+	}
+	return { total, byGroup };
+}

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -174,7 +174,7 @@ export const REQUEST_BODY_LOGGING_ENABLED = process.env.CODEX_PLUGIN_LOG_BODIES 
 export const DEBUG_ENABLED = process.env.DEBUG_CODEX_PLUGIN === "1" || LOGGING_ENABLED;
 export const LOG_LEVEL = parseLogLevel(process.env.CODEX_PLUGIN_LOG_LEVEL);
 const CONSOLE_LOG_ENABLED = process.env.CODEX_CONSOLE_LOG === "1";
-const LOG_DIR = join(homedir(), ".opencode", "logs", "codex-plugin");
+export const LOG_DIR = join(homedir(), ".opencode", "logs", "codex-plugin");
 
 let client: LogClient | null = null;
 let currentCorrelationId: string | null = null;
@@ -448,7 +448,7 @@ export function getRequestId(): number {
 	return requestCounter;
 }
 
-export { formatDuration, maskEmail };
+export { formatDuration, maskEmail, maskString, sanitizeValue };
 
 /**
  * Test-only exports. Internal helpers surfaced here so their redaction

--- a/lib/tools/codex-diag.ts
+++ b/lib/tools/codex-diag.ts
@@ -1,0 +1,157 @@
+/**
+ * `codex-diag` tool — redacted diagnostic snapshot for bug reports.
+ *
+ * Returns a single JSON document describing runtime state (plugin version,
+ * Node, platform, account count, circuit-breaker aggregates, metrics
+ * summary, log-directory presence) with aggressive redaction applied:
+ *
+ * - No account IDs, emails, labels, or refresh/access/id tokens leak.
+ * - Home-directory paths are replaced with `<HOME>` so shared bug reports
+ *   do not reveal the reporter's username.
+ * - The final JSON string is passed through `maskString` as a defence in
+ *   depth against any caller-accidental token substring in the payload.
+ *
+ * Ledger reference: docs/audits/08-feature-recommendations.md.
+ */
+
+import { readFileSync, existsSync, readdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { tool, type ToolDefinition } from "@opencode-ai/plugin/tool";
+
+import { getCircuitBreakerSummary } from "../circuit-breaker.js";
+import { LOG_DIR, maskString } from "../logger.js";
+import type { ToolContext } from "./index.js";
+
+interface PackageManifest {
+	name: string;
+	version: string;
+}
+
+function loadPluginManifest(): PackageManifest {
+	// `import.meta.url` resolves to `<plugin-root>/dist/lib/tools/codex-diag.js`
+	// at runtime (ESM). Walking four levels up lands on the plugin root
+	// regardless of whether the caller imported the source or built output.
+	try {
+		const here = fileURLToPath(import.meta.url);
+		const root = join(here, "..", "..", "..", "..");
+		const manifestPath = join(root, "package.json");
+		const raw = readFileSync(manifestPath, "utf8");
+		const parsed = JSON.parse(raw) as { name?: unknown; version?: unknown };
+		return {
+			name: typeof parsed.name === "string" ? parsed.name : "unknown",
+			version:
+				typeof parsed.version === "string" ? parsed.version : "unknown",
+		};
+	} catch {
+		return { name: "unknown", version: "unknown" };
+	}
+}
+
+function countLogFiles(): number {
+	try {
+		if (!existsSync(LOG_DIR)) return 0;
+		return readdirSync(LOG_DIR).filter((f) => f.endsWith(".json")).length;
+	} catch {
+		return 0;
+	}
+}
+
+/**
+ * Replace occurrences of the user's home directory in free-form strings
+ * with the placeholder `<HOME>`. Complements `maskString` which handles
+ * token-shaped substrings but does not know about filesystem paths.
+ */
+function redactHomePaths(input: string): string {
+	const home = homedir();
+	if (!home) return input;
+	// Normalize both POSIX- and Windows-style separators so the replacement
+	// matches regardless of how the path was embedded.
+	const needles = new Set<string>();
+	needles.add(home);
+	needles.add(home.replace(/\\/g, "/"));
+	needles.add(home.replace(/\\/g, "\\\\"));
+	let output = input;
+	for (const needle of needles) {
+		if (!needle) continue;
+		while (output.includes(needle)) {
+			output = output.replace(needle, "<HOME>");
+		}
+	}
+	return output;
+}
+
+export function createCodexDiagTool(ctx: ToolContext): ToolDefinition {
+	const {
+		cachedAccountManagerRef,
+		runtimeMetrics,
+		buildRoutingVisibilitySnapshot,
+	} = ctx;
+
+	return tool({
+		description:
+			"Generate a redacted diagnostic snapshot for bug reports. Never includes tokens, account IDs, emails, labels, or user home paths.",
+		args: {},
+		async execute() {
+			await Promise.resolve();
+			const manifest = loadPluginManifest();
+			const manager = cachedAccountManagerRef.current;
+			const accountCount = manager?.getAccountCount() ?? 0;
+			const routing = buildRoutingVisibilitySnapshot();
+			const circuit = getCircuitBreakerSummary();
+			const logFileCount = countLogFiles();
+			const logDirExists = existsSync(LOG_DIR);
+
+			const metricsSummary = {
+				uptimeMs: Math.max(0, Date.now() - runtimeMetrics.startedAt),
+				totalRequests: runtimeMetrics.totalRequests,
+				successfulRequests: runtimeMetrics.successfulRequests,
+				failedRequests: runtimeMetrics.failedRequests,
+				rateLimitedResponses: runtimeMetrics.rateLimitedResponses,
+				serverErrors: runtimeMetrics.serverErrors,
+				networkErrors: runtimeMetrics.networkErrors,
+				authRefreshFailures: runtimeMetrics.authRefreshFailures,
+				accountRotations: runtimeMetrics.accountRotations,
+				emptyResponseRetries: runtimeMetrics.emptyResponseRetries,
+				retryBudgetExhaustions: runtimeMetrics.retryBudgetExhaustions,
+				retryProfile: runtimeMetrics.retryProfile,
+				lastErrorCategory: runtimeMetrics.lastErrorCategory,
+			};
+
+			const snapshot = {
+				plugin: {
+					name: manifest.name,
+					version: manifest.version,
+				},
+				runtime: {
+					node: process.version,
+					platform: process.platform,
+					arch: process.arch,
+				},
+				accounts: {
+					count: accountCount,
+				},
+				activeFamily: routing.modelFamily,
+				circuitBreaker: circuit,
+				metrics: metricsSummary,
+				logs: logDirExists
+					? {
+							directory: "<HOME>/.opencode/logs/codex-plugin",
+							fileCount: logFileCount,
+							note:
+								"Per-request JSON files only; no aggregated log file. Contents are NOT included in this snapshot.",
+						}
+					: { note: "no log file" },
+				redactionApplied: true,
+				generatedAt: new Date().toISOString(),
+			};
+
+			const rendered = JSON.stringify(snapshot, null, 2);
+			// Defence in depth: mask any stray token-shaped strings AND scrub
+			// home-directory paths even if an upstream value embedded them.
+			return maskString(redactHomePaths(rendered));
+		},
+	});
+}

--- a/lib/tools/index.ts
+++ b/lib/tools/index.ts
@@ -52,6 +52,9 @@ import { createCodexRemoveTool } from "./codex-remove.js";
 import { createCodexRefreshTool } from "./codex-refresh.js";
 import { createCodexExportTool } from "./codex-export.js";
 import { createCodexImportTool } from "./codex-import.js";
+import { createCodexDiagTool } from "./codex-diag.js";
+
+export { createCodexDiagTool } from "./codex-diag.js";
 
 /**
  * Mutable reference wrapper.
@@ -238,5 +241,6 @@ export function createToolRegistry(ctx: ToolContext): CodexToolRegistry {
 		"codex-refresh": createCodexRefreshTool(ctx),
 		"codex-export": createCodexExportTool(ctx),
 		"codex-import": createCodexImportTool(ctx),
+		"codex-diag": createCodexDiagTool(ctx),
 	};
 }

--- a/lib/ui/format.ts
+++ b/lib/ui/format.ts
@@ -21,6 +21,10 @@ const TONE_TO_COLOR: Record<UiTextTone, keyof UiRuntimeOptions["theme"]["colors"
 
 export function paintUiText(ui: UiRuntimeOptions, text: string, tone: UiTextTone = "normal"): string {
 	if (!ui.v2Enabled) return text;
+	// `colorEnabled === false` means NO_COLOR / FORCE_COLOR=0 / no TTY;
+	// return the unstyled text so the layout (bullets, labels, spacing)
+	// is preserved but no ANSI escape sequences are emitted.
+	if (ui.colorEnabled === false) return text;
 	const colorKey = TONE_TO_COLOR[tone];
 	if (!colorKey) return text;
 	return `${ui.theme.colors[colorKey]}${text}${ui.theme.colors.reset}`;

--- a/lib/ui/runtime.ts
+++ b/lib/ui/runtime.ts
@@ -1,5 +1,6 @@
 import {
 	createUiTheme,
+	shouldUseColor,
 	type UiColorProfile,
 	type UiGlyphMode,
 	type UiTheme,
@@ -10,19 +11,29 @@ export interface UiRuntimeOptions {
 	colorProfile: UiColorProfile;
 	glyphMode: UiGlyphMode;
 	theme: UiTheme;
+	/**
+	 * Effective ANSI-color enablement after resolving `NO_COLOR` /
+	 * `FORCE_COLOR` / TTY detection via {@link shouldUseColor}.
+	 *
+	 * Optional so existing literals that build a `UiRuntimeOptions` in
+	 * tests or mocks without this field keep working; downstream
+	 * consumers must treat `undefined` as "colors allowed" to preserve
+	 * the pre-existing behaviour.
+	 */
+	colorEnabled?: boolean;
 }
 
-const DEFAULT_OPTIONS: UiRuntimeOptions = {
-	v2Enabled: true,
-	colorProfile: "truecolor",
-	glyphMode: "ascii",
-	theme: createUiTheme({
-		profile: "truecolor",
+function buildDefaultOptions(): UiRuntimeOptions {
+	return {
+		v2Enabled: true,
+		colorProfile: "truecolor",
 		glyphMode: "ascii",
-	}),
-};
+		theme: createUiTheme({ profile: "truecolor", glyphMode: "ascii" }),
+		colorEnabled: shouldUseColor(),
+	};
+}
 
-let runtimeOptions: UiRuntimeOptions = { ...DEFAULT_OPTIONS };
+let runtimeOptions: UiRuntimeOptions = buildDefaultOptions();
 
 export function setUiRuntimeOptions(
 	options: Partial<Omit<UiRuntimeOptions, "theme">>,
@@ -30,11 +41,16 @@ export function setUiRuntimeOptions(
 	const v2Enabled = options.v2Enabled ?? runtimeOptions.v2Enabled;
 	const colorProfile = options.colorProfile ?? runtimeOptions.colorProfile;
 	const glyphMode = options.glyphMode ?? runtimeOptions.glyphMode;
+	// Re-resolve colorEnabled on every apply so that a test or caller
+	// flipping `NO_COLOR` / `FORCE_COLOR` between invocations is honoured,
+	// while an explicit override via `options.colorEnabled` still wins.
+	const colorEnabled = options.colorEnabled ?? shouldUseColor();
 	runtimeOptions = {
 		v2Enabled,
 		colorProfile,
 		glyphMode,
 		theme: createUiTheme({ profile: colorProfile, glyphMode }),
+		colorEnabled,
 	};
 	return runtimeOptions;
 }
@@ -44,7 +60,7 @@ export function getUiRuntimeOptions(): UiRuntimeOptions {
 }
 
 export function resetUiRuntimeOptions(): UiRuntimeOptions {
-	runtimeOptions = { ...DEFAULT_OPTIONS };
+	runtimeOptions = buildDefaultOptions();
 	return runtimeOptions;
 }
 

--- a/lib/ui/theme.ts
+++ b/lib/ui/theme.ts
@@ -2,6 +2,35 @@
  * Shared terminal theme primitives for legacy and Codex-style TUI rendering.
  */
 
+/**
+ * Resolve whether ANSI color output is permitted, honouring the widely
+ * supported `NO_COLOR` (https://no-color.org) and `FORCE_COLOR`
+ * conventions before falling back to TTY detection.
+ *
+ * Precedence:
+ *   1. `NO_COLOR` — if set to any non-empty value, colors are disabled.
+ *      An empty string is treated as "not set" (matches the spec).
+ *   2. `FORCE_COLOR` — if set to any value other than `"0"` / `"false"`,
+ *      colors are forced on even without a TTY. `"0"` or `"false"`
+ *      forces colors OFF regardless of TTY.
+ *   3. Fallback: enable colors when the stream is a TTY.
+ *
+ * The helper takes its dependencies as parameters so it is trivially
+ * testable and can be reused from non-process contexts.
+ */
+export function shouldUseColor(
+	stdout: { isTTY?: boolean } = process.stdout,
+	env: NodeJS.ProcessEnv = process.env,
+): boolean {
+	if (env.NO_COLOR !== undefined && env.NO_COLOR !== "") return false;
+	const force = env.FORCE_COLOR;
+	if (force !== undefined && force !== "") {
+		if (force === "0" || force === "false") return false;
+		return true;
+	}
+	return Boolean(stdout.isTTY);
+}
+
 export type UiColorProfile = "ansi16" | "ansi256" | "truecolor";
 export type UiGlyphMode = "ascii" | "unicode" | "auto";
 

--- a/test/tools-codex-diag.test.ts
+++ b/test/tools-codex-diag.test.ts
@@ -1,0 +1,229 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+	clearCircuitBreakers,
+	getCircuitBreaker,
+} from "../lib/circuit-breaker.js";
+import type { ToolContext } from "../lib/tools/index.js";
+import { createCodexDiagTool } from "../lib/tools/codex-diag.js";
+import type { RuntimeMetrics, RoutingVisibilitySnapshot } from "../lib/runtime.js";
+
+function buildRuntimeMetrics(
+	overrides: Partial<RuntimeMetrics> = {},
+): RuntimeMetrics {
+	return {
+		startedAt: Date.now() - 1234,
+		totalRequests: 10,
+		successfulRequests: 8,
+		failedRequests: 2,
+		rateLimitedResponses: 0,
+		serverErrors: 0,
+		networkErrors: 1,
+		authRefreshFailures: 0,
+		emptyResponseRetries: 0,
+		accountRotations: 1,
+		cumulativeLatencyMs: 2500,
+		retryBudgetExhaustions: 0,
+		retryBudgetUsage: {
+			authRefresh: 0,
+			network: 1,
+			server: 0,
+			rateLimitShort: 0,
+			rateLimitGlobal: 0,
+			emptyResponse: 0,
+		},
+		retryBudgetLimits: {
+			authRefresh: 3,
+			network: 3,
+			server: 3,
+			rateLimitShort: 3,
+			rateLimitGlobal: 3,
+			emptyResponse: 3,
+		},
+		retryProfile: "standard",
+		lastRetryBudgetExhaustedClass: null,
+		lastRetryBudgetReason: null,
+		lastRequestAt: null,
+		lastError: null,
+		lastErrorCategory: null,
+		promptCacheEnabledRequests: 0,
+		promptCacheMissingRequests: 0,
+		lastPromptCacheKey: null,
+		lastSelectedAccountIndex: null,
+		lastQuotaKey: null,
+		lastSelectionSnapshot: null,
+		...overrides,
+	};
+}
+
+function buildRouting(
+	overrides: Partial<RoutingVisibilitySnapshot> = {},
+): RoutingVisibilitySnapshot {
+	return {
+		requestedModel: null,
+		effectiveModel: null,
+		modelFamily: null,
+		quotaKey: null,
+		selectedAccountIndex: null,
+		zeroBasedSelectedAccountIndex: null,
+		lastErrorCategory: null,
+		fallbackApplied: false,
+		fallbackFrom: null,
+		fallbackTo: null,
+		fallbackReason: null,
+		selectionExplainability: [],
+		...overrides,
+	};
+}
+
+function buildCtx(options: {
+	accountCount?: number;
+	metrics?: RuntimeMetrics;
+	routing?: RoutingVisibilitySnapshot;
+}): ToolContext {
+	const metrics = options.metrics ?? buildRuntimeMetrics();
+	const routing = options.routing ?? buildRouting();
+	const ctx = {
+		cachedAccountManagerRef: {
+			current:
+				options.accountCount === undefined
+					? null
+					: {
+							getAccountCount: () => options.accountCount ?? 0,
+						},
+		},
+		accountManagerPromiseRef: { current: null },
+		runtimeMetrics: metrics,
+		beginnerSafeModeRef: { current: false },
+		buildRoutingVisibilitySnapshot: () => routing,
+	};
+	return ctx as unknown as ToolContext;
+}
+
+describe("codex-diag tool", () => {
+	beforeEach(() => {
+		clearCircuitBreakers();
+	});
+
+	it("returns JSON with the expected top-level keys", async () => {
+		const tool = createCodexDiagTool(buildCtx({ accountCount: 2 }));
+		const raw = await tool.execute({}, {} as never);
+		const parsed = JSON.parse(raw);
+		expect(parsed).toMatchObject({
+			plugin: { name: expect.any(String), version: expect.any(String) },
+			runtime: {
+				node: expect.any(String),
+				platform: expect.any(String),
+				arch: expect.any(String),
+			},
+			accounts: { count: 2 },
+			circuitBreaker: {
+				total: { closed: 0, open: 0, halfOpen: 0 },
+				byGroup: {},
+			},
+			metrics: expect.objectContaining({
+				totalRequests: 10,
+				retryProfile: "standard",
+			}),
+			redactionApplied: true,
+		});
+		expect(typeof parsed.generatedAt).toBe("string");
+	});
+
+	it("reports accounts.count=0 when no manager is cached", async () => {
+		const tool = createCodexDiagTool(buildCtx({}));
+		const raw = await tool.execute({}, {} as never);
+		const parsed = JSON.parse(raw);
+		expect(parsed.accounts.count).toBe(0);
+	});
+
+	it("summarizes circuit breakers by group without leaking keys", async () => {
+		// Seed three breakers; two fail enough times to open.
+		const a = getCircuitBreaker("account:A");
+		const b = getCircuitBreaker("account:B");
+		getCircuitBreaker("account:C");
+		for (const breaker of [a, b]) {
+			breaker.recordFailure();
+			breaker.recordFailure();
+			breaker.recordFailure();
+		}
+		const tool = createCodexDiagTool(buildCtx({ accountCount: 3 }));
+		const raw = await tool.execute({}, {} as never);
+		const parsed = JSON.parse(raw);
+		expect(parsed.circuitBreaker.total).toEqual({
+			closed: 1,
+			open: 2,
+			halfOpen: 0,
+		});
+		expect(parsed.circuitBreaker.byGroup).toEqual({
+			account: { closed: 1, open: 2, halfOpen: 0 },
+		});
+		// The grouped summary must NOT embed the account-level keys.
+		expect(raw).not.toContain("account:A");
+		expect(raw).not.toContain("account:B");
+		expect(raw).not.toContain("account:C");
+	});
+
+	it("reports the active model family from the routing snapshot", async () => {
+		const tool = createCodexDiagTool(
+			buildCtx({ routing: buildRouting({ modelFamily: "gpt-5.4" }) }),
+		);
+		const raw = await tool.execute({}, {} as never);
+		const parsed = JSON.parse(raw);
+		expect(parsed.activeFamily).toBe("gpt-5.4");
+	});
+
+	it("redacts JWT-shaped tokens present anywhere in the metrics payload", async () => {
+		// A future leak vector: a token accidentally stored in lastError.
+		const leakyToken =
+			"eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0ZXN0In0.abcdefghij";
+		const metrics = buildRuntimeMetrics({
+			lastError: `upstream said: Bearer ${leakyToken}`,
+		});
+		const tool = createCodexDiagTool(buildCtx({ metrics }));
+		const raw = await tool.execute({}, {} as never);
+		expect(raw).not.toContain(leakyToken);
+		// Whichever masker catches it, the token must not survive verbatim.
+	});
+
+	it("does not leak the user's home directory path", async () => {
+		const tool = createCodexDiagTool(buildCtx({ accountCount: 1 }));
+		const raw = await tool.execute({}, {} as never);
+		// `<HOME>` placeholder is used whether or not the log dir exists.
+		// If the real home path leaked, it would appear in the string; this
+		// asserts the redaction path ran.
+		const home = (await import("node:os")).homedir();
+		if (home) {
+			expect(raw).not.toContain(home);
+		}
+	});
+
+	it("indicates 'no log file' when the log directory is absent", async () => {
+		const tool = createCodexDiagTool(buildCtx({}));
+		const raw = await tool.execute({}, {} as never);
+		const parsed = JSON.parse(raw);
+		// At minimum, the `logs` key is present and describes state rather
+		// than including file contents.
+		expect(parsed.logs).toBeDefined();
+		if (parsed.logs.note === "no log file") {
+			expect(parsed.logs.directory).toBeUndefined();
+			expect(parsed.logs.fileCount).toBeUndefined();
+		} else {
+			expect(parsed.logs.directory).toBe(
+				"<HOME>/.opencode/logs/codex-plugin",
+			);
+			expect(typeof parsed.logs.fileCount).toBe("number");
+			expect(parsed.logs).not.toHaveProperty("contents");
+		}
+	});
+
+	it("returns only aggregate counts — no account IDs or per-account keys", async () => {
+		const tool = createCodexDiagTool(buildCtx({ accountCount: 5 }));
+		const raw = await tool.execute({}, {} as never);
+		// The snapshot exposes a COUNT, not a list.
+		const parsed = JSON.parse(raw);
+		expect(parsed.accounts).toEqual({ count: 5 });
+		expect(parsed.accounts).not.toHaveProperty("list");
+		expect(parsed.accounts).not.toHaveProperty("items");
+	});
+});

--- a/test/ui-no-color.test.ts
+++ b/test/ui-no-color.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, beforeEach } from "vitest";
+
+import { shouldUseColor } from "../lib/ui/theme.js";
+import {
+	resetUiRuntimeOptions,
+	setUiRuntimeOptions,
+} from "../lib/ui/runtime.js";
+import { paintUiText } from "../lib/ui/format.js";
+
+describe("shouldUseColor", () => {
+	it("NO_COLOR=anything disables", () => {
+		expect(shouldUseColor({ isTTY: true }, { NO_COLOR: "1" })).toBe(false);
+		expect(shouldUseColor({ isTTY: true }, { NO_COLOR: "yes" })).toBe(
+			false,
+		);
+	});
+
+	it("NO_COLOR empty is ignored", () => {
+		expect(shouldUseColor({ isTTY: true }, { NO_COLOR: "" })).toBe(true);
+	});
+
+	it("FORCE_COLOR=1 forces over TTY=false", () => {
+		expect(shouldUseColor({ isTTY: false }, { FORCE_COLOR: "1" })).toBe(
+			true,
+		);
+	});
+
+	it("FORCE_COLOR=0 disables", () => {
+		expect(shouldUseColor({ isTTY: true }, { FORCE_COLOR: "0" })).toBe(
+			false,
+		);
+	});
+
+	it("FORCE_COLOR=false disables", () => {
+		expect(shouldUseColor({ isTTY: true }, { FORCE_COLOR: "false" })).toBe(
+			false,
+		);
+	});
+
+	it("defaults to TTY", () => {
+		expect(shouldUseColor({ isTTY: true }, {})).toBe(true);
+		expect(shouldUseColor({ isTTY: false }, {})).toBe(false);
+	});
+
+	it("NO_COLOR wins over FORCE_COLOR", () => {
+		expect(
+			shouldUseColor(
+				{ isTTY: false },
+				{ NO_COLOR: "1", FORCE_COLOR: "1" },
+			),
+		).toBe(false);
+	});
+});
+
+describe("UI runtime NO_COLOR wiring", () => {
+	beforeEach(() => {
+		resetUiRuntimeOptions();
+	});
+
+	it("paintUiText suppresses ANSI when colorEnabled=false", () => {
+		const ui = setUiRuntimeOptions({
+			v2Enabled: true,
+			colorProfile: "truecolor",
+			glyphMode: "ascii",
+			colorEnabled: false,
+		});
+		const painted = paintUiText(ui, "hello", "accent");
+		expect(painted).toBe("hello");
+		expect(painted).not.toContain("\x1b[");
+	});
+
+	it("paintUiText still emits ANSI when colorEnabled=true", () => {
+		const ui = setUiRuntimeOptions({
+			v2Enabled: true,
+			colorProfile: "truecolor",
+			glyphMode: "ascii",
+			colorEnabled: true,
+		});
+		const painted = paintUiText(ui, "hello", "accent");
+		expect(painted).toContain("hello");
+		expect(painted).toContain("\x1b[");
+	});
+});


### PR DESCRIPTION
## Summary

Phase 3 Batch C. Two items:

1. **`NO_COLOR` + `FORCE_COLOR` support** in `lib/ui/theme.ts`. Follows the conventions at https://no-color.org and https://force-color.org. `NO_COLOR` wins over `FORCE_COLOR`; either overrides TTY detection. Wired through `UiRuntimeOptions.colorEnabled` so `paintUiText` suppresses ANSI escapes when the user opts out, preserving layout without styling.

2. **`codex-diag` tool** — new `@opencode-ai/plugin` tool that emits a redacted diagnostic snapshot for bug reports. JSON output includes plugin + Node + platform info, account count (no IDs), active-family list, circuit-breaker summary (counts only), runtime metrics snapshot. All potentially-sensitive fields pass through `maskString` and a home-path scrubber so tokens, account IDs, emails, labels, and the reporter's `$HOME` never appear in a shared bug report.

## Audit refs

- `docs/audits/13-phased-roadmap.md` §3 (NO_COLOR)
- `docs/audits/08-feature-recommendations.md` (diagnostics snapshot)

## Tests

- `test/ui-no-color.test.ts` — 9 tests covering `NO_COLOR` / `FORCE_COLOR` / TTY interaction plus runtime integration for `paintUiText`
- `test/tools-codex-diag.test.ts` — 8 tests covering happy path, circuit-breaker grouping without key leak, JWT redaction pass-through, home-path scrubbing, and `no log file` branch

## Verification

Full local run: `npm run typecheck && npm run lint && npm test && npm run build` — all pass. 68 test files, 2148 tests total (baseline 2131, delta +17 from this batch).

## Commits

1. `feat(ui): respect NO_COLOR and FORCE_COLOR env vars` — `shouldUseColor` helper + wire-up + tests
2. `refactor(batch-c): expose read-only internals for diag consumption` — additive-only exports (`getCircuitBreakerSummary`, `LOG_DIR`, `maskString`, `sanitizeValue`)
3. `feat(batch-c): add codex-diag redacted diagnostic snapshot tool` — tool + registration + tests

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

phase 3 batch c lands two additive features: `shouldUseColor` in `lib/ui/theme.ts` (NO_COLOR/FORCE_COLOR precedence, injected deps, wired through `UiRuntimeOptions.colorEnabled` → `paintUiText`) and the `codex-diag` tool (redacted diagnostic snapshot with `maskString` + `redactHomePaths` defence-in-depth, aggregate-only circuit-breaker counts, no account IDs). all findings are P2 — safe to merge.

<h3>Confidence Score: 5/5</h3>

safe to merge — all findings are P2 style/coverage suggestions with no impact on correctness or token safety

no P0 or P1 issues; the redaction layering is solid, NO_COLOR precedence is spec-compliant, and circuit-breaker export leaks no account identifiers. the TOCTOU between countLogFiles and logDirExists is benign for a diagnostic snapshot tool.

lib/tools/codex-diag.ts (minor TOCTOU + no-op await), lib/logger.ts (maskString in __testOnly is now redundant)

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/tools/codex-diag.ts | new diagnostic snapshot tool; redaction layering (maskString + redactHomePaths) is solid, but has a minor TOCTOU between countLogFiles and logDirExists and a no-op await at the top of execute() |
| lib/logger.ts | promotes maskString, sanitizeValue, and LOG_DIR to public exports; maskString is now redundantly kept in __testOnly after its promotion |
| lib/ui/theme.ts | adds shouldUseColor helper with correct NO_COLOR/FORCE_COLOR precedence per spec; injected deps make it trivially testable |
| lib/ui/runtime.ts | wires colorEnabled into UiRuntimeOptions; re-resolves on every setUiRuntimeOptions call so env-var flips in tests are honoured; undefined preserved for backward compat |
| lib/ui/format.ts | strict === false guard in paintUiText correctly preserves legacy behaviour when colorEnabled is undefined |
| lib/circuit-breaker.ts | adds getCircuitBreakerSummary — returns aggregate counts only (no account keys), safe for diagnostic embedding |
| lib/tools/index.ts | registers codex-diag in the tool registry and re-exports the factory; no functional issues |
| test/ui-no-color.test.ts | 9 tests cover the main NO_COLOR/FORCE_COLOR/TTY paths; missing cases for NO_COLOR=0, FORCE_COLOR empty, and colorEnabled=undefined in paintUiText |
| test/tools-codex-diag.test.ts | 8 tests cover happy path, JWT redaction, home-path scrubbing, and circuit-breaker grouping; no windows-path or TOCTOU coverage |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller as Tool caller
    participant Diag as codex-diag.execute()
    participant AM as AccountManager (ref)
    participant CB as getCircuitBreakerSummary
    participant FS as node:fs (LOG_DIR)
    participant Mask as redactHomePaths + maskString

    Caller->>Diag: execute({})
    Diag->>AM: getAccountCount()
    AM-->>Diag: count (no IDs)
    Diag->>CB: getCircuitBreakerSummary()
    CB-->>Diag: { total, byGroup } (counts only)
    Diag->>FS: existsSync(LOG_DIR) + readdirSync
    FS-->>Diag: logDirExists, logFileCount
    Diag->>Diag: build snapshot (hardcoded <HOME> placeholder for dir)
    Diag->>Diag: JSON.stringify(snapshot)
    Diag->>Mask: redactHomePaths(rendered)
    Mask-->>Diag: home paths replaced with <HOME>
    Diag->>Mask: maskString(redacted)
    Mask-->>Diag: tokens/emails masked
    Diag-->>Caller: final redacted JSON string
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Foc-codex-multi-auth%22%20on%20the%20existing%20branch%20%22feat%2Fphase3-batch-c-ux-diag%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fphase3-batch-c-ux-diag%22.%0A%0AFix%20the%20following%205%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%205%0Alib%2Ftools%2Fcodex-diag.ts%3A104-105%0A**TOCTOU%20between%20%60countLogFiles%60%20and%20%60logDirExists%60**%0A%0A%60countLogFiles%28%29%60%20calls%20%60existsSync%28LOG_DIR%29%60%20internally%3B%20then%20%60logDirExists%60%20re-checks%20it%20independently.%20if%20the%20log%20dir%20is%20created%20%28by%20a%20concurrent%20%60logRequest%60%20call%29%20between%20the%20two%2C%20you%20get%20%60fileCount%3D0%60%20paired%20with%20%60logDirExists%3Dtrue%60%2C%20producing%20a%20snapshot%20where%20%60directory%60%20is%20shown%20but%20%60fileCount%60%20is%20stale.%20for%20a%20diagnostic%20snapshot%20this%20is%20cosmetic%2C%20but%20the%20simplest%20fix%20is%20one%20call%20that%20gives%20both%20pieces%3A%0A%0A%60%60%60ts%0Aconst%20logDirExists%20%3D%20existsSync%28LOG_DIR%29%3B%0Aconst%20logFileCount%20%3D%20logDirExists%20%3F%20countLogFiles%28%29%20%3A%200%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%205%0Alib%2Ftools%2Fcodex-diag.ts%3A98%0A**unnecessary%20%60await%20Promise.resolve%28%29%60**%0A%0Athis%20yield%20has%20no%20functional%20effect%20%E2%80%94%20nothing%20upstream%20awaits%20before%20the%20first%20real%20read.%20it%20pushes%20the%20entire%20snapshot%20build%20into%20the%20next%20microtask%20for%20no%20observable%20reason.%20safe%20to%20drop.%0A%0A%60%60%60suggestion%0A%09%09%09const%20manifest%20%3D%20loadPluginManifest%28%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%205%0Alib%2Flogger.ts%3A459-462%0A**%60maskString%60%20in%20%60__testOnly%60%20is%20now%20redundant**%0A%0A%60maskString%60%20was%20promoted%20to%20a%20public%20named%20export%20on%20line%20451%20as%20part%20of%20this%20PR.%20keeping%20it%20inside%20%60__testOnly%60%20as%20well%20is%20misleading%20%E2%80%94%20it%20implies%20the%20function%20is%20still%20private%2Ftest-only%2C%20and%20any%20import%20from%20%60__testOnly.maskString%60%20will%20silently%20shadow%20the%20public%20export%20if%20the%20namespace%20is%20mixed.%20recommend%20removing%20it%20from%20%60__testOnly%60%3A%0A%0A%60%60%60suggestion%0Aexport%20const%20__testOnly%20%3D%20%7B%0A%09sanitizeValue%2C%0A%7D%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%204%20of%205%0Atest%2Fui-no-color.test.ts%3A1-53%0A**missing%20vitest%20edge-case%20coverage**%0A%0Athree%20gaps%20worth%20noting%3A%0A%0A-%20%60NO_COLOR%3D%220%22%60%20%E2%80%94%20the%20spec%20says%20any%20non-empty%20string%20disables%20color%2C%20so%20%60%220%22%60%20should%20return%20%60false%60.%20there's%20no%20explicit%20test%20for%20this%3B%20currently%20only%20%60%221%22%60%20and%20%60%22yes%22%60%20are%20exercised.%0A-%20%60FORCE_COLOR%3D%22%22%60%20%28empty%20string%29%20%E2%80%94%20the%20current%20implementation%20treats%20this%20as%20unset%20and%20falls%20back%20to%20TTY%20detection.%20a%20test%20asserting%20that%20behavior%20is%20the%20intended%20contract%20would%20lock%20it%20in.%0A-%20%60colorEnabled%3Dundefined%60%20in%20%60paintUiText%60%20%E2%80%94%20the%20interface%20documents%20that%20%60undefined%60%20means%20%22colors%20allowed%22%20%28legacy-safe%29.%20no%20test%20covers%20this%20path%3B%20if%20the%20guard%20is%20ever%20tightened%20to%20%60!%3D%3D%20false%60%20it%20would%20break%20silently%20without%20a%20failing%20test.%0A%0A%23%23%23%20Issue%205%20of%205%0Atest%2Ftools-codex-diag.test.ts%3A189-199%0A**no%20windows-path%20redaction%20test**%0A%0Athe%20home-path%20scrub%20test%20guards%20against%20leaking%20%60homedir%28%29%60%2C%20but%20on%20POSIX%20CI%20it%20only%20validates%20the%20forward-slash%20form.%20the%20%60redactHomePaths%60%20helper%20builds%20three%20needles%20%28original%2C%20posix%2C%20double-backslash%29%20specifically%20for%20windows%20paths%20embedded%20in%20JSON%20output%20%E2%80%94%20there's%20no%20vitest%20case%20that%20injects%20a%20backslash-style%20path%20string%20and%20asserts%20the%20double-backslash%20needle%20fires.%20if%20windows%20CI%20is%20ever%20added%2C%20this%20will%20pass%20vacuously%3B%20a%20synthetic%20test%20with%20a%20faked%20home%20path%20of%20%60C%3A%5C%5CUsers%5C%5Ctester%60%20would%20lock%20in%20the%20logic%20now.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: lib/tools/codex-diag.ts
Line: 104-105

Comment:
**TOCTOU between `countLogFiles` and `logDirExists`**

`countLogFiles()` calls `existsSync(LOG_DIR)` internally; then `logDirExists` re-checks it independently. if the log dir is created (by a concurrent `logRequest` call) between the two, you get `fileCount=0` paired with `logDirExists=true`, producing a snapshot where `directory` is shown but `fileCount` is stale. for a diagnostic snapshot this is cosmetic, but the simplest fix is one call that gives both pieces:

```ts
const logDirExists = existsSync(LOG_DIR);
const logFileCount = logDirExists ? countLogFiles() : 0;
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: lib/tools/codex-diag.ts
Line: 98

Comment:
**unnecessary `await Promise.resolve()`**

this yield has no functional effect — nothing upstream awaits before the first real read. it pushes the entire snapshot build into the next microtask for no observable reason. safe to drop.

```suggestion
			const manifest = loadPluginManifest();
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: lib/logger.ts
Line: 459-462

Comment:
**`maskString` in `__testOnly` is now redundant**

`maskString` was promoted to a public named export on line 451 as part of this PR. keeping it inside `__testOnly` as well is misleading — it implies the function is still private/test-only, and any import from `__testOnly.maskString` will silently shadow the public export if the namespace is mixed. recommend removing it from `__testOnly`:

```suggestion
export const __testOnly = {
	sanitizeValue,
};
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: test/ui-no-color.test.ts
Line: 1-53

Comment:
**missing vitest edge-case coverage**

three gaps worth noting:

- `NO_COLOR="0"` — the spec says any non-empty string disables color, so `"0"` should return `false`. there's no explicit test for this; currently only `"1"` and `"yes"` are exercised.
- `FORCE_COLOR=""` (empty string) — the current implementation treats this as unset and falls back to TTY detection. a test asserting that behavior is the intended contract would lock it in.
- `colorEnabled=undefined` in `paintUiText` — the interface documents that `undefined` means "colors allowed" (legacy-safe). no test covers this path; if the guard is ever tightened to `!== false` it would break silently without a failing test.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: test/tools-codex-diag.test.ts
Line: 189-199

Comment:
**no windows-path redaction test**

the home-path scrub test guards against leaking `homedir()`, but on POSIX CI it only validates the forward-slash form. the `redactHomePaths` helper builds three needles (original, posix, double-backslash) specifically for windows paths embedded in JSON output — there's no vitest case that injects a backslash-style path string and asserts the double-backslash needle fires. if windows CI is ever added, this will pass vacuously; a synthetic test with a faked home path of `C:\\Users\\tester` would lock in the logic now.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(batch-c): add codex-diag redacted d..."](https://github.com/ndycode/oc-codex-multi-auth/commit/5370264bf29c45452d310de98b07c7630aedc429) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28753884)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->