### PR TITLE
feat: Phase 4 F2 - multi-worktree collision detection

### DIFF
--- a/lib/storage/load-save.ts
+++ b/lib/storage/load-save.ts
@@ -37,8 +37,61 @@ import {
   UNKNOWN_V2_FORMAT_CODE,
   type AccountStorageV3,
 } from "./migrations.js";
+import { acquireOrDetectLock } from "./worktree-lock.js";
+import os from "node:os";
 
 const log = createLogger("storage");
+
+/**
+ * Probes the worktree lock for the currently active storage path and surfaces
+ * any foreign live lock as a non-fatal warning. The lock check is advisory:
+ * Phase 4 F2 deliberately chose warn-over-block so a user with two legitimate
+ * OpenCode sessions on the same project (separate worktrees, IDE + CLI) is
+ * never stranded. The warning still carries enough detail (pid, host, cwd)
+ * for the user to reconcile state manually if a rotation was lost to a race.
+ *
+ * Failure modes:
+ *   - Storage path is not resolvable (no project, no global dir set): skip
+ *     silently, the actual storage call will surface the real error.
+ *   - Lock file unreadable (disk full, EACCES): log at debug so it cannot
+ *     drown the normal "collision detected" warning, then continue. A broken
+ *     sidecar must never gate auth-critical reads/writes.
+ */
+async function checkWorktreeLockForCurrentStorage(
+  operation: "load" | "save",
+): Promise<void> {
+  let path: string;
+  try {
+    path = getStoragePath();
+  } catch (error) {
+    log.debug("Skipping worktree lock check: storage path unavailable", {
+      error: String(error),
+    });
+    return;
+  }
+  try {
+    const result = await acquireOrDetectLock(path);
+    if (!result.acquired && result.foreign) {
+      log.warn("Multi-worktree collision detected on account storage", {
+        operation,
+        storagePath: path,
+        foreignPid: result.foreign.pid,
+        foreignHost: result.foreign.hostname,
+        foreignCwd: result.foreign.cwd,
+        foreignLastActive: result.foreign.lastActive,
+        ourPid: process.pid,
+        ourHost: os.hostname(),
+        ourCwd: process.cwd(),
+      });
+    }
+  } catch (error) {
+    log.debug("Worktree lock probe failed", {
+      operation,
+      storagePath: path,
+      error: String(error),
+    });
+  }
+}
 
 async function ensureGitignore(storagePath: string): Promise<void> {
   if (!getCurrentStoragePath()) return;
@@ -228,6 +281,10 @@ async function loadGlobalAccountsFallback(): Promise<AccountStorageV3 | null> {
 async function loadAccountsInternal(
   persistMigration: ((storage: AccountStorageV3) => Promise<void>) | null,
 ): Promise<AccountStorageV3 | null> {
+  // Advisory: surface multi-worktree collisions before the read but never
+  // block. Must come before the try/catch so a genuine storage error still
+  // takes precedence over any lock-related log output below.
+  await checkWorktreeLockForCurrentStorage("load");
   try {
     const path = getStoragePath();
     const content = await fs.readFile(path, "utf-8");
@@ -397,6 +454,10 @@ async function writeAccountsToPathUnlocked(path: string, storage: AccountStorage
 }
 
 async function saveAccountsUnlocked(storage: AccountStorageV3): Promise<void> {
+  // Refresh our lock (or surface a collision) on every write. This also
+  // bumps `lastActive`, which is the stale-detection timestamp read by
+  // other worktrees on their next acquire.
+  await checkWorktreeLockForCurrentStorage("save");
   await writeAccountsToPathUnlocked(getStoragePath(), storage);
 }
 

--- a/lib/storage/worktree-lock.ts
+++ b/lib/storage/worktree-lock.ts
@@ -1,0 +1,305 @@
+/**
+ * Multi-worktree collision detection for per-project account storage.
+ *
+ * Problem: when multiple OpenCode sessions (tabs, IDE windows, detached
+ * worktrees, or CI runs) point at the same per-project accounts file, their
+ * writes can interleave and lose rotation updates, health-score changes, or
+ * rate-limit state. The in-process `withStorageLock` mutex solves intra-process
+ * races but cannot see another Node process mutating the same file.
+ *
+ * Strategy: sidecar lock file at `<storage>.lock`. Every `loadAccounts` /
+ * `saveAccounts` call verifies ownership:
+ *
+ *   - No lock on disk -> write our own, proceed.
+ *   - Lock owned by us (same pid + hostname) -> refresh `lastActive`, proceed.
+ *   - Foreign lock with dead owner (same host, pid gone) -> take over.
+ *   - Foreign lock stale (`lastActive` older than STALE_THRESHOLD_MS) -> take
+ *     over. Required because a prior process that SIGKILL'd never released
+ *     its lock, so "dead pid" detection alone leaks locks on long-lived hosts.
+ *   - Foreign lock live -> surface a WARNING to the logger identifying both
+ *     worktrees and proceed anyway. The locking contract here is advisory
+ *     (Phase 4 F2 audit recommendation): blocking would strand the user when
+ *     two legitimate sessions share a project, so we prefer visibility over
+ *     enforcement.
+ *
+ * Cross-host note: we cannot probe a PID on a different machine, so a lock
+ * written from another hostname is always treated as live until its
+ * `lastActive` timestamp ages past STALE_THRESHOLD_MS. This is conservative
+ * but matches the audit requirement to "not block" — the worst case is a
+ * warning the user can dismiss.
+ *
+ * See `docs/audits/08-feature-recommendations.md` and
+ * `docs/audits/13-phased-roadmap.md#phase-4-f2` for background.
+ */
+
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import { createLogger } from "../logger.js";
+import { registerCleanup } from "../shutdown.js";
+
+const log = createLogger("storage.worktree-lock");
+
+/**
+ * Time after which a lock whose owner never refreshed it is considered
+ * abandoned, regardless of PID liveness. One hour matches the roadmap spec
+ * and is long enough to avoid stealing a lock from a session that is merely
+ * idle between saves.
+ */
+export const STALE_THRESHOLD_MS = 60 * 60 * 1000;
+
+/**
+ * Persisted lock-file payload. Written as pretty-printed JSON so a human
+ * inspecting the file can immediately tell which worktree holds the lock.
+ */
+export interface WorktreeLockInfo {
+	pid: number;
+	hostname: string;
+	cwd: string;
+	startedAt: string; // ISO-8601
+	lastActive: string; // ISO-8601, refreshed on every acquire
+}
+
+export interface AcquireLockResult {
+	/** True when we now own the lock on disk. */
+	acquired: boolean;
+	/** Populated only when a foreign live lock was detected. */
+	foreign?: WorktreeLockInfo;
+}
+
+/**
+ * Tracks lock-file paths this process has written so a single shutdown
+ * cleanup can release all of them. Keyed by lock path, not storage path,
+ * to avoid double-registering cleanup if the same path is acquired twice.
+ */
+const ownedLockPaths = new Set<string>();
+let shutdownCleanupRegistered = false;
+
+function lockPath(storagePath: string): string {
+	return `${storagePath}.lock`;
+}
+
+/**
+ * Probes whether a PID is still running. Returns `true` conservatively for
+ * cross-host locks: we cannot signal a remote PID, so the safe default is
+ * "assume alive" and let the stale-timestamp branch reclaim it instead.
+ *
+ * Intentionally synchronous: `process.kill` is non-blocking and making this
+ * async buys nothing while incurring a useless microtask per lock check.
+ */
+function processAlive(pid: number, hostname: string): boolean {
+	if (hostname !== os.hostname()) {
+		return true;
+	}
+	// Guard against invalid PIDs that would make `process.kill` throw
+	// EINVAL (treated as "alive" by the catch below) and leak the lock.
+	if (!Number.isInteger(pid) || pid <= 0) {
+		return false;
+	}
+	try {
+		// Signal 0 performs the permission + existence check without
+		// actually delivering a signal. ESRCH means "no such process".
+		process.kill(pid, 0);
+		return true;
+	} catch (err) {
+		const code = (err as NodeJS.ErrnoException).code;
+		// EPERM means the process exists but we cannot signal it (different
+		// user). Treat as alive to avoid stealing a lock we can't verify.
+		if (code === "EPERM") return true;
+		return false;
+	}
+}
+
+function buildOwnLockInfo(existingStartedAt?: string): WorktreeLockInfo {
+	const now = new Date().toISOString();
+	return {
+		pid: process.pid,
+		hostname: os.hostname(),
+		cwd: process.cwd(),
+		startedAt: existingStartedAt ?? now,
+		lastActive: now,
+	};
+}
+
+async function writeOurLock(
+	lockFile: string,
+	existingStartedAt?: string,
+): Promise<void> {
+	const info = buildOwnLockInfo(existingStartedAt);
+	// mode 0o600: lock discloses pid/cwd, so restrict to owner like the
+	// storage file itself.
+	await fs.writeFile(lockFile, JSON.stringify(info, null, 2), {
+		encoding: "utf-8",
+		mode: 0o600,
+	});
+	ownedLockPaths.add(lockFile);
+	ensureShutdownReleaseRegistered();
+}
+
+/**
+ * Best-effort shutdown hook that removes every lock we still own. Failures
+ * are swallowed so one bad unlink cannot stall process exit.
+ */
+function ensureShutdownReleaseRegistered(): void {
+	if (shutdownCleanupRegistered) return;
+	shutdownCleanupRegistered = true;
+	registerCleanup(async () => {
+		const paths = Array.from(ownedLockPaths);
+		ownedLockPaths.clear();
+		await Promise.all(
+			paths.map(async (lp) => {
+				try {
+					await releaseLockFile(lp);
+				} catch {
+					// Swallow: shutdown path must not throw.
+				}
+			}),
+		);
+	});
+}
+
+function isOwnLock(info: WorktreeLockInfo): boolean {
+	return info.pid === process.pid && info.hostname === os.hostname();
+}
+
+/**
+ * Parse a lock file. Returns `null` if the file is missing, unreadable, or
+ * structurally invalid. Callers treat `null` the same as "no lock" so a
+ * corrupt sidecar never wedges storage access.
+ */
+async function readLock(lockFile: string): Promise<WorktreeLockInfo | null> {
+	let raw: string;
+	try {
+		raw = await fs.readFile(lockFile, "utf-8");
+	} catch (err) {
+		if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+			return null;
+		}
+		throw err;
+	}
+	try {
+		const parsed = JSON.parse(raw) as unknown;
+		if (!parsed || typeof parsed !== "object") return null;
+		const obj = parsed as Partial<WorktreeLockInfo>;
+		if (
+			typeof obj.pid !== "number" ||
+			typeof obj.hostname !== "string" ||
+			typeof obj.cwd !== "string" ||
+			typeof obj.startedAt !== "string" ||
+			typeof obj.lastActive !== "string"
+		) {
+			return null;
+		}
+		return obj as WorktreeLockInfo;
+	} catch {
+		// Corrupt JSON: treat as absent rather than crashing the storage
+		// pipeline. `writeOurLock` will overwrite it on the next acquire.
+		return null;
+	}
+}
+
+/**
+ * Checks ownership of the worktree lock and acquires it when possible.
+ *
+ * Contract:
+ *   - Never throws on lock I/O errors *other than* propagating read/write
+ *     failures the caller needs to know about (disk full, EACCES).
+ *   - Always returns a discriminated result: either `acquired: true` (we
+ *     now own or refreshed the lock) or `acquired: false` with `foreign`
+ *     populated (another live worktree owns it; caller should warn).
+ *   - Never blocks. This is advisory locking by design.
+ */
+export async function acquireOrDetectLock(
+	storagePath: string,
+): Promise<AcquireLockResult> {
+	const lockFile = lockPath(storagePath);
+	const existing = await readLock(lockFile);
+
+	if (!existing) {
+		await writeOurLock(lockFile);
+		return { acquired: true };
+	}
+
+	// Own lock: refresh timestamp so stale-detection on a long-running
+	// process never accidentally reclaims its own lock from itself.
+	if (isOwnLock(existing)) {
+		await writeOurLock(lockFile, existing.startedAt);
+		return { acquired: true };
+	}
+
+	// Stale timestamp takes priority over liveness probe: on the same host
+	// a fresh-looking PID that was reused by the OS would otherwise mask a
+	// dead session that never released its lock. Timestamp age is the
+	// authoritative abandonment signal.
+	const lastActiveMs = Date.parse(existing.lastActive);
+	if (
+		Number.isFinite(lastActiveMs) &&
+		Date.now() - lastActiveMs > STALE_THRESHOLD_MS
+	) {
+		log.info("Replacing stale worktree lock", {
+			staleCwd: existing.cwd,
+			stalePid: existing.pid,
+			staleHost: existing.hostname,
+			ageMs: Date.now() - lastActiveMs,
+		});
+		await writeOurLock(lockFile);
+		return { acquired: true };
+	}
+
+	// Non-stale foreign lock. If the owner pid is gone (same host), the
+	// previous process crashed without cleanup and we can take over.
+	const alive = processAlive(existing.pid, existing.hostname);
+	if (!alive) {
+		log.info("Replacing lock from dead worktree", {
+			deadCwd: existing.cwd,
+			deadPid: existing.pid,
+			deadHost: existing.hostname,
+		});
+		await writeOurLock(lockFile);
+		return { acquired: true };
+	}
+
+	// Foreign live lock. Advisory protocol: surface but do not block.
+	return { acquired: false, foreign: existing };
+}
+
+/**
+ * Release a lock file, but only if we currently own it. This guards against
+ * a late shutdown hook racing a newer process that re-acquired the lock.
+ */
+async function releaseLockFile(lockFile: string): Promise<void> {
+	ownedLockPaths.delete(lockFile);
+	const existing = await readLock(lockFile);
+	if (!existing) return;
+	if (!isOwnLock(existing)) return;
+	try {
+		await fs.unlink(lockFile);
+	} catch (err) {
+		if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+			// Degrade to warn; a leftover lock file is recoverable via the
+			// stale-timestamp branch on the next acquire.
+			log.warn("Failed to release worktree lock", {
+				lockFile,
+				error: String(err),
+			});
+		}
+	}
+}
+
+export async function releaseLock(storagePath: string): Promise<void> {
+	await releaseLockFile(lockPath(storagePath));
+}
+
+/**
+ * Test-only reset hook. Vitest reuses a single Node process across files,
+ * so `ownedLockPaths` state would leak between suites and confuse the
+ * "no lock on disk" acquire branch. Not re-exported from the barrel.
+ */
+export function __resetWorktreeLockForTests(): void {
+	ownedLockPaths.clear();
+	shutdownCleanupRegistered = false;
+}
+
+/** Test-only: inspect owned paths without exposing the internal Set. */
+export function __getOwnedLockPathsForTests(): readonly string[] {
+	return Array.from(ownedLockPaths);
+}

--- a/test/chaos/storage-faults.test.ts
+++ b/test/chaos/storage-faults.test.ts
@@ -77,14 +77,31 @@ describe("chaos/storage-faults — real fault injection", () => {
 
 	describe("scenario 1: ENOSPC on save", () => {
 		it("saveAccounts throws StorageError with ENOSPC hint, then recovers on next attempt", async () => {
-			// Inject ENOSPC on the first writeFile; let the second one proceed
-			// so we can assert clean recovery on the next save.
+			// Inject ENOSPC on the first accounts-file write; let the second
+			// one proceed so we can assert clean recovery on the next save.
+			// Phase 4 F2 added a worktree lock sidecar write on every save;
+			// it piggybacks on the same fs.writeFile surface, so we filter
+			// the fault injection by target path to keep the chaos scenario
+			// focused on the actual storage write rather than the lock.
 			const originalWriteFile = fs.writeFile.bind(fs);
-			let call = 0;
+			const isAccountsWrite = (target: unknown): boolean => {
+				const p = typeof target === "string" ? target : String(target);
+				// Lock file writes always land on `<storage>.lock`; the
+				// accounts write targets the atomic tmp file alongside it.
+				return !p.endsWith(".lock");
+			};
+			let accountsWriteCalls = 0;
 			const spy = vi.spyOn(fs, "writeFile").mockImplementation(
 				async (path, data, options) => {
-					call += 1;
-					if (call === 1) {
+					if (!isAccountsWrite(path)) {
+						return originalWriteFile(
+							path as Parameters<typeof originalWriteFile>[0],
+							data as Parameters<typeof originalWriteFile>[1],
+							options as Parameters<typeof originalWriteFile>[2],
+						);
+					}
+					accountsWriteCalls += 1;
+					if (accountsWriteCalls === 1) {
 						const err = Object.assign(
 							new Error("ENOSPC: no space left on device") as NodeJS.ErrnoException,
 							{ code: "ENOSPC" },
@@ -121,7 +138,11 @@ describe("chaos/storage-faults — real fault injection", () => {
 				accounts: Array<{ refreshToken: string }>;
 			};
 			expect(persisted.accounts[0]?.refreshToken).toBe("token-2");
-			expect(spy).toHaveBeenCalledTimes(2);
+			// Exactly two accounts-file writes: the ENOSPC failure and the
+			// successful recovery. Lock-file writes are counted separately
+			// and not asserted here.
+			expect(accountsWriteCalls).toBe(2);
+			expect(spy).toHaveBeenCalled();
 		});
 	});
 

--- a/test/storage-worktree-lock.test.ts
+++ b/test/storage-worktree-lock.test.ts
@@ -1,0 +1,265 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { promises as fs, existsSync } from "node:fs";
+import os from "node:os";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+	acquireOrDetectLock,
+	releaseLock,
+	STALE_THRESHOLD_MS,
+	__getOwnedLockPathsForTests,
+	__resetWorktreeLockForTests,
+	type WorktreeLockInfo,
+} from "../lib/storage/worktree-lock.js";
+
+/**
+ * Allocates a unique storage-file path under tmpdir(). The file itself is
+ * never created; the lock sidecar is what matters. Using tmpdir guarantees
+ * we stay inside the paths allow-list enforced elsewhere.
+ */
+async function allocateStoragePath(): Promise<string> {
+	const dir = join(
+		tmpdir(),
+		`worktree-lock-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+	);
+	await fs.mkdir(dir, { recursive: true });
+	return join(dir, "accounts.json");
+}
+
+function lockPathFor(storagePath: string): string {
+	return `${storagePath}.lock`;
+}
+
+/**
+ * Picks a PID that is guaranteed not to be running on this host. Node
+ * PIDs are 32-bit on Windows and positive 32-bit on POSIX, so a value near
+ * the top of the range has effectively zero chance of being live.
+ */
+const DEAD_PID = 2_000_000_000;
+
+async function writeForeignLock(
+	storagePath: string,
+	overrides: Partial<WorktreeLockInfo> = {},
+): Promise<WorktreeLockInfo> {
+	const now = new Date().toISOString();
+	const info: WorktreeLockInfo = {
+		pid: DEAD_PID,
+		hostname: os.hostname(),
+		cwd: "/tmp/other-worktree",
+		startedAt: now,
+		lastActive: now,
+		...overrides,
+	};
+	await fs.writeFile(lockPathFor(storagePath), JSON.stringify(info, null, 2), {
+		encoding: "utf-8",
+		mode: 0o600,
+	});
+	return info;
+}
+
+describe("worktree-lock: acquireOrDetectLock", () => {
+	let storagePath: string;
+
+	beforeEach(async () => {
+		__resetWorktreeLockForTests();
+		storagePath = await allocateStoragePath();
+	});
+
+	afterEach(async () => {
+		__resetWorktreeLockForTests();
+		try {
+			await fs.rm(
+				join(storagePath, ".."),
+				{ recursive: true, force: true },
+			);
+		} catch {
+			// Ignore cleanup failure.
+		}
+	});
+
+	it("acquires cleanly when no lock file exists", async () => {
+		const result = await acquireOrDetectLock(storagePath);
+
+		expect(result.acquired).toBe(true);
+		expect(result.foreign).toBeUndefined();
+		expect(existsSync(lockPathFor(storagePath))).toBe(true);
+
+		const onDisk = JSON.parse(
+			await fs.readFile(lockPathFor(storagePath), "utf-8"),
+		) as WorktreeLockInfo;
+		expect(onDisk.pid).toBe(process.pid);
+		expect(onDisk.hostname).toBe(os.hostname());
+		expect(onDisk.cwd).toBe(process.cwd());
+	});
+
+	it("reports a foreign live lock without acquiring", async () => {
+		// Use our own PID as the foreign owner but a different "hostname" so
+		// the cross-host branch treats it as live. This avoids racing on an
+		// actual second process while still exercising the "acquired=false,
+		// foreign populated" contract.
+		const foreign = await writeForeignLock(storagePath, {
+			pid: process.pid + 1,
+			hostname: `remote-${os.hostname()}`,
+			cwd: "/tmp/other",
+		});
+
+		const result = await acquireOrDetectLock(storagePath);
+
+		expect(result.acquired).toBe(false);
+		expect(result.foreign).toBeDefined();
+		expect(result.foreign?.pid).toBe(foreign.pid);
+		expect(result.foreign?.hostname).toBe(foreign.hostname);
+		expect(result.foreign?.cwd).toBe(foreign.cwd);
+
+		// Foreign lock must remain untouched on disk.
+		const stillOnDisk = JSON.parse(
+			await fs.readFile(lockPathFor(storagePath), "utf-8"),
+		) as WorktreeLockInfo;
+		expect(stillOnDisk.pid).toBe(foreign.pid);
+		expect(stillOnDisk.hostname).toBe(foreign.hostname);
+	});
+
+	it("takes over a stale lock older than the threshold", async () => {
+		const staleIso = new Date(
+			Date.now() - (STALE_THRESHOLD_MS + 60_000),
+		).toISOString();
+		// Live PID on a remote host: normally we'd treat this as live, so
+		// the only reason we reclaim is the aged `lastActive`.
+		await writeForeignLock(storagePath, {
+			pid: process.pid,
+			hostname: `remote-${os.hostname()}`,
+			lastActive: staleIso,
+			startedAt: staleIso,
+		});
+
+		const result = await acquireOrDetectLock(storagePath);
+
+		expect(result.acquired).toBe(true);
+		expect(result.foreign).toBeUndefined();
+
+		const takenOver = JSON.parse(
+			await fs.readFile(lockPathFor(storagePath), "utf-8"),
+		) as WorktreeLockInfo;
+		expect(takenOver.pid).toBe(process.pid);
+		expect(takenOver.hostname).toBe(os.hostname());
+		// lastActive refreshed to "now", not the stale value.
+		expect(Date.parse(takenOver.lastActive)).toBeGreaterThan(
+			Date.parse(staleIso),
+		);
+	});
+
+	it("takes over a lock whose owning PID is dead on this host", async () => {
+		await writeForeignLock(storagePath, {
+			pid: DEAD_PID,
+			hostname: os.hostname(),
+		});
+
+		const result = await acquireOrDetectLock(storagePath);
+
+		expect(result.acquired).toBe(true);
+		expect(result.foreign).toBeUndefined();
+
+		const info = JSON.parse(
+			await fs.readFile(lockPathFor(storagePath), "utf-8"),
+		) as WorktreeLockInfo;
+		expect(info.pid).toBe(process.pid);
+	});
+
+	it("refreshes our own lock without flagging a collision", async () => {
+		const first = await acquireOrDetectLock(storagePath);
+		expect(first.acquired).toBe(true);
+
+		const firstInfo = JSON.parse(
+			await fs.readFile(lockPathFor(storagePath), "utf-8"),
+		) as WorktreeLockInfo;
+
+		// Small delay so the refreshed lastActive is strictly later.
+		await new Promise((resolve) => setTimeout(resolve, 10));
+
+		const second = await acquireOrDetectLock(storagePath);
+		expect(second.acquired).toBe(true);
+		expect(second.foreign).toBeUndefined();
+
+		const secondInfo = JSON.parse(
+			await fs.readFile(lockPathFor(storagePath), "utf-8"),
+		) as WorktreeLockInfo;
+		expect(secondInfo.pid).toBe(process.pid);
+		expect(secondInfo.startedAt).toBe(firstInfo.startedAt);
+		expect(Date.parse(secondInfo.lastActive)).toBeGreaterThanOrEqual(
+			Date.parse(firstInfo.lastActive),
+		);
+	});
+
+	it("overwrites a corrupt lock file instead of crashing", async () => {
+		await fs.writeFile(lockPathFor(storagePath), "{ not valid json", {
+			encoding: "utf-8",
+			mode: 0o600,
+		});
+
+		const result = await acquireOrDetectLock(storagePath);
+
+		expect(result.acquired).toBe(true);
+		const info = JSON.parse(
+			await fs.readFile(lockPathFor(storagePath), "utf-8"),
+		) as WorktreeLockInfo;
+		expect(info.pid).toBe(process.pid);
+	});
+
+	it("registers the acquired lock for shutdown release", async () => {
+		await acquireOrDetectLock(storagePath);
+		expect(__getOwnedLockPathsForTests()).toContain(lockPathFor(storagePath));
+	});
+});
+
+describe("worktree-lock: releaseLock", () => {
+	let storagePath: string;
+
+	beforeEach(async () => {
+		__resetWorktreeLockForTests();
+		storagePath = await allocateStoragePath();
+	});
+
+	afterEach(async () => {
+		__resetWorktreeLockForTests();
+		try {
+			await fs.rm(
+				join(storagePath, ".."),
+				{ recursive: true, force: true },
+			);
+		} catch {
+			// Ignore cleanup failure.
+		}
+	});
+
+	it("removes the lock file when we own it", async () => {
+		await acquireOrDetectLock(storagePath);
+		expect(existsSync(lockPathFor(storagePath))).toBe(true);
+
+		await releaseLock(storagePath);
+
+		expect(existsSync(lockPathFor(storagePath))).toBe(false);
+		expect(__getOwnedLockPathsForTests()).not.toContain(
+			lockPathFor(storagePath),
+		);
+	});
+
+	it("leaves a foreign lock in place", async () => {
+		const foreign = await writeForeignLock(storagePath, {
+			pid: process.pid + 1,
+			hostname: `remote-${os.hostname()}`,
+		});
+
+		await releaseLock(storagePath);
+
+		expect(existsSync(lockPathFor(storagePath))).toBe(true);
+		const onDisk = JSON.parse(
+			await fs.readFile(lockPathFor(storagePath), "utf-8"),
+		) as WorktreeLockInfo;
+		expect(onDisk.pid).toBe(foreign.pid);
+		expect(onDisk.hostname).toBe(foreign.hostname);
+	});
+
+	it("is a no-op when no lock file exists", async () => {
+		await expect(releaseLock(storagePath)).resolves.toBeUndefined();
+	});
+});


### PR DESCRIPTION
## Summary

Phase 4 F2 from `docs/audits/08-feature-recommendations.md` and `docs/audits/13-phased-roadmap.md` §4: detect multi-worktree collisions on the per-project account storage file via an advisory lock-file protocol.

Multiple OpenCode sessions (tabs, IDE + CLI, separate git worktrees, CI runs) that share a project can interleave writes and lose rotation, health, or rate-limit state. The in-process `withStorageLock` mutex cannot see cross-process writes. This PR adds a sidecar `<accounts>.lock` carrying `pid`, `hostname`, `cwd`, `startedAt`, and `lastActive`. Every `loadAccounts` / `saveAccounts` probes it and either acquires, refreshes, reclaims, or warns.

## Design

- **Advisory, not blocking**: foreign live locks surface a `log.warn` with both worktrees' identifiers and the operation continues. Two legitimate sessions (e.g., IDE + CLI on the same project) must never be stranded; the warning gives the user enough to reconcile manually if a rotation is lost.
- **Stale timeout**: locks with `lastActive` older than one hour are reclaimed quietly. Required because the PID liveness probe alone leaks locks on same-host crashes where a PID is reused.
- **Dead-pid takeover**: same-host only. `process.kill(pid, 0)` distinguishes ESRCH from EPERM; EPERM is treated as alive.
- **Cross-host**: cannot probe remote PIDs, so same-host + stale timestamp is the only reclaim path. Conservative.
- **Corrupt sidecar JSON**: treated as absent so a broken lock file never wedges storage access.
- **Shutdown cleanup**: registered once on first acquire via `registerCleanup`; unlinks every lock this process still owns.
- **Best-effort release**: if another process already took over the lock (same path, different owner), we leave it alone.

## Integration points

- `lib/storage/load-save.ts`: `loadAccountsInternal` probes on entry; `saveAccountsUnlocked` probes before every write (refreshes `lastActive` for stale detection).
- `lib/storage/worktree-lock.ts` (new): `acquireOrDetectLock`, `releaseLock`, and the test-only reset hooks.
- Foreign-lock warnings route through the existing `createLogger("storage")` pipeline, which already scrubs emails/tokens/PII.

## Tests

- `test/storage-worktree-lock.test.ts` (new, 10 tests): clean acquire, foreign live detection, stale takeover, dead-PID takeover, own-lock refresh, corrupt file tolerance, shutdown registration, and release semantics (own vs foreign, missing file).
- `test/chaos/storage-faults.test.ts`: scenario 1 spy now filters by target path so the new lock-file write does not consume the ENOSPC budget. Same contract, same assertions.

Test baseline 2168 → 2178 (+10). `npm run typecheck && lint && test && build` all green locally.

## Files

- `lib/storage/worktree-lock.ts` (new, 305 lines)
- `lib/storage/load-save.ts` (+61 lines for the probe helper + two call sites)
- `test/storage-worktree-lock.test.ts` (new, 265 lines)
- `test/chaos/storage-faults.test.ts` (+27/-6, path filter for lock-file writes)

## Non-goals

- Not a mandatory-blocking lock. The roadmap explicitly prefers warn-over-block.
- No changes to `lib/accounts/**` semantics or the public storage API.
- No new environment variables or config surface; the lock is transparent to existing users.

## Refs

- Audit: `docs/audits/08-feature-recommendations.md`
- Roadmap: `docs/audits/13-phased-roadmap.md#phase-4-f2`
- Parallel with F3 (codex-diff, #PR-F3) and F4 (contract tests); non-overlapping surfaces.

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

adds an advisory sidecar lock file (`<accounts>.lock`) that detects multi-worktree collisions on every `loadAccounts` / `saveAccounts` call. the stale-timeout (1 h), dead-pid takeover, corrupt-json tolerance, and shutdown cleanup are all correctly implemented; the warn-over-block contract is upheld throughout.

the one structural gap worth addressing before the feature can be considered race-proof: the initial acquisition uses a plain `writeFile` with no `O_EXCL` flag, so two processes that simultaneously see a null lock file both return `{ acquired: true }` and proceed without a warning for that first operation pair. fixing this with the `'wx'` flag (atomic on both posix and windows) would close the window cleanly.

<h3>Confidence Score: 5/5</h3>

safe to merge; all findings are P2 style/robustness suggestions that do not block the advisory-lock contract.

no P0/P1 defects found. the TOCTOU gap on initial acquisition is real but consistent with the explicit advisory (warn-over-block) design choice documented in the PR; subsequent calls detect and warn correctly. the O_EXCL suggestion would strengthen the guarantee but is not a blocker under the stated design.

lib/storage/worktree-lock.ts — TOCTOU window on initial lock write; test/chaos/storage-faults.test.ts — isAccountsWrite filter could misfire if gitignore runs.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/storage/worktree-lock.ts | new advisory lock module — solid overall; initial acquisition uses plain writeFile with no O_EXCL flag, leaving a TOCTOU window where two concurrent processes can both claim ownership on the very first race; subsequent calls detect the collision correctly. |
| lib/storage/load-save.ts | integration of lock probe into load/save pipeline; error handling is correct (lock errors are swallowed at debug so a broken sidecar never gates auth reads/writes); os import is out-of-order at the bottom of the import block. |
| test/storage-worktree-lock.test.ts | 10 targeted vitest scenarios covering the major branches; missing coverage for the concurrent-acquire TOCTOU path (two simultaneous acquires on a null lock). |
| test/chaos/storage-faults.test.ts | ENOSPC spy correctly filtered to exclude .lock writes; isAccountsWrite filter would mis-count a gitignore write (doesn't end with .lock, not a tmp path) if ensureGitignore ever fires in the test dir — benign in practice since tmpdir has no .git. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant C as Caller
    participant LS as load-save.ts
    participant WL as worktree-lock.ts
    participant FS as Filesystem

    C->>LS: loadAccounts() / saveAccounts()
    LS->>LS: withStorageLock (in-process mutex)
    LS->>WL: checkWorktreeLockForCurrentStorage(op)
    WL->>FS: readLock(storagePath.lock)
    FS-->>WL: null / WorktreeLockInfo

    alt No lock on disk
        WL->>FS: writeFile(storagePath.lock, ownInfo)
        WL-->>LS: { acquired: true }
    else Own lock (same pid+hostname)
        WL->>FS: writeFile(storagePath.lock, refreshed lastActive)
        WL-->>LS: { acquired: true }
    else Foreign, lastActive > 1h stale
        WL->>FS: writeFile(storagePath.lock, ownInfo)
        WL-->>LS: { acquired: true }
    else Foreign, same host, dead PID
        Note over WL: process.kill(pid, 0) -> ESRCH
        WL->>FS: writeFile(storagePath.lock, ownInfo)
        WL-->>LS: { acquired: true }
    else Foreign live lock
        WL-->>LS: { acquired: false, foreign: info }
        LS->>LS: log.warn(collision detected)
    end

    LS->>FS: read/write accounts file
    LS-->>C: result
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Foc-codex-multi-auth%22%20on%20the%20existing%20branch%20%22feat%2Fphase4-f2-worktree-collision%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fphase4-f2-worktree-collision%22.%0A%0AFix%20the%20following%205%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%205%0Alib%2Fstorage%2Fworktree-lock.ts%3A123-136%0A**TOCTOU%20window%20on%20initial%20lock%20acquisition**%0A%0Atwo%20processes%20that%20both%20call%20%60acquireOrDetectLock%60%20concurrently%20on%20a%20null%20lock%20file%20will%20both%20pass%20the%20%60!existing%60%20branch%2C%20both%20write%20their%20own%20PID%2C%20and%20both%20return%20%60%7B%20acquired%3A%20true%20%7D%60%20%E2%80%94%20so%20the%20very%20first%20concurrent%20access%20pair%20goes%20through%20without%20a%20warning.%20the%20loser%20%28whose%20write%20was%20overwritten%29%20detects%20the%20collision%20only%20on%20the%20*next*%20call.%20using%20%60O_EXCL%60%20%28the%20%60'wx'%60%20flag%29%20for%20the%20initial%20write%20makes%20the%20creation%20atomic%3B%20the%20loser%20gets%20%60EEXIST%60%2C%20re-reads%2C%20and%20surfaces%20the%20live-foreign%20path%20immediately%3A%0A%0A%60%60%60ts%0Aasync%20function%20writeOurLock%28%0A%20%20lockFile%3A%20string%2C%0A%20%20existingStartedAt%3F%3A%20string%2C%0A%20%20exclusive%20%3D%20false%2C%0A%29%3A%20Promise%3Cvoid%3E%20%7B%0A%20%20const%20info%20%3D%20buildOwnLockInfo%28existingStartedAt%29%3B%0A%20%20await%20fs.writeFile%28lockFile%2C%20JSON.stringify%28info%2C%20null%2C%202%29%2C%20%7B%0A%20%20%20%20encoding%3A%20%22utf-8%22%2C%0A%20%20%20%20mode%3A%200o600%2C%0A%20%20%20%20flag%3A%20exclusive%20%3F%20%22wx%22%20%3A%20%22w%22%2C%0A%20%20%7D%29%3B%0A%20%20ownedLockPaths.add%28lockFile%29%3B%0A%20%20ensureShutdownReleaseRegistered%28%29%3B%0A%7D%0A%60%60%60%0A%0Athen%20in%20%60acquireOrDetectLock%60%2C%20call%20%60writeOurLock%28lockFile%2C%20undefined%2C%20true%29%60%20on%20the%20%60!existing%60%20branch%20and%20catch%20%60EEXIST%60%20to%20re-enter%20the%20detection%20path.%20note%20that%20%60O_CREAT%7CO_EXCL%60%20is%20atomic%20on%20posix%3B%20on%20windows%20node.js%20maps%20%60wx%60%20to%20%60FILE_FLAG_CREATE_NEW%60%20which%20is%20also%20atomic.%0A%0A%23%23%23%20Issue%202%20of%205%0Alib%2Fstorage%2Fworktree-lock.ts%3A123-136%0A**Windows%3A%20%60mode%3A%200o600%60%20is%20silently%20ignored**%0A%0Aon%20windows%2C%20node.js%20does%20not%20honour%20posix%20permission%20bits%20on%20%60writeFile%60.%20the%20lock%20file%20will%20be%20world-readable%20to%20any%20user%20on%20the%20same%20machine%2C%20exposing%20%60pid%60%2C%20%60hostname%60%2C%20and%20%60cwd%60.%20no%20tokens%20are%20stored%2C%20so%20this%20is%20not%20a%20credential%20leak%2C%20but%20%60cwd%60%20reveals%20the%20project%20directory.%20the%20accounts%20file%20itself%20has%20the%20same%20behaviour%20%28%60mode%3A%200o600%60%20in%20%60writeAccountsToPathUnlocked%60%29%2C%20so%20this%20is%20consistent%20with%20the%20existing%20pattern%20%E2%80%94%20worth%20a%20code%20comment%20so%20the%20next%20reader%20doesn't%20assume%20the%20600%20is%20enforced%20on%20windows.%0A%0A%23%23%23%20Issue%203%20of%205%0Alib%2Fstorage%2Fload-save.ts%3A41-42%0A**%60os%60%20import%20out%20of%20order**%0A%0A%60import%20os%20from%20%22node%3Aos%22%60%20landed%20after%20the%20local%20imports%20rather%20than%20grouped%20with%20the%20other%20%60node%3A%60%20builtins%20at%20the%20top%20of%20the%20block.%0A%0A%60%60%60suggestion%0Aimport%20os%20from%20%22node%3Aos%22%3B%0Aimport%20%7B%20promises%20as%20fs%2C%20existsSync%20%7D%20from%20%22node%3Afs%22%3B%0A%60%60%60%0A%0A%28move%20it%20above%20%60node%3Afs%60%20and%20remove%20the%20trailing%20lone%20import%20at%20line%2041.%29%0A%0A%23%23%23%20Issue%204%20of%205%0Atest%2Fchaos%2Fstorage-faults.test.ts%3A87-92%0A**%60isAccountsWrite%60%20filter%20is%20fragile%20if%20%60ensureGitignore%60%20fires**%0A%0Athe%20filter%20passes%20any%20path%20that%20doesn't%20end%20with%20%60.lock%60%20as%20an%20%22accounts%20write%22.%20if%20%60ensureGitignore%60%20runs%20%28it%20won't%20in%20a%20bare%20tmpdir%2C%20but%20it%20will%20if%20a%20%60.git%60%20ancestor%20is%20present%29%2C%20the%20%60.gitignore%60%20write%20hits%20the%20spy%20and%20consumes%20the%20first%20%60accountsWriteCalls%60%20slot%20%E2%80%94%20throwing%20ENOSPC%20on%20the%20gitignore%20instead%20of%20the%20storage%20file%20and%20breaking%20the%20assertion.%20filtering%20on%20%60.tmp%60%20%28the%20actual%20atomic%20temp%20path%29%20is%20tighter%3A%0A%0A%60%60%60ts%0Aconst%20isAccountsWrite%20%3D%20%28target%3A%20unknown%29%3A%20boolean%20%3D%3E%20%7B%0A%20%20const%20p%20%3D%20typeof%20target%20%3D%3D%3D%20%22string%22%20%3F%20target%20%3A%20String%28target%29%3B%0A%20%20return%20p.includes%28%22.tmp%22%29%3B%0A%7D%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%205%20of%205%0Atest%2Fstorage-worktree-lock.test.ts%3A60-79%0A**missing%20vitest%20coverage%3A%20concurrent-acquire%20TOCTOU%20path**%0A%0Ano%20test%20exercises%20two%20simultaneous%20%60acquireOrDetectLock%60%20calls%20on%20a%20null%20lock%20file.%20the%20current%20suite%20covers%20all%20single-caller%20branches%20cleanly%2C%20but%20the%20concurrency%20gap%20%28both%20callers%20return%20%60acquired%3A%20true%60%20on%20the%20first%20race%29%20is%20the%20most%20surprising%20observable%20behaviour%20and%20worth%20pinning.%20a%20test%20that%20stubs%20%60readLock%60%20to%20return%20null%20for%20both%20calls%2C%20lets%20both%20%60writeFile%60%20calls%20race%2C%20then%20asserts%20that%20one%20caller%20ends%20up%20detecting%20the%20foreign%20PID%20on%20a%20third%20call%20would%20cover%20this%20without%20spawning%20a%20real%20second%20process.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: lib/storage/worktree-lock.ts
Line: 123-136

Comment:
**TOCTOU window on initial lock acquisition**

two processes that both call `acquireOrDetectLock` concurrently on a null lock file will both pass the `!existing` branch, both write their own PID, and both return `{ acquired: true }` — so the very first concurrent access pair goes through without a warning. the loser (whose write was overwritten) detects the collision only on the *next* call. using `O_EXCL` (the `'wx'` flag) for the initial write makes the creation atomic; the loser gets `EEXIST`, re-reads, and surfaces the live-foreign path immediately:

```ts
async function writeOurLock(
  lockFile: string,
  existingStartedAt?: string,
  exclusive = false,
): Promise<void> {
  const info = buildOwnLockInfo(existingStartedAt);
  await fs.writeFile(lockFile, JSON.stringify(info, null, 2), {
    encoding: "utf-8",
    mode: 0o600,
    flag: exclusive ? "wx" : "w",
  });
  ownedLockPaths.add(lockFile);
  ensureShutdownReleaseRegistered();
}
```

then in `acquireOrDetectLock`, call `writeOurLock(lockFile, undefined, true)` on the `!existing` branch and catch `EEXIST` to re-enter the detection path. note that `O_CREAT|O_EXCL` is atomic on posix; on windows node.js maps `wx` to `FILE_FLAG_CREATE_NEW` which is also atomic.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: lib/storage/worktree-lock.ts
Line: 123-136

Comment:
**Windows: `mode: 0o600` is silently ignored**

on windows, node.js does not honour posix permission bits on `writeFile`. the lock file will be world-readable to any user on the same machine, exposing `pid`, `hostname`, and `cwd`. no tokens are stored, so this is not a credential leak, but `cwd` reveals the project directory. the accounts file itself has the same behaviour (`mode: 0o600` in `writeAccountsToPathUnlocked`), so this is consistent with the existing pattern — worth a code comment so the next reader doesn't assume the 600 is enforced on windows.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: lib/storage/load-save.ts
Line: 41-42

Comment:
**`os` import out of order**

`import os from "node:os"` landed after the local imports rather than grouped with the other `node:` builtins at the top of the block.

```suggestion
import os from "node:os";
import { promises as fs, existsSync } from "node:fs";
```

(move it above `node:fs` and remove the trailing lone import at line 41.)

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: test/chaos/storage-faults.test.ts
Line: 87-92

Comment:
**`isAccountsWrite` filter is fragile if `ensureGitignore` fires**

the filter passes any path that doesn't end with `.lock` as an "accounts write". if `ensureGitignore` runs (it won't in a bare tmpdir, but it will if a `.git` ancestor is present), the `.gitignore` write hits the spy and consumes the first `accountsWriteCalls` slot — throwing ENOSPC on the gitignore instead of the storage file and breaking the assertion. filtering on `.tmp` (the actual atomic temp path) is tighter:

```ts
const isAccountsWrite = (target: unknown): boolean => {
  const p = typeof target === "string" ? target : String(target);
  return p.includes(".tmp");
};
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: test/storage-worktree-lock.test.ts
Line: 60-79

Comment:
**missing vitest coverage: concurrent-acquire TOCTOU path**

no test exercises two simultaneous `acquireOrDetectLock` calls on a null lock file. the current suite covers all single-caller branches cleanly, but the concurrency gap (both callers return `acquired: true` on the first race) is the most surprising observable behaviour and worth pinning. a test that stubs `readLock` to return null for both calls, lets both `writeFile` calls race, then asserts that one caller ends up detecting the foreign PID on a third call would cover this without spawning a real second process.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test(chaos): filter ENOSPC fault injecti..."](https://github.com/ndycode/oc-codex-multi-auth/commit/e5396557e2ec17f5038f0104652383802a9cb166) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28757133)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->