### PR TITLE
test: Phase 4 F4 - contract-test framework for external API shapes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -170,6 +170,23 @@ git commit --no-verify -m "..."
 ### How to add a test
 Match the closest existing test file under `test/`. For a new `lib/<module>.ts`, add `test/<module>.test.ts`. Follow the Vitest + Zod + fake-timer conventions in existing tests (see `test/rotation.test.ts` for a mid-complexity example).
 
+### Updating API contract fixtures
+
+Contract tests in `test/contracts/` pin external API response shapes (OAuth token endpoint, Codex non-streaming chat-completions, Codex SSE stream). They read sanitized fixtures from `test/contracts/fixtures/` and feed them through the SAME production parsers and schemas the plugin uses at runtime (`OAuthTokenResponseSchema`, `isEmptyResponse`, `convertSseToJson`). A failing contract test means the upstream shape drifted or the parser was changed in a way that no longer accepts a known-good response.
+
+**When to update:**
+- An upstream API release changes the response shape.
+- You want to capture a new edge case (e.g., a new `reasoning.encrypted_content` variant or a new SSE event).
+
+**How to update:**
+1. Capture a real response from the live endpoint while debugging. **Sanitize every token, account id, organization id, email, and JWT** — replace them with `FAKE_*` placeholders matching the style of the existing fixtures.
+2. Update the fixture file under `test/contracts/fixtures/` with the sanitized payload.
+3. Run the contract test (`npx vitest run test/contracts/`). A pass means the new fixture is compatible with production parsers; a failure means either the fixture or the parser needs to change.
+4. If the upstream added a new optional field, no code change is required — the existing schema will accept it and the test will still pass.
+5. If the upstream change is backward-incompatible, update the production parser AND the contract test in the same commit so the two stay in sync.
+
+**Never commit real tokens, real account ids, real organization ids, real JWT payloads, or any PII in fixtures.** The fixtures live in version control; treat them as public.
+
 ### Debug OAuth flow locally
 Set `CODEX_DEBUG_AUTH=1` in your shell before running. See `docs/development/AUTH_FLOW.md` (if present) for protocol details.
 

--- a/test/contracts/codex-chat.test.ts
+++ b/test/contracts/codex-chat.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Contract test — Codex non-streaming chat-completions response shape.
+ *
+ * Pins the shape of the JSON body the Codex backend returns for a
+ * non-streaming request. The production pipeline at `index.ts` (see
+ * `isEmptyResponse(parsedBody)` around the empty-response retry path)
+ * parses this body with `JSON.parse` and then feeds it through the
+ * production validator `isEmptyResponse` from
+ * `lib/request/response-handler.ts`.
+ *
+ * If Codex ships a shape change — for example, moving `output[]` to a
+ * different key, dropping `reasoning.encrypted_content`, or returning an
+ * empty-shaped body that production would now treat as empty — this test
+ * fails with a clear "upstream shape changed" message.
+ *
+ * The test reuses the SAME parser (`JSON.parse` + `isEmptyResponse`) that
+ * production uses. It does NOT re-implement parsing.
+ */
+
+import { describe, it, expect } from "vitest";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { isEmptyResponse } from "../../lib/request/response-handler.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const fixturePath = path.join(
+	__dirname,
+	"fixtures",
+	"codex-chat-response.json",
+);
+
+describe("contract: Codex chat-completions (non-streaming)", () => {
+	it("production validator recognizes the pinned fixture as non-empty", async () => {
+		const raw = await fs.readFile(fixturePath, "utf-8");
+		const parsed = JSON.parse(raw) as unknown;
+
+		// isEmptyResponse is the exact validator the request pipeline uses
+		// after JSON.parse(bodyText). A change that makes production treat a
+		// healthy Codex response as "empty" would trigger spurious retries
+		// and account health penalties. Guard against that here.
+		if (isEmptyResponse(parsed)) {
+			throw new Error(
+				"Contract broken: upstream shape changed for Codex chat response. " +
+					"isEmptyResponse() now reports the pinned fixture as empty, which " +
+					"would cause the production pipeline to retry and rotate accounts.",
+			);
+		}
+
+		expect(isEmptyResponse(parsed)).toBe(false);
+	});
+
+	it("pins the top-level response envelope fields", async () => {
+		const raw = await fs.readFile(fixturePath, "utf-8");
+		const parsed = JSON.parse(raw) as Record<string, unknown>;
+
+		// Fields the plugin reads directly or forwards to OpenCode. A
+		// mismatch here indicates a backward-incompatible Codex response
+		// change that must be reviewed before users are affected.
+		expect(parsed).toMatchObject({
+			id: expect.any(String),
+			object: "response",
+			model: expect.any(String),
+			status: "completed",
+			output: expect.any(Array),
+		});
+	});
+
+	it("pins the output[].message -> content[].output_text structure", async () => {
+		const raw = await fs.readFile(fixturePath, "utf-8");
+		const parsed = JSON.parse(raw) as {
+			output: Array<{
+				type: string;
+				role: string;
+				content: Array<{ type: string; text: string }>;
+			}>;
+		};
+
+		expect(parsed.output.length).toBeGreaterThan(0);
+		const first = parsed.output[0];
+		expect(first).toBeDefined();
+		expect(first?.type).toBe("message");
+		expect(first?.role).toBe("assistant");
+		expect(Array.isArray(first?.content)).toBe(true);
+		const firstContent = first?.content?.[0];
+		expect(firstContent?.type).toBe("output_text");
+		expect(typeof firstContent?.text).toBe("string");
+	});
+
+	it("pins reasoning.encrypted_content (required for stateless continuity)", async () => {
+		const raw = await fs.readFile(fixturePath, "utf-8");
+		const parsed = JSON.parse(raw) as {
+			reasoning?: { encrypted_content?: unknown };
+		};
+
+		// Per AGENTS.md: the plugin sends `store: false` and RELIES on
+		// `reasoning.encrypted_content` coming back to preserve multi-turn
+		// session context. If Codex drops this field we MUST know about it
+		// before real conversations start losing continuity.
+		expect(parsed.reasoning).toBeDefined();
+		expect(typeof parsed.reasoning?.encrypted_content).toBe("string");
+	});
+
+	it("pins the usage counters used by retry budgets", async () => {
+		const raw = await fs.readFile(fixturePath, "utf-8");
+		const parsed = JSON.parse(raw) as {
+			usage?: Record<string, unknown>;
+		};
+
+		expect(parsed.usage).toBeDefined();
+		expect(typeof parsed.usage?.input_tokens).toBe("number");
+		expect(typeof parsed.usage?.output_tokens).toBe("number");
+		expect(typeof parsed.usage?.total_tokens).toBe("number");
+	});
+
+	it("production validator treats an empty response as empty (drift guard)", () => {
+		// Control case: confirms isEmptyResponse still treats an unambiguously
+		// empty response envelope as empty. If this check ever fails, the
+		// empty-response retry logic in index.ts is silently broken.
+		expect(isEmptyResponse({ id: "resp_empty", object: "response" })).toBe(
+			true,
+		);
+	});
+});

--- a/test/contracts/codex-sse.test.ts
+++ b/test/contracts/codex-sse.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Contract test — Codex SSE stream event shapes.
+ *
+ * Pins the SSE framing and event shapes the Codex backend emits for a
+ * streaming response. The production SSE parser is
+ * `convertSseToJson` in `lib/request/response-handler.ts`; it scans the
+ * stream, matches `response.done` / `response.completed` events, extracts
+ * the embedded `response` object, and returns a JSON `Response`.
+ *
+ * If Codex changes the SSE framing (`data:` prefix, terminal event name,
+ * embedded `response` object structure), this test fails fast with a clear
+ * "upstream shape changed" message. The test uses the EXACT production
+ * parser — no duplicated SSE parsing in test code.
+ */
+
+import { describe, it, expect } from "vitest";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { convertSseToJson } from "../../lib/request/response-handler.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const fixturePath = path.join(
+	__dirname,
+	"fixtures",
+	"codex-sse-stream.txt",
+);
+
+async function loadFixtureAsResponse(): Promise<Response> {
+	const raw = await fs.readFile(fixturePath, "utf-8");
+	return new Response(raw, {
+		status: 200,
+		statusText: "OK",
+		headers: { "content-type": "text/event-stream; charset=utf-8" },
+	});
+}
+
+describe("contract: Codex SSE stream events", () => {
+	it("production parser extracts the final response from the pinned stream", async () => {
+		const response = await loadFixtureAsResponse();
+		const headers = new Headers();
+
+		const converted = await convertSseToJson(response, headers);
+
+		if (converted.status >= 400) {
+			const errorBody = await converted.text();
+			throw new Error(
+				`Contract broken: upstream shape changed for Codex SSE stream. ` +
+					`convertSseToJson returned status ${converted.status} for the pinned ` +
+					`fixture. Body: ${errorBody}`,
+			);
+		}
+
+		expect(converted.status).toBe(200);
+		expect(converted.headers.get("content-type")).toBe(
+			"application/json; charset=utf-8",
+		);
+
+		const body = (await converted.json()) as Record<string, unknown>;
+		expect(body).toMatchObject({
+			id: expect.any(String),
+			object: "response",
+			model: expect.any(String),
+			status: "completed",
+			output: expect.any(Array),
+		});
+	});
+
+	it("pins response.completed as the terminal event shape", async () => {
+		const response = await loadFixtureAsResponse();
+		const converted = await convertSseToJson(response, new Headers());
+		const body = (await converted.json()) as {
+			output: Array<{
+				type: string;
+				content: Array<{ type: string; text: string }>;
+			}>;
+			reasoning?: { encrypted_content?: unknown };
+		};
+
+		// Nested shape the plugin forwards to OpenCode. If upstream moves
+		// these fields, downstream renderers break — we catch that here.
+		const firstMessage = body.output[0];
+		expect(firstMessage?.type).toBe("message");
+		const firstContent = firstMessage?.content?.[0];
+		expect(firstContent?.type).toBe("output_text");
+		expect(typeof firstContent?.text).toBe("string");
+
+		// Per AGENTS.md, streaming responses must still carry
+		// reasoning.encrypted_content for stateless continuity.
+		expect(typeof body.reasoning?.encrypted_content).toBe("string");
+	});
+
+	it("rejects an SSE stream that lacks a terminal response event (drift guard)", async () => {
+		// Control case: an SSE stream with only delta events and NO
+		// response.done / response.completed must NOT be parsed as a JSON
+		// response. If upstream ever renames the terminal event, we need this
+		// to fail loudly rather than silently returning an empty JSON body.
+		const streamWithoutTerminal =
+			'data: {"type":"response.output_text.delta","delta":"hello"}\n\n';
+		const resp = new Response(streamWithoutTerminal, { status: 200 });
+		const converted = await convertSseToJson(resp, new Headers());
+
+		// Production falls back to returning the raw text unchanged when no
+		// terminal event is seen. Assert that behavior — it is the signal
+		// that we are looking at a parser-vs-upstream mismatch.
+		expect(converted.headers.get("content-type")).not.toBe(
+			"application/json; charset=utf-8",
+		);
+		const text = await converted.text();
+		expect(text).toContain("response.output_text.delta");
+	});
+
+	it("pins stream error event shape (error contract)", async () => {
+		// A Codex error event must be converted to a JSON error body with
+		// status 502 and the error envelope shape the plugin forwards to
+		// OpenCode. This is part of the upstream contract: if the error
+		// event shape changes, users see unhandled errors.
+		const errorStream =
+			'data: {"type":"error","error":{"message":"contract error","code":"test_code"}}\n\n';
+		const resp = new Response(errorStream, { status: 200 });
+		const converted = await convertSseToJson(resp, new Headers());
+
+		expect(converted.status).toBe(502);
+		const body = (await converted.json()) as {
+			error?: { message?: string; type?: string; code?: string };
+		};
+		expect(body.error).toBeDefined();
+		expect(body.error?.message).toBe("contract error");
+		expect(body.error?.code).toBe("test_code");
+	});
+});

--- a/test/contracts/fixtures/codex-chat-response.json
+++ b/test/contracts/fixtures/codex-chat-response.json
@@ -1,0 +1,25 @@
+{
+  "id": "resp_FAKE_contract_test",
+  "object": "response",
+  "created_at": 1700000000,
+  "model": "gpt-5-codex",
+  "status": "completed",
+  "output": [
+    {
+      "type": "message",
+      "role": "assistant",
+      "content": [
+        { "type": "output_text", "text": "hello from contract fixture" }
+      ]
+    }
+  ],
+  "usage": {
+    "input_tokens": 10,
+    "output_tokens": 5,
+    "total_tokens": 15
+  },
+  "reasoning": {
+    "encrypted_content": "FAKE_ENCRYPTED_REASONING_BLOB"
+  },
+  "metadata": {}
+}

--- a/test/contracts/fixtures/codex-sse-stream.txt
+++ b/test/contracts/fixtures/codex-sse-stream.txt
@@ -1,0 +1,12 @@
+event: response.created
+data: {"type":"response.created","response":{"id":"resp_FAKE_sse","object":"response","model":"gpt-5-codex","status":"in_progress"}}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","delta":"hello"}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","delta":" from contract fixture"}
+
+event: response.completed
+data: {"type":"response.completed","response":{"id":"resp_FAKE_sse","object":"response","model":"gpt-5-codex","status":"completed","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"hello from contract fixture"}]}],"usage":{"input_tokens":10,"output_tokens":5,"total_tokens":15},"reasoning":{"encrypted_content":"FAKE_ENCRYPTED_REASONING_BLOB"},"metadata":{}}}
+

--- a/test/contracts/fixtures/openai-token-response.json
+++ b/test/contracts/fixtures/openai-token-response.json
@@ -1,0 +1,8 @@
+{
+  "access_token": "FAKE_ACCESS_TOKEN_FOR_CONTRACT_TESTS",
+  "refresh_token": "FAKE_REFRESH_TOKEN_FOR_CONTRACT_TESTS",
+  "id_token": "FAKE.JWT.FOR_CONTRACT_TESTS",
+  "token_type": "Bearer",
+  "expires_in": 3600,
+  "scope": "openid profile email offline_access"
+}

--- a/test/contracts/openai-token.test.ts
+++ b/test/contracts/openai-token.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Contract test — OpenAI OAuth token endpoint response shape.
+ *
+ * Pins the wire-level shape that `lib/auth/auth.ts` expects from
+ * `https://auth.openai.com/oauth/token` (both the initial authorization-code
+ * exchange and the refresh_token grant). If OpenAI ships a change to the
+ * token response that is not backward-compatible, this test fails fast with a
+ * clear "upstream shape changed" message before the drift can reach users in
+ * production.
+ *
+ * The test deliberately feeds the pinned fixture through the SAME parser
+ * (`OAuthTokenResponseSchema` / `safeParseOAuthTokenResponse` from
+ * `lib/schemas.ts`) that `exchangeAuthorizationCode` and `refreshAccessToken`
+ * call. It does NOT re-implement validation.
+ */
+
+import { describe, it, expect } from "vitest";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+	OAuthTokenResponseSchema,
+	safeParseOAuthTokenResponse,
+} from "../../lib/schemas.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const fixturePath = path.join(
+	__dirname,
+	"fixtures",
+	"openai-token-response.json",
+);
+
+describe("contract: OpenAI OAuth token endpoint", () => {
+	it("parses the pinned fixture cleanly via production schema", async () => {
+		const raw = await fs.readFile(fixturePath, "utf-8");
+		const parsed = OAuthTokenResponseSchema.safeParse(JSON.parse(raw));
+
+		if (!parsed.success) {
+			throw new Error(
+				`Contract broken: upstream shape changed for OAuth token endpoint. ` +
+					`Production parser rejected the pinned fixture. Details: ${parsed.error.message}`,
+			);
+		}
+
+		expect(parsed.data).toMatchObject({
+			access_token: expect.any(String),
+			refresh_token: expect.any(String),
+			id_token: expect.any(String),
+			token_type: "Bearer",
+			expires_in: expect.any(Number),
+			scope: expect.any(String),
+		});
+
+		// Production code derives `expires` as `Date.now() + expires_in * 1000`
+		// (see lib/auth/auth.ts:111,179). Guard against the field becoming a
+		// string ("3600") or ms-based without a coordinated code change.
+		expect(typeof parsed.data.expires_in).toBe("number");
+		expect(parsed.data.expires_in).toBeGreaterThan(0);
+	});
+
+	it("exposes the same normalized shape via safeParseOAuthTokenResponse", async () => {
+		const raw = await fs.readFile(fixturePath, "utf-8");
+		const parsed = safeParseOAuthTokenResponse(JSON.parse(raw));
+
+		if (parsed === null) {
+			throw new Error(
+				"Contract broken: upstream shape changed for OAuth token endpoint. " +
+					"safeParseOAuthTokenResponse returned null for the pinned fixture.",
+			);
+		}
+
+		// These are the exact fields the production auth flow reads
+		// (lib/auth/auth.ts:109-112 + :177-180).
+		expect(parsed.access_token.length).toBeGreaterThan(0);
+		expect(parsed.expires_in).toBeGreaterThan(0);
+	});
+
+	it("rejects malformed responses (defensive schema)", () => {
+		// If this parses, the schema has lost its shape-guarantee — the whole
+		// point of the contract test is to ensure malformed inputs are
+		// detected at the process boundary instead of silently crashing the
+		// token-exchange code.
+		const bogus = { not_a_token: true };
+		const parsed = OAuthTokenResponseSchema.safeParse(bogus);
+		expect(parsed.success).toBe(false);
+
+		const parsedHelper = safeParseOAuthTokenResponse(bogus);
+		expect(parsedHelper).toBeNull();
+	});
+
+	it("accepts a refresh response that omits refresh_token (rotation-skip case)", () => {
+		// The real OAuth server returns `refresh_token` on initial exchange but
+		// may omit it on some refresh responses. lib/auth/auth.ts:169 handles
+		// that explicitly by reusing the existing refresh token — the schema
+		// must therefore allow `refresh_token` to be optional. This case is
+		// part of the contract.
+		const refreshOnly = {
+			access_token: "FAKE_REFRESHED_ACCESS_TOKEN",
+			token_type: "Bearer",
+			expires_in: 1800,
+		};
+		const parsed = OAuthTokenResponseSchema.safeParse(refreshOnly);
+		expect(parsed.success).toBe(true);
+	});
+});


### PR DESCRIPTION
## Summary
Phase 4 F4. Adds offline contract tests pinning the shape of three external API surfaces the plugin depends on:
- OpenAI OAuth token endpoint response
- Codex chat-completions (non-streaming) response
- Codex SSE stream events

## How it works
Each contract test loads a sanitized fixture from `test/contracts/fixtures/` and runs it through the SAME parser / schema production uses — no duplicated parsing in test code. A mismatch fails fast with "upstream shape changed", giving early warning of API drift before it degrades users in production.

Parsers consumed (from production):
- `OAuthTokenResponseSchema` + `safeParseOAuthTokenResponse` (from `lib/schemas.ts`) — used by `lib/auth/auth.ts:102,163` for both the authorization-code exchange and the refresh grant.
- `isEmptyResponse` (from `lib/request/response-handler.ts`) — used by `index.ts:2335` in the empty-response retry path to decide whether a non-streaming body is healthy.
- `convertSseToJson` (from `lib/request/response-handler.ts`) — the SSE-to-JSON converter used by the request pipeline for streaming responses.

## Files added
- `test/contracts/openai-token.test.ts`
- `test/contracts/codex-chat.test.ts`
- `test/contracts/codex-sse.test.ts`
- `test/contracts/fixtures/openai-token-response.json`
- `test/contracts/fixtures/codex-chat-response.json`
- `test/contracts/fixtures/codex-sse-stream.txt`
- `CONTRIBUTING.md` — new subsection **Updating API contract fixtures** under Local Development.

## Audit refs
- `docs/audits/10-testing-gaps.md` — contract-test gap
- `docs/audits/13-phased-roadmap.md` §4

## Verification
- `npm run typecheck` — clean
- `npm run lint` — clean
- `npm test` — **2204 tests pass** across 76 test files (was 2190 before this PR; +14 new contract tests)
- `npm run build` — clean
- Contract tests are fully offline (no network) and fast — each case runs in <20 ms in local vitest runs, well under the 500 ms per-test budget.
- All fixtures use `FAKE_*` placeholders: no real tokens, no real account ids, no real JWT payloads, no PII.

## Notes / follow-ups
- There is no strict Zod schema for the Codex Responses API envelope today. Contract tests consume the production validator `isEmptyResponse` plus structural asserts on the fixture (envelope fields, `output[].message.content[].output_text`, `reasoning.encrypted_content`, `usage.*_tokens`). If a later phase adds a formal schema, the Codex contract test should be upgraded to feed the fixture through that schema. Tracked here for follow-up.
- The SSE contract test also asserts the error-event shape (`type: "error"` -> 502 JSON envelope) which is part of the upstream contract the plugin currently forwards to OpenCode.
- No changes to `lib/**` in this PR — contract tests only consume existing exports.

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

adds offline contract tests for three external api surfaces (oauth token endpoint, codex non-streaming chat, codex sse stream) by feeding sanitized fixtures through the same production parsers (`OAuthTokenResponseSchema`, `isEmptyResponse`, `convertSseToJson`) that the plugin uses at runtime. no changes to `lib/**`; +14 tests across 3 new files plus a `CONTRIBUTING.md` subsection on fixture hygiene.

<h3>Confidence Score: 5/5</h3>

safe to merge — no production code changed, all findings are p2 style suggestions.

all 14 new tests are additive, test-only, and offline. fixtures are fully sanitized with FAKE_* placeholders — no token safety risk. production parsers are consumed directly without re-implementation. only two minor p2 gaps in the sse contract test (missing role assertion, unpinned error.type) that don't block merge.

test/contracts/codex-sse.test.ts — two small coverage gaps noted as p2 suggestions.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| test/contracts/openai-token.test.ts | 4 well-scoped contract tests covering parse, helper, rejection, and refresh-skip cases; correctly consumes production schema without re-implementing validation. |
| test/contracts/codex-chat.test.ts | 6 tests covering isEmptyResponse path, envelope fields, output structure, reasoning.encrypted_content, usage counters, and the control/empty case. |
| test/contracts/codex-sse.test.ts | 4 tests via convertSseToJson; two minor gaps — role field not asserted on output[0] and error.type not pinned in the error-event contract test. |
| test/contracts/fixtures/openai-token-response.json | all fields sanitized with FAKE_* placeholders; no real tokens, JWTs, or PII. |
| test/contracts/fixtures/codex-chat-response.json | minimal, fully sanitized fixture covering all asserted fields (output, usage, reasoning.encrypted_content). |
| test/contracts/fixtures/codex-sse-stream.txt | well-formed sse fixture with created → delta → delta → completed sequence; sanitized, correct double-newline framing. |
| CONTRIBUTING.md | new 'updating api contract fixtures' subsection with clear sanitization rules and update workflow; explicitly forbids committing real tokens or PII. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    F1[fixtures/openai-token-response.json] -->|fs.readFile + JSON.parse| T1[openai-token.test.ts]
    T1 -->|OAuthTokenResponseSchema.safeParse| S1[lib/schemas.ts\nOAuthTokenResponseSchema]
    T1 -->|safeParseOAuthTokenResponse| S1

    F2[fixtures/codex-chat-response.json] -->|fs.readFile + JSON.parse| T2[codex-chat.test.ts]
    T2 -->|isEmptyResponse| S2[lib/request/response-handler.ts\nisEmptyResponse]

    F3[fixtures/codex-sse-stream.txt] -->|fs.readFile → new Response| T3[codex-sse.test.ts]
    T3 -->|convertSseToJson| S3[lib/request/response-handler.ts\nconvertSseToJson]

    S1 -.->|used by| A[lib/auth/auth.ts\nexchangeAuthorizationCode\nrefreshAccessToken]
    S2 -.->|used by| I[index.ts\nempty-response retry path]
    S3 -.->|used by| I
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Foc-codex-multi-auth%22%20on%20the%20existing%20branch%20%22test%2Fphase4-f4-contract-tests%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22test%2Fphase4-f4-contract-tests%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Atest%2Fcontracts%2Fcodex-sse.test.ts%3A83-91%0A**missing%20%60role%60%20assertion%20%E2%80%94%20inconsistent%20with%20chat%20contract%20test**%0A%0Athe%20%22pins%20response.completed%22%20test%20doesn't%20assert%20%60role%3A%20%22assistant%22%60%20on%20%60output%5B0%5D%60%2C%20but%20%60codex-chat.test.ts%3A84%60%20does.%20if%20codex%20drops%20or%20renames%20the%20%60role%60%20field%20in%20sse%20responses%20the%20sse%20contract%20won't%20catch%20it%2C%20even%20though%20it's%20a%20field%20the%20plugin%20forwards%20downstream%20to%20opencode.%0A%0A%60%60%60suggestion%0A%09%09const%20firstMessage%20%3D%20body.output%5B0%5D%3B%0A%09%09expect%28firstMessage%3F.type%29.toBe%28%22message%22%29%3B%0A%09%09expect%28firstMessage%3F.role%29.toBe%28%22assistant%22%29%3B%0A%09%09const%20firstContent%20%3D%20firstMessage%3F.content%3F.%5B0%5D%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Atest%2Fcontracts%2Fcodex-sse.test.ts%3A124-131%0A**%60error.type%60%20field%20left%20unpinned%20in%20error-event%20contract**%0A%0A%60convertSseToJson%60%20defaults%20%60error.type%60%20to%20%60STREAM_ERROR_CODE%20%3D%20%22stream_error%22%60%20when%20the%20sse%20payload%20omits%20it%20%28see%20%60response-handler.ts%60%20line%20206%29.%20the%20test%20asserts%20%60message%60%20and%20%60code%60%20but%20not%20%60type%60%2C%20so%20a%20rename%20of%20%60STREAM_ERROR_CODE%60%20silently%20breaks%20the%20forwarded%20error%20envelope%20without%20failing%20this%20contract.%0A%0A%60%60%60suggestion%0A%09%09expect%28body.error%29.toBeDefined%28%29%3B%0A%09%09expect%28body.error%3F.message%29.toBe%28%22contract%20error%22%29%3B%0A%09%09expect%28body.error%3F.type%29.toBe%28%22stream_error%22%29%3B%0A%09%09expect%28body.error%3F.code%29.toBe%28%22test_code%22%29%3B%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: test/contracts/codex-sse.test.ts
Line: 83-91

Comment:
**missing `role` assertion — inconsistent with chat contract test**

the "pins response.completed" test doesn't assert `role: "assistant"` on `output[0]`, but `codex-chat.test.ts:84` does. if codex drops or renames the `role` field in sse responses the sse contract won't catch it, even though it's a field the plugin forwards downstream to opencode.

```suggestion
		const firstMessage = body.output[0];
		expect(firstMessage?.type).toBe("message");
		expect(firstMessage?.role).toBe("assistant");
		const firstContent = firstMessage?.content?.[0];
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: test/contracts/codex-sse.test.ts
Line: 124-131

Comment:
**`error.type` field left unpinned in error-event contract**

`convertSseToJson` defaults `error.type` to `STREAM_ERROR_CODE = "stream_error"` when the sse payload omits it (see `response-handler.ts` line 206). the test asserts `message` and `code` but not `type`, so a rename of `STREAM_ERROR_CODE` silently breaks the forwarded error envelope without failing this contract.

```suggestion
		expect(body.error).toBeDefined();
		expect(body.error?.message).toBe("contract error");
		expect(body.error?.type).toBe("stream_error");
		expect(body.error?.code).toBe("test_code");
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test(contracts): pin external API shapes..."](https://github.com/ndycode/oc-codex-multi-auth/commit/655876563ac14048f9aa01da1d7fcf53c878ea7c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28757707)</sub>

<!-- /greptile_comment -->