### PR TITLE
test: Phase 3 Batch E - real fault-injection chaos tests

### DIFF
--- a/test/chaos/auth-faults.test.ts
+++ b/test/chaos/auth-faults.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Phase 3 Batch E — auth-faults chaos tests.
+ *
+ * Injects faults into the OAuth refresh + rotation path and the local
+ * callback server, then asserts the plugin's real recovery behavior
+ * (cooldown, rotation to next account, PKCE isolation).
+ *
+ * Scenarios covered:
+ *   3. 401 mid-request → refreshAccessToken surfaces failed/http_error
+ *      and AccountManager.markAccountsWithRefreshTokenCoolingDown puts
+ *      the offending refresh token on cooldown; the next rotation call
+ *      returns a different account for the same model family.
+ *   6. Port-1455 collision on concurrent login → only the first
+ *      startLocalOAuthServer call binds; the second resolves with
+ *      ready=false. PKCE verifier isolation: concurrent
+ *      createAuthorizationFlow() calls each produce a distinct verifier
+ *      and state so the winning login cannot be replayed by the loser.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+import {
+	createAuthorizationFlow,
+	refreshAccessToken,
+} from "../../lib/auth/auth.js";
+import { startLocalOAuthServer } from "../../lib/auth/server.js";
+import { AccountManager } from "../../lib/accounts.js";
+import type { AccountStorageV3 } from "../../lib/storage.js";
+
+// Two-account pool so rotation has somewhere to go when the first account
+// is cooled down by the 401 path. Using fixed timestamps keeps the selection
+// deterministic across runs (cursor-based rotation is stable).
+function makeTwoAccountStorage(): AccountStorageV3 {
+	const now = 1_700_000_000_000;
+	return {
+		version: 3,
+		activeIndex: 0,
+		accounts: [
+			{ refreshToken: "rt-alpha", addedAt: now, lastUsed: now },
+			{ refreshToken: "rt-bravo", addedAt: now, lastUsed: now - 1 },
+		],
+	};
+}
+
+describe("chaos/auth-faults — real fault injection", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+		vi.useRealTimers();
+	});
+
+	describe("scenario 3: 401 mid-request rotates to next account + cools refresh token", () => {
+		it("refreshAccessToken surfaces http_error(401) so callers can trigger cooldown", async () => {
+			// Upstream /oauth/token returns 401 once; the helper must report
+			// the typed failure so the plugin can mark the token and rotate.
+			const originalFetch = globalThis.fetch;
+			const fetchSpy = vi.fn(async () =>
+				new Response(JSON.stringify({ error: "invalid_grant" }), { status: 401 }),
+			);
+			globalThis.fetch = fetchSpy as typeof globalThis.fetch;
+
+			try {
+				const result = await refreshAccessToken("rt-alpha");
+				expect(result.type).toBe("failed");
+				if (result.type === "failed") {
+					expect(result.reason).toBe("http_error");
+					expect(result.statusCode).toBe(401);
+				}
+				expect(fetchSpy).toHaveBeenCalledTimes(1);
+			} finally {
+				globalThis.fetch = originalFetch;
+			}
+		});
+
+		it("manager rotates to the next account and marks the failing refresh token as cooled down", async () => {
+			// Freeze wall-clock so cooldown timestamps are comparable.
+			vi.useFakeTimers();
+			vi.setSystemTime(new Date(1_700_000_000_000));
+
+			const manager = new AccountManager(undefined, makeTwoAccountStorage());
+			const snapshotBefore = manager.getAccountsSnapshot();
+			expect(snapshotBefore).toHaveLength(2);
+
+			// Pick the current account for codex and simulate a 401 path:
+			// the refresh failure handler calls
+			// markAccountsWithRefreshTokenCoolingDown on the offending token.
+			const activeBefore = manager.getCurrentOrNextForFamily("codex");
+			expect(activeBefore).not.toBeNull();
+			const firstRefreshToken = activeBefore!.refreshToken;
+			expect(firstRefreshToken).toBe("rt-alpha");
+
+			const cooldownMs = 30_000;
+			const cooled = manager.markAccountsWithRefreshTokenCoolingDown(
+				firstRefreshToken,
+				cooldownMs,
+				"auth-failure",
+			);
+			expect(cooled).toBe(1);
+
+			// Rotation: the next eligible account for codex must differ.
+			const next = manager.getNextForFamily("codex");
+			expect(next).not.toBeNull();
+			expect(next!.refreshToken).toBe("rt-bravo");
+
+			// The cooled account carries a typed cooldown reason + a future
+			// expiry, both of which downstream explainability surfaces read.
+			const snapshotAfter = manager.getAccountsSnapshot();
+			const coolingAccount = snapshotAfter.find(
+				(a) => a.refreshToken === firstRefreshToken,
+			);
+			expect(coolingAccount).toBeDefined();
+			expect(coolingAccount!.cooldownReason).toBe("auth-failure");
+			expect(coolingAccount!.coolingDownUntil).toBeDefined();
+			expect(coolingAccount!.coolingDownUntil!).toBeGreaterThan(Date.now());
+			expect(coolingAccount!.coolingDownUntil! - Date.now()).toBeLessThanOrEqual(
+				cooldownMs,
+			);
+
+			manager.disposeShutdownHandler();
+		});
+
+		it("auth-failure counter increments atomically for the offending refresh token", async () => {
+			// The counter must serialize across two near-simultaneous 401s
+			// that share a refresh token (org-variant accounts). Without
+			// serialization both callers can read stale 0 and write 1,
+			// masking the real failure count.
+			const manager = new AccountManager(undefined, makeTwoAccountStorage());
+			const accounts = manager.getAccountsSnapshot();
+			const alpha = accounts.find((a) => a.refreshToken === "rt-alpha")!;
+
+			const [first, second] = await Promise.all([
+				manager.incrementAuthFailures(alpha),
+				manager.incrementAuthFailures(alpha),
+			]);
+			expect([first, second].sort()).toEqual([1, 2]);
+			expect(manager.getAuthFailures(alpha)).toBe(2);
+
+			manager.disposeShutdownHandler();
+		});
+	});
+
+	describe("scenario 6: port-1455 collision + PKCE verifier isolation", () => {
+		let firstServer: Awaited<ReturnType<typeof startLocalOAuthServer>> | null =
+			null;
+		let secondServer: Awaited<ReturnType<typeof startLocalOAuthServer>> | null =
+			null;
+
+		afterEach(() => {
+			// Defensive: tear servers down in both orderings so a half-bound
+			// port does not bleed into sibling tests.
+			if (firstServer) {
+				firstServer.close();
+				firstServer = null;
+			}
+			if (secondServer) {
+				secondServer.close();
+				secondServer = null;
+			}
+		});
+
+		it("concurrent startLocalOAuthServer: first binds, second resolves with ready=false", async () => {
+			const stateA = "chaos-state-alpha";
+			const stateB = "chaos-state-bravo";
+
+			firstServer = await startLocalOAuthServer({ state: stateA });
+			expect(firstServer.ready).toBe(true);
+			expect(firstServer.port).toBe(1455);
+
+			// Second concurrent attempt on the same port must surface the
+			// collision as ready=false instead of silently hanging.
+			secondServer = await startLocalOAuthServer({ state: stateB });
+			expect(secondServer.ready).toBe(false);
+			expect(secondServer.port).toBe(1455);
+
+			// The loser's waitForCode must resolve deterministically (null)
+			// so the caller can fall through to device-code / manual paste.
+			const loserCode = await secondServer.waitForCode();
+			expect(loserCode).toBeNull();
+		});
+
+		it("concurrent authorization flows get distinct PKCE verifiers, states, and URLs", async () => {
+			const [flowA, flowB, flowC] = await Promise.all([
+				createAuthorizationFlow(),
+				createAuthorizationFlow(),
+				createAuthorizationFlow(),
+			]);
+
+			const verifiers = new Set([
+				flowA.pkce.verifier,
+				flowB.pkce.verifier,
+				flowC.pkce.verifier,
+			]);
+			const challenges = new Set([
+				flowA.pkce.challenge,
+				flowB.pkce.challenge,
+				flowC.pkce.challenge,
+			]);
+			const states = new Set([flowA.state, flowB.state, flowC.state]);
+
+			// Each concurrent flow MUST have an isolated (verifier, challenge,
+			// state) triple; collisions would allow the loser to replay the
+			// winner's auth code against the token endpoint.
+			expect(verifiers.size).toBe(3);
+			expect(challenges.size).toBe(3);
+			expect(states.size).toBe(3);
+
+			// Verifier shape: PKCE spec (RFC 7636) requires 43-128 chars
+			// of [A-Za-z0-9-._~]. We do not reimplement validation here;
+			// we just assert the field exists and meets the minimum length.
+			for (const verifier of verifiers) {
+				expect(verifier.length).toBeGreaterThanOrEqual(43);
+			}
+		});
+
+		it("bound server rejects callback with a mismatched state (replay protection)", async () => {
+			firstServer = await startLocalOAuthServer({ state: "winner-state" });
+			expect(firstServer.ready).toBe(true);
+
+			// A concurrent login's code cannot be hijacked because the state
+			// guard rejects a different state value. This is the property
+			// that makes PKCE isolation safe under port contention.
+			const res = await fetch(
+				"http://127.0.0.1:1455/auth/callback?code=hijack&state=loser-state",
+			);
+			expect(res.status).toBe(400);
+			expect(await res.text()).toContain("State mismatch");
+		});
+	});
+});

--- a/test/chaos/request-faults.test.ts
+++ b/test/chaos/request-faults.test.ts
@@ -1,0 +1,219 @@
+/**
+ * Phase 3 Batch E — request-faults chaos tests.
+ *
+ * Covers the two request-pipeline chaos scenarios: a circuit breaker
+ * opening while a request is in flight, and a 429 Retry-After response
+ * being translated into a real token-bucket delay that the next call
+ * respects.
+ *
+ * Scenarios covered:
+ *   4. Breaker opens mid-flight → the in-flight caller (already past the
+ *      gate) completes without raising CircuitOpenError, but the next
+ *      canAttempt short-circuits with state=open, reason=open.
+ *   5. Rate-limit 429 with Retry-After → handleErrorResponse parses the
+ *      header, and both the account-level rate-limit marker and the
+ *      per-quota token-bucket backoff state respect the delay window.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+import {
+	CircuitBreaker,
+	CircuitOpenError,
+} from "../../lib/circuit-breaker.js";
+import { handleErrorResponse } from "../../lib/request/fetch-helpers.js";
+import {
+	clearRateLimitBackoffState,
+	getRateLimitBackoff,
+} from "../../lib/request/rate-limit-backoff.js";
+import { AccountManager } from "../../lib/accounts.js";
+import { isRateLimitedForFamily } from "../../lib/accounts/rate-limits.js";
+import type { AccountStorageV3 } from "../../lib/storage.js";
+
+describe("chaos/request-faults — real fault injection", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date(1_700_000_000_000));
+		clearRateLimitBackoffState();
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+		vi.useRealTimers();
+		clearRateLimitBackoffState();
+	});
+
+	describe("scenario 4: circuit breaker opens mid-flight", () => {
+		it("in-flight request completes; the next canAttempt short-circuits with state=open", () => {
+			const breaker = new CircuitBreaker({
+				failureThreshold: 3,
+				failureWindowMs: 60_000,
+				resetTimeoutMs: 30_000,
+			});
+
+			// Simulate request A passing the gate while the breaker is still
+			// closed (the hot path: canAttempt() returns true, then the HTTP
+			// call begins). This is the "in-flight" condition.
+			const gateA = breaker.canAttempt();
+			expect(gateA.allowed).toBe(true);
+			expect(gateA.state).toBe("closed");
+
+			// Meanwhile, three concurrent failures accumulate — the breaker
+			// trips OPEN while request A is still waiting on its response.
+			breaker.recordFailure();
+			breaker.recordFailure();
+			breaker.recordFailure();
+			expect(breaker.getState()).toBe("open");
+
+			// Request A eventually returns successfully. In the open state,
+			// recordSuccess is a no-op by design (see lib/circuit-breaker.ts)
+			// — the breaker must not reset from an open state on a single
+			// late success, otherwise it would thrash between open and closed.
+			breaker.recordSuccess();
+			expect(breaker.getState()).toBe("open");
+
+			// Request B, dispatched after the trip, must be short-circuited.
+			const gateB = breaker.canAttempt();
+			expect(gateB.allowed).toBe(false);
+			expect(gateB.state).toBe("open");
+			expect(gateB.reason).toBe("open");
+
+			// The throwing API parallels canAttempt: callers that used the
+			// canExecute() guard get a typed CircuitOpenError.
+			expect(() => breaker.canExecute()).toThrow(CircuitOpenError);
+		});
+
+		it("after resetTimeoutMs only one probe is admitted; concurrent probes see probe-in-flight", () => {
+			const breaker = new CircuitBreaker({
+				failureThreshold: 1,
+				resetTimeoutMs: 10_000,
+				halfOpenMaxAttempts: 1,
+			});
+
+			breaker.recordFailure();
+			expect(breaker.getState()).toBe("open");
+
+			// Still inside the reset window → both probes are denied.
+			const early = breaker.canAttempt();
+			expect(early.allowed).toBe(false);
+			expect(early.state).toBe("open");
+
+			// Cross the reset boundary: the breaker auto-transitions to
+			// half-open and admits exactly one probe.
+			vi.setSystemTime(new Date(Date.now() + 10_000));
+			const probeA = breaker.canAttempt();
+			expect(probeA.allowed).toBe(true);
+			expect(probeA.state).toBe("half-open");
+
+			// A concurrent probe must be rejected with the explicit
+			// `probe-in-flight` reason so the caller can rotate instead of
+			// burning the shared slot.
+			const probeB = breaker.canAttempt();
+			expect(probeB.allowed).toBe(false);
+			expect(probeB.state).toBe("half-open");
+			expect(probeB.reason).toBe("probe-in-flight");
+		});
+	});
+
+	describe("scenario 5: 429 with Retry-After respects the delay", () => {
+		it("handleErrorResponse parses Retry-After header into retryAfterMs", async () => {
+			// Build a real upstream 429 response carrying the header and
+			// a usage_limit_reached body so the helper treats it as a rate
+			// limit (not an entitlement error).
+			const upstream = new Response(
+				JSON.stringify({ error: { code: "usage_limit_reached" } }),
+				{
+					status: 429,
+					statusText: "Too Many Requests",
+					headers: { "retry-after": "2", "content-type": "application/json" },
+				},
+			);
+
+			const result = await handleErrorResponse(upstream);
+			expect(result.rateLimit).toBeDefined();
+			expect(result.rateLimit!.retryAfterMs).toBe(2000);
+			expect(result.rateLimit!.code).toBe("usage_limit_reached");
+		});
+
+		it("handleErrorResponse prefers retry-after-ms over retry-after (seconds) when both are present", async () => {
+			// retry-after-ms is a Codex-specific extension; it must win
+			// because it's strictly more precise than the RFC 7231 header.
+			const upstream = new Response(
+				JSON.stringify({ error: { code: "rate_limit_exceeded" } }),
+				{
+					status: 429,
+					headers: {
+						"retry-after-ms": "1750",
+						"retry-after": "5",
+						"content-type": "application/json",
+					},
+				},
+			);
+
+			const result = await handleErrorResponse(upstream);
+			expect(result.rateLimit?.retryAfterMs).toBe(1750);
+		});
+
+		it("account rate-limit marker blocks selection until the Retry-After window elapses", () => {
+			const now = Date.now();
+			const storage: AccountStorageV3 = {
+				version: 3,
+				activeIndex: 0,
+				accounts: [{ refreshToken: "rt-429", addedAt: now, lastUsed: now }],
+			};
+			const manager = new AccountManager(undefined, storage);
+
+			// Work against the live account reference (not a snapshot copy);
+			// markRateLimitedWithReason mutates rateLimitResetTimes in place,
+			// and getAccountsSnapshot returns shallow-cloned maps that would
+			// not reflect the mutation on a subsequent read.
+			const liveAccount = manager.getCurrentAccountForFamily("codex")!;
+			expect(liveAccount.refreshToken).toBe("rt-429");
+
+			// Mark the account as rate-limited for 2 seconds, then walk time
+			// across the boundary. The state module's predicate is the exact
+			// check rotation uses, so asserting it here exercises the real
+			// gate the plugin uses after a 429.
+			manager.markRateLimitedWithReason(liveAccount, 2000, "codex", "quota");
+
+			expect(isRateLimitedForFamily(liveAccount, "codex")).toBe(true);
+			// Rotation treats a rate-limited single-account pool as "no
+			// eligible accounts" so callers know to back off.
+			expect(manager.getCurrentOrNextForFamily("codex")).toBeNull();
+
+			// 1s later — still blocked.
+			vi.setSystemTime(new Date(now + 1_000));
+			expect(isRateLimitedForFamily(liveAccount, "codex")).toBe(true);
+
+			// 2.5s later — the window has elapsed, the account is eligible.
+			vi.setSystemTime(new Date(now + 2_500));
+			expect(isRateLimitedForFamily(liveAccount, "codex")).toBe(false);
+			expect(manager.getCurrentOrNextForFamily("codex")).not.toBeNull();
+
+			manager.disposeShutdownHandler();
+		});
+
+		it("token-bucket backoff deduplicates inside the 2s window and increments past it", () => {
+			// First 429: attempt 1, no dedup.
+			const first = getRateLimitBackoff(0, "codex", 2000);
+			expect(first.attempt).toBe(1);
+			expect(first.delayMs).toBe(2000);
+			expect(first.isDuplicate).toBe(false);
+
+			// Concurrent duplicate inside the 2s dedup window — same attempt,
+			// flagged as duplicate so the caller doesn't double-increment.
+			vi.setSystemTime(new Date(Date.now() + 1_500));
+			const dup = getRateLimitBackoff(0, "codex", 2000);
+			expect(dup.attempt).toBe(1);
+			expect(dup.isDuplicate).toBe(true);
+
+			// Past the dedup window → attempt increments and the exponential
+			// delay doubles (2s → 4s), bounded by MAX_BACKOFF_MS upstream.
+			vi.setSystemTime(new Date(Date.now() + 1_000));
+			const second = getRateLimitBackoff(0, "codex", 2000);
+			expect(second.attempt).toBe(2);
+			expect(second.delayMs).toBe(4000);
+			expect(second.isDuplicate).toBe(false);
+		});
+	});
+});

--- a/test/chaos/storage-faults.test.ts
+++ b/test/chaos/storage-faults.test.ts
@@ -1,0 +1,317 @@
+/**
+ * Phase 3 Batch E — storage-faults chaos tests.
+ *
+ * Exercises the real disk-write, atomic-rename, load, and shutdown-flush
+ * code paths under injected failures, then asserts that the plugin either
+ * recovers (retries + eventual success) or degrades safely (typed
+ * StorageError with an actionable hint, file preserved on disk).
+ *
+ * Scenarios covered:
+ *   1. Disk-full (ENOSPC) on save — saveAccounts must throw StorageError
+ *      with code=ENOSPC + "Disk is full" hint, and the next call with
+ *      writable disk must succeed (recovery).
+ *   2. Atomic rename EBUSY (simulated antivirus / indexer) — save must
+ *      succeed within the retry budget, and no orphaned .tmp file may
+ *      remain after the final successful rename.
+ *   7. Corrupted V3 file on load — the loader must not crash the plugin;
+ *      V2 files (intermediate shape) and forward-compat schemas must raise
+ *      a typed StorageError with a recovery hint pointing at the real
+ *      path. Malformed JSON is preserved on disk for recovery tooling.
+ *   8. SIGTERM fires mid-500ms debounce — runCleanup() must flush the
+ *      pending save synchronously so no rotation is lost.
+ *
+ * Determinism: every scenario injects the fault with vi.spyOn / vi.mock
+ * and drives time with vi.useFakeTimers({ shouldAdvanceTime: true }) where
+ * real-setTimeout retries are part of the path under test. Mocks are
+ * restored between tests so shared in-memory state cannot leak.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { promises as fs, existsSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import {
+	loadAccounts,
+	saveAccounts,
+	setStoragePathDirect,
+	StorageError,
+	type AccountStorageV3,
+} from "../../lib/storage.js";
+import { AccountManager } from "../../lib/accounts.js";
+import { registerCleanup, runCleanup } from "../../lib/shutdown.js";
+
+// Tiny helper: build a single-account V3 payload with a deterministic timestamp
+function makeStorage(refreshToken = "token-1"): AccountStorageV3 {
+	const now = 1_700_000_000_000; // frozen; never Date.now() to avoid drift
+	return {
+		version: 3,
+		activeIndex: 0,
+		accounts: [{ refreshToken, addedAt: now, lastUsed: now }],
+	};
+}
+
+describe("chaos/storage-faults — real fault injection", () => {
+	let testDir: string;
+	let storagePath: string;
+
+	beforeEach(async () => {
+		testDir = join(
+			tmpdir(),
+			"codex-chaos-storage-" + Math.random().toString(36).slice(2),
+		);
+		await fs.mkdir(testDir, { recursive: true });
+		storagePath = join(testDir, "accounts.json");
+		setStoragePathDirect(storagePath);
+	});
+
+	afterEach(async () => {
+		vi.restoreAllMocks();
+		vi.useRealTimers();
+		setStoragePathDirect(null);
+		await runCleanup();
+		await fs.rm(testDir, { recursive: true, force: true }).catch(() => {
+			/* best-effort cleanup */
+		});
+	});
+
+	describe("scenario 1: ENOSPC on save", () => {
+		it("saveAccounts throws StorageError with ENOSPC hint, then recovers on next attempt", async () => {
+			// Inject ENOSPC on the first writeFile; let the second one proceed
+			// so we can assert clean recovery on the next save.
+			const originalWriteFile = fs.writeFile.bind(fs);
+			let call = 0;
+			const spy = vi.spyOn(fs, "writeFile").mockImplementation(
+				async (path, data, options) => {
+					call += 1;
+					if (call === 1) {
+						const err = Object.assign(
+							new Error("ENOSPC: no space left on device") as NodeJS.ErrnoException,
+							{ code: "ENOSPC" },
+						);
+						throw err;
+					}
+					return originalWriteFile(
+						path as Parameters<typeof originalWriteFile>[0],
+						data as Parameters<typeof originalWriteFile>[1],
+						options as Parameters<typeof originalWriteFile>[2],
+					);
+				},
+			);
+
+			// First save: must raise a typed StorageError carrying the ENOSPC
+			// code and a user-actionable hint so the CLI can surface it.
+			let caught: unknown;
+			try {
+				await saveAccounts(makeStorage());
+			} catch (err) {
+				caught = err;
+			}
+			expect(caught).toBeInstanceOf(StorageError);
+			const storageErr = caught as StorageError;
+			expect(storageErr.code).toBe("ENOSPC");
+			expect(storageErr.path).toBe(storagePath);
+			expect(storageErr.hint.toLowerCase()).toContain("disk is full");
+			expect(storageErr.message).toContain("ENOSPC");
+
+			// Recovery: the next call should succeed now that the disk is writable.
+			await expect(saveAccounts(makeStorage("token-2"))).resolves.toBeUndefined();
+			expect(existsSync(storagePath)).toBe(true);
+			const persisted = JSON.parse(await fs.readFile(storagePath, "utf-8")) as {
+				accounts: Array<{ refreshToken: string }>;
+			};
+			expect(persisted.accounts[0]?.refreshToken).toBe("token-2");
+			expect(spy).toHaveBeenCalledTimes(2);
+		});
+	});
+
+	describe("scenario 2: EBUSY on atomic rename (AV/indexer lock)", () => {
+		beforeEach(() => {
+			// The retry path uses real setTimeout with exponential backoff
+			// (10/20/40/80ms); `shouldAdvanceTime` lets fake timers drain them
+			// automatically so the assertion arrives within the vitest budget.
+			vi.useFakeTimers({ shouldAdvanceTime: true });
+		});
+
+		it("retries on EBUSY and succeeds without leaving a .tmp orphan", async () => {
+			const originalRename = fs.rename.bind(fs);
+			let attempts = 0;
+			vi.spyOn(fs, "rename").mockImplementation(async (from, to) => {
+				attempts += 1;
+				if (attempts <= 2) {
+					const err = Object.assign(
+						new Error("EBUSY: file locked") as NodeJS.ErrnoException,
+						{ code: "EBUSY" },
+					);
+					throw err;
+				}
+				return originalRename(from as string, to as string);
+			});
+
+			await expect(saveAccounts(makeStorage("ebusy-token"))).resolves.toBeUndefined();
+			expect(attempts).toBe(3);
+			expect(existsSync(storagePath)).toBe(true);
+
+			// Invariant: after a successful rename the temp file MUST be gone.
+			// Orphaned .tmp files accumulate over time and signal broken cleanup.
+			const remaining = readdirSync(testDir);
+			const tmpOrphans = remaining.filter((entry) => entry.endsWith(".tmp"));
+			expect(tmpOrphans).toEqual([]);
+		});
+	});
+
+	describe("scenario 7: corrupted V3 file on load", () => {
+		it("malformed JSON does not crash loadAccounts and preserves the file on disk for recovery", async () => {
+			// The loader must tolerate garbage that could appear after a
+			// crash or a third-party text editor mangling the file. Returning
+			// null here is the degraded-but-safe path: the file stays on disk
+			// so recovery tooling (`codex-recovery`) can inspect it.
+			await fs.writeFile(storagePath, "{not-json", "utf-8");
+
+			const loaded = await loadAccounts();
+			expect(loaded).toBeNull();
+
+			// File must not have been clobbered by the failed load.
+			const preserved = await fs.readFile(storagePath, "utf-8");
+			expect(preserved).toBe("{not-json");
+		});
+
+		it("V2 account file raises typed StorageError with a recovery hint", async () => {
+			// V2 is the intermediate 4.x shape for which no forward migrator
+			// shipped. Loading it must refuse instead of silently discarding
+			// credentials (see lib/storage/migrations.ts → UNKNOWN_V2_FORMAT).
+			await fs.writeFile(
+				storagePath,
+				JSON.stringify({ version: 2, accounts: [] }),
+				"utf-8",
+			);
+
+			let caught: unknown;
+			try {
+				await loadAccounts();
+			} catch (err) {
+				caught = err;
+			}
+			expect(caught).toBeInstanceOf(StorageError);
+			const storageErr = caught as StorageError;
+			expect(storageErr.code).toBe("UNKNOWN_V2_FORMAT");
+			expect(storageErr.path).toBe(storagePath);
+			expect(storageErr.hint.toLowerCase()).toContain("schema v2");
+			expect(storageErr.hint.toLowerCase()).toContain("recover");
+		});
+
+		it("future schema (v4) raises typed StorageError with upgrade hint", async () => {
+			await fs.writeFile(
+				storagePath,
+				JSON.stringify({ version: 4, accounts: [] }),
+				"utf-8",
+			);
+
+			let caught: unknown;
+			try {
+				await loadAccounts();
+			} catch (err) {
+				caught = err;
+			}
+			expect(caught).toBeInstanceOf(StorageError);
+			const storageErr = caught as StorageError;
+			expect(storageErr.code).toBe("UNSUPPORTED_SCHEMA_VERSION");
+			expect(storageErr.message).toContain("4");
+			// Forward-compat guard must not overwrite the future-schema file.
+			const preserved = JSON.parse(await fs.readFile(storagePath, "utf-8")) as {
+				version: number;
+			};
+			expect(preserved.version).toBe(4);
+		});
+	});
+
+	describe("scenario 8: SIGTERM during 500ms debounce", () => {
+		beforeEach(() => {
+			vi.useFakeTimers({ shouldAdvanceTime: true });
+			vi.setSystemTime(new Date(1_700_000_000_000));
+		});
+
+		it("runCleanup flushes the pending debounced save before process exit", async () => {
+			// Spy on the real saveAccounts via the storage module so we can
+			// observe the flush without blocking on disk I/O through the
+			// AccountManager wrapper.
+			const storageModule = await import("../../lib/storage.js");
+			const saveSpy = vi
+				.spyOn(storageModule, "saveAccounts")
+				.mockResolvedValue(undefined);
+
+			const now = Date.now();
+			const manager = new AccountManager(undefined, {
+				version: 3,
+				activeIndex: 0,
+				accounts: [{ refreshToken: "rt-debounced", addedAt: now, lastUsed: now }],
+			});
+
+			// Schedule a save with a long debounce; without a shutdown flush
+			// the save would be silently lost when the process exits.
+			manager.saveToDiskDebounced(500);
+			await vi.advanceTimersByTimeAsync(100); // SIGTERM arrives partway through
+			expect(saveSpy).not.toHaveBeenCalled();
+
+			// runCleanup() is the public SIGTERM equivalent (signal handler
+			// funnels into this). It must drain the pending flush.
+			await runCleanup();
+
+			expect(saveSpy).toHaveBeenCalledTimes(1);
+
+			manager.disposeShutdownHandler();
+		});
+
+		it("multiple rotations inside the debounce window are coalesced into one flushed save", async () => {
+			const storageModule = await import("../../lib/storage.js");
+			const saveSpy = vi
+				.spyOn(storageModule, "saveAccounts")
+				.mockResolvedValue(undefined);
+
+			const now = Date.now();
+			const manager = new AccountManager(undefined, {
+				version: 3,
+				activeIndex: 0,
+				accounts: [{ refreshToken: "rt-coalesce", addedAt: now, lastUsed: now }],
+			});
+
+			// Three rapid debounce calls — each reschedules the 500ms timer.
+			// A correct shutdown flush must still produce exactly one save.
+			manager.saveToDiskDebounced(500);
+			await vi.advanceTimersByTimeAsync(50);
+			manager.saveToDiskDebounced(500);
+			await vi.advanceTimersByTimeAsync(50);
+			manager.saveToDiskDebounced(500);
+
+			await runCleanup();
+			expect(saveSpy).toHaveBeenCalledTimes(1);
+			manager.disposeShutdownHandler();
+		});
+
+		it("additional cleanup callbacks still run even if flush-on-shutdown fails", async () => {
+			// Defense-in-depth: if the AccountManager flush throws, the rest
+			// of the cleanup queue (log drains, server closes) must still run.
+			const storageModule = await import("../../lib/storage.js");
+			const saveSpy = vi
+				.spyOn(storageModule, "saveAccounts")
+				.mockRejectedValueOnce(new Error("simulated disk failure"));
+
+			const now = Date.now();
+			const manager = new AccountManager(undefined, {
+				version: 3,
+				activeIndex: 0,
+				accounts: [{ refreshToken: "rt-fail", addedAt: now, lastUsed: now }],
+			});
+
+			const secondary = vi.fn();
+			registerCleanup(secondary);
+			manager.saveToDiskDebounced(500);
+
+			await runCleanup();
+
+			expect(saveSpy).toHaveBeenCalledTimes(1);
+			expect(secondary).toHaveBeenCalledTimes(1);
+			manager.disposeShutdownHandler();
+		});
+	});
+});


### PR DESCRIPTION
## Summary
Phase 3 Batch E. Converts the chaos scaffolding at `test/chaos/fault-injection.test.ts` into 8 deterministic fault-injection scenarios across three new files, each arranging the fault with `vi.spyOn` / `vi.mock` / `vi.useFakeTimers` and firing a real public API to assert the typed recovery the plugin must produce.

## Scenarios
1. **Disk-full on save** → `saveAccounts` raises `StorageError(code=ENOSPC)` with the platform hint `Disk is full`; recovery on the next call succeeds and the file is written.
2. **EBUSY on atomic-rename** → the retry loop survives two EBUSY responses, completes on the third, and leaves no `*.tmp` orphan in the storage directory.
3. **401 mid-request** → `refreshAccessToken` surfaces `failed/http_error(401)`; `markAccountsWithRefreshTokenCoolingDown` puts the token on cooldown, `getNextForFamily` returns the sibling account, and `incrementAuthFailures` stays atomic under concurrent calls.
4. **Circuit breaker opens mid-flight** → the in-flight caller (already past `canAttempt`) completes as a no-op success, the next `canAttempt` returns `allowed=false, state=open, reason=open`, and `canExecute` throws `CircuitOpenError`; half-open probe serialization rejects concurrent probes with `probe-in-flight`.
5. **429 Retry-After** → `handleErrorResponse` parses both `retry-after` seconds and `retry-after-ms` with the ms header winning; the account-level marker blocks selection until the window elapses; the token-bucket backoff dedupes inside the 2s window and doubles the delay past it.
6. **Port-1455 collision on concurrent login** → only the first `startLocalOAuthServer` binds; the second resolves with `ready=false` so callers fall through to device-code paste; concurrent `createAuthorizationFlow` calls produce distinct PKCE verifiers, challenges, and states so a loser cannot replay a winner's auth code; state mismatch on the bound server returns 400.
7. **Corrupted V3 file on load** → malformed JSON returns `null` without crashing and the file is preserved for recovery tooling; intermediate V2 files raise `StorageError(code=UNKNOWN_V2_FORMAT)` with the schema-v2 recovery hint; forward-compat v4 files raise `StorageError(code=UNSUPPORTED_SCHEMA_VERSION)` without clobbering the file.
8. **SIGTERM during 500ms debounce** → `runCleanup` (the SIGTERM funnel) flushes the pending save; multiple rotations inside the window coalesce into exactly one save; sibling cleanup callbacks still run when the flush itself rejects.

## Determinism
- Every scenario replaces real I/O, time, or fetch with vitest spies before the API under test runs, and restores them in `afterEach`.
- Retry paths that use real `setTimeout` backoff (`renameWithWindowsRetry`) use `vi.useFakeTimers({ shouldAdvanceTime: true })` so the test completes within the vitest budget without a race.
- Non-flaky: the chaos suite was run 3× locally (63 tests passing each run).

## Audit refs
- `docs/audits/10-testing-gaps.md` (chaos test scope)
- `docs/audits/13-phased-roadmap.md` §3 (chaos tests with real fault injection)

## Gap flagged (no lib change in this PR per `MUST NOT`)
Audit scenario 7 calls for `StorageError(code=CORRUPT_FILE)` with a `codex-recovery` hint on malformed JSON. The loader in `lib/storage/load-save.ts` currently degrades silently (`null` return, file preserved). The chaos test pins the current behavior; closing the audit gap is a follow-up PR.

## Verification
- `npm run typecheck` — pass
- `npm run lint` — pass
- `npm test` — pass (2148 → 2168, +20 chaos tests; 71 files)
- `npm run build` — pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive chaos and fault-injection testing suite to validate system resilience across authentication, request handling, and data storage components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

adds 20 deterministic chaos tests across three files covering disk-full, ebusy-rename, 401 cooldown, circuit-breaker mid-flight, 429 retry-after, port-1455 collision, corrupted-v3 load, and sigterm-debounce-flush scenarios using vi.spyOn / vi.useFakeTimers with real public apis.

- **P1 — `storage-faults.test.ts` afterEach ordering**: `setStoragePathDirect(null)` is called *before* `runCleanup()`, so if any scenario-8 test throws before its test-body `runCleanup()`, the afterEach flush writes test tokens to the developer's global `accounts.json` via the real `saveAccounts()` (mocks already restored). swap the two lines so cleanup always flushes to the temp `testDir`.
- **P2 — port 1455 hardcoded**: `auth-faults.test.ts` asserts `firstServer.port === 1455`; if that port is bound on the CI host the test fails with an opaque assertion error rather than a clear skip.

<h3>Confidence Score: 4/5</h3>

safe to merge after fixing the afterEach ordering in storage-faults; the P1 can corrupt the global accounts file on a test failure

one P1 in test infrastructure: setStoragePathDirect(null) before runCleanup() means a mid-test failure in scenario 8 flushes test tokens to the real global accounts.json via the restored real saveAccounts(). that's a data-safety issue for the developer/CI environment, not production, but it's real. all other findings are P2 style or coverage gaps. the test logic itself (circuit-breaker math, rate-limit timing, PKCE distinctness, cooldown rotation) is correct and the suite passes 3x locally.

test/chaos/storage-faults.test.ts — afterEach ordering; test/chaos/auth-faults.test.ts — port 1455 assertion and close() on ready=false

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| test/chaos/storage-faults.test.ts | 8 storage chaos scenarios; P1 ordering bug in afterEach (setStoragePathDirect(null) before runCleanup()) can write test tokens to global accounts file on failure; missing retry-exhaustion coverage for EBUSY path |
| test/chaos/auth-faults.test.ts | 401 cooldown + PKCE isolation scenarios; port 1455 hardcoded (CI reliability risk); close() called on ready=false server without defensive guard; fetch spy uses manual save/restore instead of vi.spyOn |
| test/chaos/request-faults.test.ts | circuit-breaker and 429 rate-limit scenarios are well-structured; fake-timer usage, dedup-window arithmetic, and probe-in-flight serialization assertions all look correct |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph storage-faults
        S1[ENOSPC on writeFile] -->|StorageError ENOSPC| SE1[caller catches typed error]
        SE1 -->|second call| SR1[recovery: file written]
        S2[EBUSY on rename x2] -->|renameWithWindowsRetry| SR2[success on attempt 3, no .tmp orphan]
        S7a[malformed JSON] -->|JSON.parse throws| SN[loadAccounts null, file preserved]
        S7b[v2 schema] -->|normalizeAccountStorage| SE2[StorageError UNKNOWN_V2_FORMAT]
        S7c[v4 schema] -->|loadAccountsInternal| SE3[StorageError UNSUPPORTED_SCHEMA_VERSION]
        S8[SIGTERM during 500ms debounce] -->|runCleanup| SF[flushPendingSave to saveToDisk]
    end
    subgraph auth-faults
        A3a[401 from /oauth/token] -->|refreshAccessToken| AF[failed/http_error 401]
        AF -->|markAccountsWithRefreshTokenCoolingDown| AC[token on cooldown]
        AC -->|getNextForFamily| AN[sibling account returned]
        A3b[Promise.all incrementAuthFailures] -->|chain serialization| AI[atomic 1 then 2]
        A6a[startLocalOAuthServer x2] -->|port 1455 bound| AP[second ready=false]
        A6b[createAuthorizationFlow x3] -->|crypto random| AK[distinct verifier/challenge/state]
    end
    subgraph request-faults
        R4a[recordFailure x3] -->|threshold| RO[breaker state=open]
        RO -->|recordSuccess no-op| RO2[stays open]
        RO2 -->|canAttempt| RD[allowed=false reason=open]
        R4b[advance resetTimeoutMs] -->|canAttempt| RH[half-open probe admitted]
        RH -->|second canAttempt| RP[probe-in-flight]
        R5a[429 retry-after:2] -->|handleErrorResponse| RM[retryAfterMs=2000]
        R5b[retry-after-ms:1750 + retry-after:5] -->|ms header wins| RM2[retryAfterMs=1750]
        R5c[markRateLimitedWithReason 2s] -->|time advance| RR[unblocked at 2.5s]
    end
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Foc-codex-multi-auth%22%20on%20the%20existing%20branch%20%22test%2Fphase3-batch-e-chaos-tests%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22test%2Fphase3-batch-e-chaos-tests%22.%0A%0AFix%20the%20following%205%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%205%0Atest%2Fchaos%2Fstorage-faults.test.ts%3A103-110%0A**%60setStoragePathDirect%28null%29%60%20called%20before%20%60runCleanup%28%29%60%20%E2%80%94%20test%20data%20can%20reach%20global%20accounts%20file**%0A%0A%60setStoragePathDirect%28null%29%60%20runs%20at%20step%203%2C%20so%20%60getStoragePath%28%29%60%20falls%20back%20to%20the%20global%20config%20path%20before%20%60runCleanup%28%29%60%20fires%20at%20step%204.%20if%20any%20scenario-8%20test%20throws%20before%20it%20reaches%20its%20own%20%60await%20runCleanup%28%29%60%2C%20the%20manager's%20registered%20shutdown%20handler%20is%20still%20in%20the%20cleanup%20queue.%20the%20afterEach%20%60runCleanup%28%29%60%20then%20calls%20%60flushPendingSave%28%29%60%20%E2%86%92%20%60saveToDisk%28%29%60%20%E2%86%92%20the%20real%20%60saveAccounts%28%29%60%20%28mocks%20already%20restored%20at%20step%201%29%20%E2%80%94%20and%20writes%20test%20tokens%20%28%60rt-debounced%60%2C%20%60rt-coalesce%60%2C%20%60rt-fail%60%29%20to%20the%20developer's%20global%20accounts%20file.%20on%20windows%20that%20overwrites%20live%20credentials%20in%20%60~%2F.opencode%2Faccounts.json%60.%0A%0Athe%20fix%20is%20to%20move%20%60setStoragePathDirect%28null%29%60%20after%20%60runCleanup%28%29%60%20so%20that%20any%20cleanup%20flush%20writes%20to%20the%20temp%20%60testDir%60%20%28which%20is%20deleted%20immediately%20after%29%3A%0A%0A%60%60%60suggestion%0A%09%09vi.restoreAllMocks%28%29%3B%0A%09%09vi.useRealTimers%28%29%3B%0A%09%09await%20runCleanup%28%29%3B%0A%09%09setStoragePathDirect%28null%29%3B%0A%09%09await%20fs.rm%28testDir%2C%20%7B%20recursive%3A%20true%2C%20force%3A%20true%20%7D%29.catch%28%28%29%20%3D%3E%20%7B%0A%09%09%09%2F*%20best-effort%20cleanup%20*%2F%0A%09%09%7D%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%205%0Atest%2Fchaos%2Fauth-faults.test.ts%3A137-149%0A**hardcoded%20port%201455%20is%20a%20CI%20reliability%20risk**%0A%0Athe%20test%20asserts%20%60expect%28firstServer.port%29.toBe%281455%29%60%20and%20expects%20%60ready%3Dtrue%60.%20if%20port%201455%20is%20already%20bound%20on%20the%20CI%20host%20%28common%20on%20linux%20%E2%80%94%20it's%20in%20the%20ephemeral%20range%20of%20some%20distros%2C%20or%20held%20by%20another%20test%20runner%20or%20service%29%2C%20%60firstServer.ready%60%20will%20be%20%60false%60%20and%20the%20test%20fails%20with%20an%20opaque%20assertion%20error%20rather%20than%20a%20clear%20%22port%20in%20use%22%20message.%20the%20test%20also%20starts%20both%20servers%20sequentially%20rather%20than%20concurrently%2C%20which%20differs%20from%20the%20pr%20description's%20%22concurrent%22%20framing%20%E2%80%94%20worth%20noting%20for%20any%20future%20reader%20reasoning%20about%20the%20scenario.%0A%0A%23%23%23%20Issue%203%20of%205%0Atest%2Fchaos%2Fauth-faults.test.ts%3A121-133%0A**%60secondServer.close%28%29%60%20called%20when%20%60ready%3Dfalse%60%20%E2%80%94%20safety%20depends%20on%20server%20impl**%0A%0Athe%20inner%20%60afterEach%60%20calls%20%60secondServer.close%28%29%60%20unconditionally%20regardless%20of%20%60ready%60.%20if%20%60startLocalOAuthServer%60%20returns%20a%20stub%20%60close%60%20that%20is%20a%20no-op%20when%20the%20server%20never%20bound%2C%20this%20is%20fine.%20but%20if%20the%20stub%20throws%20or%20the%20return%20type%20omits%20%60close%60%20for%20the%20%60ready%3Dfalse%60%20path%2C%20every%20collision-scenario%20teardown%20silently%20eats%20the%20error%20%28the%20outer%20%60afterEach%60%20has%20no%20try%2Fcatch%29.%20worth%20adding%20a%20guard%20or%20at%20least%20verifying%20%60startLocalOAuthServer%60's%20contract%20for%20the%20failure%20path.%0A%0A%60%60%60suggestion%0A%09%09%09if%20%28firstServer%29%20%7B%0A%09%09%09%09if%20%28firstServer.ready%29%20firstServer.close%28%29%3B%0A%09%09%09%09firstServer%20%3D%20null%3B%0A%09%09%09%7D%0A%09%09%09if%20%28secondServer%29%20%7B%0A%09%09%09%09if%20%28secondServer.ready%29%20secondServer.close%28%29%3B%0A%09%09%09%09secondServer%20%3D%20null%3B%0A%09%09%09%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%204%20of%205%0Atest%2Fchaos%2Fauth-faults.test.ts%3A51-67%0A**manual%20%60fetch%60%20save%2Frestore%20%E2%80%94%20prefer%20%60vi.spyOn%60**%0A%0Athe%20manual%20save%2Frestore%20of%20%60globalThis.fetch%60%20with%20a%20%60try%2Ffinally%60%20works%20but%20leaks%20the%20original%20reference%20into%20the%20test%20scope%20and%20is%20a%20pattern%20inconsistent%20with%20the%20rest%20of%20this%20chaos%20suite.%20using%20%60vi.spyOn%28globalThis%2C%20%22fetch%22%29%60%20and%20relying%20on%20the%20outer%20%60afterEach%60's%20%60vi.restoreAllMocks%28%29%60%20achieves%20the%20same%20result%20with%20less%20boilerplate%20and%20ensures%20restoration%20even%20if%20the%20%60finally%60%20block%20is%20somehow%20skipped%20by%20an%20async%20timeout.%0A%0A%60%60%60suggestion%0A%09%09%09const%20fetchSpy%20%3D%20vi.spyOn%28globalThis%2C%20%22fetch%22%29.mockResolvedValueOnce%28%0A%09%09%09%09new%20Response%28JSON.stringify%28%7B%20error%3A%20%22invalid_grant%22%20%7D%29%2C%20%7B%20status%3A%20401%20%7D%29%2C%0A%09%09%09%29%3B%0A%0A%09%09%09const%20result%20%3D%20await%20refreshAccessToken%28%22rt-alpha%22%29%3B%0A%09%09%09expect%28result.type%29.toBe%28%22failed%22%29%3B%0A%09%09%09if%20%28result.type%20%3D%3D%3D%20%22failed%22%29%20%7B%0A%09%09%09%09expect%28result.reason%29.toBe%28%22http_error%22%29%3B%0A%09%09%09%09expect%28result.statusCode%29.toBe%28401%29%3B%0A%09%09%09%7D%0A%09%09%09expect%28fetchSpy%29.toHaveBeenCalledTimes%281%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%205%20of%205%0Atest%2Fchaos%2Fstorage-faults.test.ts%3A165-194%0A**ebusy%20test%20doesn't%20cover%20retry-budget%20exhaustion%20%E2%80%94%20windows%20lock%20scenario%20is%20half-covered**%0A%0Athe%20test%20only%20verifies%20the%20happy%20path%20%282%20ebusy%20%E2%86%92%20success%20on%20attempt%203%29.%20%60renameWithWindowsRetry%60%20has%20a%20budget%20of%20%60WINDOWS_RENAME_RETRY_ATTEMPTS%20%3D%205%60%3B%20the%20path%20where%20all%205%20retries%20are%20exhausted%20and%20the%20function%20re-throws%20the%20last%20error%20is%20untested.%20for%20windows%20antivirus%20scenarios%20the%20exhaustion%20path%20is%20the%20one%20that%20surfaces%20as%20a%20%60StorageError%28code%3DEBUSY%29%60%20with%20the%20%22file%20is%20locked%22%20hint%20%E2%80%94%20that%20hint%20text%20and%20the%20typed%20error%20shape%20should%20have%20a%20companion%20test%20here%20alongside%20the%20recovery%20path.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: test/chaos/storage-faults.test.ts
Line: 103-110

Comment:
**`setStoragePathDirect(null)` called before `runCleanup()` — test data can reach global accounts file**

`setStoragePathDirect(null)` runs at step 3, so `getStoragePath()` falls back to the global config path before `runCleanup()` fires at step 4. if any scenario-8 test throws before it reaches its own `await runCleanup()`, the manager's registered shutdown handler is still in the cleanup queue. the afterEach `runCleanup()` then calls `flushPendingSave()` → `saveToDisk()` → the real `saveAccounts()` (mocks already restored at step 1) — and writes test tokens (`rt-debounced`, `rt-coalesce`, `rt-fail`) to the developer's global accounts file. on windows that overwrites live credentials in `~/.opencode/accounts.json`.

the fix is to move `setStoragePathDirect(null)` after `runCleanup()` so that any cleanup flush writes to the temp `testDir` (which is deleted immediately after):

```suggestion
		vi.restoreAllMocks();
		vi.useRealTimers();
		await runCleanup();
		setStoragePathDirect(null);
		await fs.rm(testDir, { recursive: true, force: true }).catch(() => {
			/* best-effort cleanup */
		});
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: test/chaos/auth-faults.test.ts
Line: 137-149

Comment:
**hardcoded port 1455 is a CI reliability risk**

the test asserts `expect(firstServer.port).toBe(1455)` and expects `ready=true`. if port 1455 is already bound on the CI host (common on linux — it's in the ephemeral range of some distros, or held by another test runner or service), `firstServer.ready` will be `false` and the test fails with an opaque assertion error rather than a clear "port in use" message. the test also starts both servers sequentially rather than concurrently, which differs from the pr description's "concurrent" framing — worth noting for any future reader reasoning about the scenario.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: test/chaos/auth-faults.test.ts
Line: 121-133

Comment:
**`secondServer.close()` called when `ready=false` — safety depends on server impl**

the inner `afterEach` calls `secondServer.close()` unconditionally regardless of `ready`. if `startLocalOAuthServer` returns a stub `close` that is a no-op when the server never bound, this is fine. but if the stub throws or the return type omits `close` for the `ready=false` path, every collision-scenario teardown silently eats the error (the outer `afterEach` has no try/catch). worth adding a guard or at least verifying `startLocalOAuthServer`'s contract for the failure path.

```suggestion
			if (firstServer) {
				if (firstServer.ready) firstServer.close();
				firstServer = null;
			}
			if (secondServer) {
				if (secondServer.ready) secondServer.close();
				secondServer = null;
			}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: test/chaos/auth-faults.test.ts
Line: 51-67

Comment:
**manual `fetch` save/restore — prefer `vi.spyOn`**

the manual save/restore of `globalThis.fetch` with a `try/finally` works but leaks the original reference into the test scope and is a pattern inconsistent with the rest of this chaos suite. using `vi.spyOn(globalThis, "fetch")` and relying on the outer `afterEach`'s `vi.restoreAllMocks()` achieves the same result with less boilerplate and ensures restoration even if the `finally` block is somehow skipped by an async timeout.

```suggestion
			const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
				new Response(JSON.stringify({ error: "invalid_grant" }), { status: 401 }),
			);

			const result = await refreshAccessToken("rt-alpha");
			expect(result.type).toBe("failed");
			if (result.type === "failed") {
				expect(result.reason).toBe("http_error");
				expect(result.statusCode).toBe(401);
			}
			expect(fetchSpy).toHaveBeenCalledTimes(1);
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: test/chaos/storage-faults.test.ts
Line: 165-194

Comment:
**ebusy test doesn't cover retry-budget exhaustion — windows lock scenario is half-covered**

the test only verifies the happy path (2 ebusy → success on attempt 3). `renameWithWindowsRetry` has a budget of `WINDOWS_RENAME_RETRY_ATTEMPTS = 5`; the path where all 5 retries are exhausted and the function re-throws the last error is untested. for windows antivirus scenarios the exhaustion path is the one that surfaces as a `StorageError(code=EBUSY)` with the "file is locked" hint — that hint text and the typed error shape should have a companion test here alongside the recovery path.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test(batch-e): real fault-injection chao..."](https://github.com/ndycode/oc-codex-multi-auth/commit/9b79eb8b707c004d51408db3822c295eb272e6cd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28754822)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->