### PR TITLE
fix(keychain): F1 post-merge review findings (1 HIGH + 3 MEDIUM)

### DIFF
--- a/docs/audits/_meta/f1-post-merge-review.md
+++ b/docs/audits/_meta/f1-post-merge-review.md
@@ -1,0 +1,139 @@
+﻿# F1 (#132) Post-Merge Security Review
+
+> **Reviewer**: oracle (adversarial post-merge review)
+> **Review date**: 2026-04-18
+> **Commit reviewed**: `ae75093` on `main`
+> **Verdict**: **APPROVE-WITH-FOLLOWUPS**
+
+## Summary
+
+F1 lands a correctly scoped, genuinely opt-in OS-keychain backend. The default-off
+contract is airtight (`CODEX_KEYCHAIN === "1"` strict equality, no probe calls when
+unset, a dedicated regression test asserts zero mock calls on the baseline path),
+the fallback-on-every-error contract holds end-to-end, and no secret material
+leaks through logs or error strings. Findings below are real but non-blocking:
+one HIGH atomicity issue around partial migration, a couple of MEDIUMs on
+rollback UX and `clearAccounts` ordering, plus LOW/NIT hygiene items. None
+warrant revert; all can be cleaned up in a small follow-up PR.
+
+## Findings
+
+### [HIGH] Partial-migration window: keychain write succeeds, JSON rename fails -> duplicated source of truth
+- **File**: `lib/storage/load-save.ts:535-554` (`saveAccountsUnlocked`) and `lib/storage/load-save.ts:507-527` (`migrateOnDiskJsonToKeychainBackup`)
+- **Issue**: After a successful keychain write, `migrateOnDiskJsonToKeychainBackup` attempts to rename the JSON file. If the rename fails (EACCES, EBUSY on Windows, disk full, parent dir permission drift), the failure is swallowed with `log.warn` and `saveAccountsUnlocked` returns success. The on-disk JSON now holds a **stale-but-valid** V3 blob while the keychain holds the authoritative fresh blob. On the next `loadAccounts` with opt-in still set, the keychain read wins and everything is fine - but if the user **disables the opt-in** (unsets `CODEX_KEYCHAIN`) they are silently rolled back to the stale JSON with no warning. The code comment acknowledges "at worst a duplicate JSON file on disk" but the real blast radius is silent staleness across an opt-in toggle.
+- **Evidence**:
+  ```ts
+  // lib/storage/load-save.ts:520-526
+  } catch (err) {
+    log.warn("keychain: failed to rename on-disk JSON after successful keychain write", {
+      path, error: String(err),
+    });
+  }
+  // saveAccountsUnlocked then returns normally -> caller sees success
+  ```
+- **Fix**: Either (a) overwrite the stale JSON with the new blob when the rename fails (so the on-disk copy remains consistent), or (b) on every opt-in `loadAccounts`, if both keychain entry and non-suffixed JSON exist, log a HIGH-severity warning. Option (a) is simpler and keeps the rollback invariant.
+
+### [MEDIUM] `clearAccounts` order: keychain delete before JSON unlink can resurrect credentials on error
+- **File**: `lib/storage/load-save.ts:602-627`
+- **Issue**: When opt-in is on, the keychain entry is deleted first (line 611), then the JSON file is unlinked (line 620). If the unlink fails for a non-ENOENT reason (permission, EBUSY), the keychain is cleared but the JSON remains. A subsequent `loadAccounts` with opt-in **still on** sees `keychain -> null` (line 319: "no entry found; falling back to JSON read") and resurrects the "deleted" credentials from the JSON file. The fallback path was designed for read-time keychain *unavailability*, not for an explicit `clearAccounts`. Combined with the fact that users typically run `clearAccounts` to *recover* from a bad credential set (e.g. leaked token), this is a meaningful failure mode.
+- **Evidence**: The code comment on line 604-607 asserts "a subsequent load would resurrect" exactly this scenario but only considers the inverse ordering.
+- **Fix**: Reverse the order - unlink JSON first, then delete keychain entry. On unlink failure propagate the error (or at least log at `error` and skip keychain delete so callers can retry).
+
+### [MEDIUM] `rollback` silently overwrites a live JSON file when one exists alongside a `.migrated-to-keychain.<ts>` backup
+- **File**: `lib/tools/codex-keychain.ts:188-224`
+- **Issue**: `rollback` calls `clearAccounts()` (line 212) and then `fs.rename(mostRecent, storagePath)` (line 214). `clearAccounts` only unlinks the current JSON inside `try { fs.unlink(path) } catch {}` - if the unlink fails silently, or if a race write has just landed a new JSON at `storagePath`, the subsequent `fs.rename` on POSIX will clobber it without confirmation. On Windows the rename would throw EEXIST and the tool surfaces the error, but the POSIX path is the silent one. User may reasonably expect rollback to be non-destructive of a current live JSON.
+- **Evidence**:
+  ```ts
+  // lib/tools/codex-keychain.ts:212-217
+  await clearAccounts();               // best-effort unlink; failure swallowed
+  try { await fs.rename(mostRecent, storagePath); }  // POSIX overwrite on conflict
+  ```
+- **Fix**: Before `rename`, `fs.access(storagePath)` - if it still exists, either refuse with an explicit error message ("current accounts file already present; move it aside first") or archive it with a `.pre-rollback.<ts>` suffix.
+
+### [MEDIUM] `rollback` backup selection is lexicographic, not timestamp-aware
+- **File**: `lib/tools/codex-keychain.ts:64-77` (`findMigrationBackups`)
+- **Issue**: Backups are named `<path>.migrated-to-keychain.<ISO-ts-with-:-and-.-replaced-by-->` (see `lib/storage/load-save.ts:513`). The sort on line 75 is a bare string comparison (`a < b ? 1 : a > b ? -1 : 0`). For timestamps produced by `new Date().toISOString().replace(/[:.]/g, "-")` this happens to sort correctly *because ISO-8601 is lexicographically ordered when all fields are zero-padded and fixed-width*. However the file header comments promise "fallback to filename sort when the suffix is unparseable so we degrade gracefully" - there is **no** actual timestamp parse + fallback. If the format ever changes (new epoch, locale mishap, test fixture with non-ISO suffix) the rollback picks whatever sorts last alphabetically - which may not be the most recent. Low blast radius today; silent trap on format change.
+- **Evidence**: `lib/tools/codex-keychain.ts:74-75` - no `Date.parse`, no try/catch, doc/code mismatch.
+- **Fix**: Parse the timestamp portion, sort by epoch, fall back to string sort only when parse returns `NaN`. Or tighten the doc comment to state "lexicographic-only sort, relies on ISO-8601 invariant".
+
+### [LOW] Availability probe has a keychain-write side effect that can prompt the user
+- **File**: `lib/storage/keychain.ts:146-163`
+- **Issue**: `isAvailable()` calls `entry.setPassword("probe"); entry.deletePassword();` against the real OS keychain. On macOS the **first-ever** write from a new signed binary can trigger a "allow/always allow" prompt. `codex-keychain status` is advertised as a read-only status command in the docs and tool description, but it actually triggers a write-side-effect on the keychain and may pop a user prompt. This is a UX surprise, not a data-safety issue.
+- **Evidence**: README line 143 + SECURITY.md paragraph describe `status` as reporting reachability; nothing warns that it performs a mutating probe.
+- **Fix**: Either (a) probe with a read-only operation (try `getPassword` on a fixed probe key, treat any non-throw as available) or (b) document the side effect in README / tool description and add a `--no-probe` flag.
+
+### [LOW] Backup file inherits the default umask, not the `0o600` applied to active JSON
+- **File**: `lib/storage/load-save.ts:516` (`fs.rename(path, backup)`)
+- **Issue**: The active JSON is written with `mode: 0o600` via `writeAccountsToPathUnlocked` (line 460). On rename, the file retains its inode/mode, so the `.migrated-to-keychain.<ts>` backup keeps `0o600` at first. However, if a user ever restores via `codex-keychain rollback`, that rename also preserves the mode - but if anyone `cp`'s or manually touches the file between migration and rollback, the restored file may end up world-readable. The code doesn't re-apply `chmod 0o600` after rename on either side.
+- **Evidence**: No `fs.chmod` call in either `migrateOnDiskJsonToKeychainBackup` or the rollback flow.
+- **Fix**: `await fs.chmod(backup, 0o600)` after rename (and again in rollback path). Cheap belt-and-braces for filesystem permission drift.
+
+### [LOW] Availability probe account key is not namespaced to avoid future collision
+- **File**: `lib/storage/keychain.ts:151`
+- **Issue**: The probe uses account `"__availability_probe__"` while real entries use `"accounts:<project-key>"`. No collision today because real keys always have the `accounts:` prefix. Still, a future refactor that drops the prefix could silently corrupt the probe. Worth locking down.
+- **Fix**: Prefix with `__probe:` or include the service name: `__availability_probe__@oc-codex-multi-auth`. Trivially low-risk as-is; flag for hygiene.
+
+### [LOW] `codex-keychain status` probes the keychain even when opt-in is unset
+- **File**: `lib/storage/keychain.ts:269-273` + `lib/tools/codex-keychain.ts:110`
+- **Issue**: `codex-keychain status` calls `keychainIsAvailable()` unconditionally (line 110) - *including when `CODEX_KEYCHAIN` is unset*. If the native module loads successfully on a user's machine with opt-in off, running `codex-keychain status` still writes a probe entry to the OS keychain. The tool description promises opt-in semantics; this creates a tiny, transient keychain entry without opt-in. Not a security issue (entry is deleted immediately) but violates the "unset == no keychain code path" invariant the PR advertises. Note: `saveAccounts` / `loadAccounts` / `clearAccounts` correctly short-circuit on `isKeychainOptInEnabled()`; only the status tool bypasses this gate.
+- **Evidence**: `codex-keychain.ts:110` calls `keychainIsAvailable()` regardless of `optIn`; `optIn` is only read for the `keychainHasEntry` flag (line 111).
+- **Fix**: Skip the probe when `optIn === false` and report "keychain reachable: (not checked; CODEX_KEYCHAIN unset)". Preserves strict opt-in.
+
+### [NIT] Misleading comment about `async` + `require-await` suppressions in the backend wrapper
+- **File**: `lib/storage/keychain.ts:105-112`
+- **Issue**: The comment block says the suppressions exist "to keep intent explicit". Standard approach would be to drop `async` on the methods and rely on the interface declaring `Promise<T>`, or return `Promise.resolve(...)`. The per-method `// eslint-disable-next-line` is noisy. Code-style nit; zero security impact.
+- **Fix**: Drop `async`, return `Promise.resolve(...)` where needed, or rewrap with `(async () => ...)()`.
+
+### [NIT] Test at line 188-203 contains a confused setup that does not test what its title claims
+- **File**: `test/storage-keychain.test.ts:188-203`
+- **Issue**: The test "readFromKeychain returns null when backend is unavailable" sets a mock (!) then calls `readFromKeychain("never-written-key")` and expects `null`. This asserts "mock backend returns null for a missing key", not "backend unavailable" (which would be `cachedBackend === null`). The inline comment acknowledges the confusion ("For this assertion we still need a mock: a null backend would take the 'unavailable' branch"). The null-backend branch at `keychain.ts:211` (`if (!backend) return null`) is therefore **not directly tested**. Coverage-wise it is likely hit by other tests, but the assertion as written is misleading.
+- **Fix**: Split into two tests: (1) mock returns null for missing key; (2) genuinely-unavailable backend (reset + do not inject) returns null. The second needs `_resetBackendForTests` + a way to force `loadNativeBackend` to return `null` (e.g. module mock of `@napi-rs/keyring` via `vi.doMock`).
+
+### [NIT] Dependency caret range on a credential-handling dep
+- **File**: `package.json:99`
+- **Issue**: `"@napi-rs/keyring": "^1.2.0"` allows any 1.x up through 1.999.x. For a package that will exfiltrate the exact bytes of a refresh token to native code, tighter pinning (`~1.2.0` or exact) would reduce supply-chain surface. Integrity is SHA-512-pinned in `package-lock.json` across all 12 platform variants, so the current install is safe — but a fresh `npm install` on a machine without the lockfile would resolve to the newest 1.x.
+- **Fix**: Tighten to `~1.2.0` and gate minor bumps on an explicit review.
+
+## Verdict Rationale
+
+The feature is functionally sound and the default-off guarantee (the primary
+safety invariant) is verified by an explicit regression test
+(`test/storage-keychain.test.ts:382-390`: `expect(mock.calls).toHaveLength(0)`
+after full save -> load roundtrip). No secret material reaches logs, error
+strings, or test fixtures (spot-grep confirms no `eyJ`, `sk-`, or 40+ hex
+outside of redaction-test fixtures). `_setBackendForTests` has zero production
+callers; only the test file imports it. The `@napi-rs/keyring@1.2.0` dependency
+is SHA-512 integrity-pinned in `package-lock.json` across 12 platform variants,
+and the dynamic-import fallback means a missing prebuilt binary degrades
+gracefully to JSON.
+
+The HIGH finding (partial-migration staleness) is a real edge case but
+extremely rare in practice and only becomes user-visible after an opt-in
+toggle - not a revert-worthy blast radius. The MEDIUMs are genuine rough
+edges on the rollback UX and `clearAccounts` ordering. Nothing in this
+review blocks ship; all findings fit in a small follow-up PR.
+
+## Recommended follow-ups
+
+- Small PR #1 (credentials safety): fix HIGH (partial-migration staleness) + the two MEDIUM `clearAccounts` / `rollback` ordering issues together - all three are one-liners in `load-save.ts` and `codex-keychain.ts`.
+- Small PR #2 (hygiene): gate `keychainIsAvailable` on `isKeychainOptInEnabled` (LOW), add `fs.chmod 0o600` post-rename (LOW), namespace the probe account key (LOW).
+- Doc-only: update README / `codex-keychain status` description to reflect that the command may trigger an OS-keychain prompt on first run (macOS), until the probe becomes read-only.
+- Test hardening: replace the confused "unavailable backend returns null" case with a genuine missing-module scenario using `vi.doMock("@napi-rs/keyring", ...)`.
+- Dependency hygiene: tighten `@napi-rs/keyring` range (NIT) and add a dependabot/renovate rule requiring manual review on minor bumps for credential-handling deps.
+
+## Checklist coverage
+
+| Area | Status | Key evidence |
+|---|---|---|
+| A. Opt-in safety | PASS | `isKeychainOptInEnabled` strict `=== "1"`; regression test `test:382-390` asserts `mock.calls.length === 0` |
+| B. Migration safety | PARTIAL | HIGH finding on partial-migration atomicity; rollback path exists |
+| C. Fallback safety | PASS | Every error path falls through to JSON; tested at `test:308-324` |
+| D. Secret leakage | PASS | No raw secrets in log calls; error messages carry native message only; no tokens in test fixtures |
+| E. Backend abstraction integrity | PASS | `_setBackendForTests` has zero production callers (verified via grep) |
+| F. Dependency risk | PASS with NIT | `@napi-rs/keyring@1.2.0`, SHA-512 pinned; caret range could tighten |
+| G. Cross-platform gotchas | PARTIAL | LOW finding on macOS prompt; Linux fallback path correct |
+| H. Account key collision | PASS | `accounts:<project-hash>` format; global uses reserved sentinel |
+| I. Rollback UX | PARTIAL | Two MEDIUMs (clobber + sort correctness) |
+| J. Test quality | PASS with NIT | Baseline regression test is rigorous; one confused test case |
+
+**Finding counts**: HIGH: 1, MEDIUM: 3, LOW: 4, NIT: 3. Total: 11.

--- a/lib/storage/load-save.ts
+++ b/lib/storage/load-save.ts
@@ -500,11 +500,23 @@ async function writeAccountsToPathUnlocked(path: string, storage: AccountStorage
  * `.migrated-to-keychain.<ts>` suffix instead of deleting it. Preserving the
  * original file as a rollback artefact is load-bearing: it is the user's
  * explicit escape hatch if the keychain backend turns out to be unreliable
- * on their platform. Failure to rename is logged and swallowed because the
- * authoritative copy now lives in the keychain; a missed rename means at
- * worst a duplicate JSON file on disk.
+ * on their platform.
+ *
+ * Atomicity across a partial migration window (F1 post-merge HIGH finding):
+ * if the rename fails (EACCES, EBUSY on Windows, disk full, parent dir
+ * permission drift) the file at `path` would otherwise hold a stale-but-valid
+ * V3 blob while the keychain holds the authoritative fresh blob. This is
+ * safe while the opt-in is on (keychain wins at load time) but silently
+ * resurrects stale credentials if the user later unsets `CODEX_KEYCHAIN`.
+ * We resolve this by overwriting the file with the fresh normalized blob
+ * when the rename fails so both sides agree, at the cost of losing that
+ * one rollback artefact. This matches the "rollback invariant" documented
+ * in the F1 post-merge review (option (a)).
  */
-async function migrateOnDiskJsonToKeychainBackup(path: string): Promise<void> {
+async function migrateOnDiskJsonToKeychainBackup(
+  path: string,
+  freshStorage: AccountStorageV3,
+): Promise<void> {
   try {
     await fs.access(path);
   } catch {
@@ -519,10 +531,28 @@ async function migrateOnDiskJsonToKeychainBackup(path: string): Promise<void> {
       backup,
     });
   } catch (err) {
-    log.warn("keychain: failed to rename on-disk JSON after successful keychain write", {
-      path,
-      error: String(err),
-    });
+    log.warn(
+      "keychain: failed to rename on-disk JSON after successful keychain write; overwriting on-disk copy with fresh blob to prevent stale-rollback-on-opt-out",
+      {
+        path,
+        error: String(err),
+      },
+    );
+    try {
+      await writeAccountsToPathUnlocked(path, freshStorage);
+    } catch (writeErr) {
+      // Last-resort: on-disk refresh also failed. The keychain still
+      // holds the authoritative blob so current operation succeeds, but
+      // a subsequent opt-in toggle off would now surface the stale
+      // file. Log at error so the operator can reconcile manually.
+      log.error(
+        "keychain: failed to refresh stale on-disk JSON after rename failure; opt-in toggle off may surface stale credentials",
+        {
+          path,
+          error: String(writeErr),
+        },
+      );
+    }
   }
 }
 
@@ -542,7 +572,7 @@ async function saveAccountsUnlocked(storage: AccountStorageV3): Promise<void> {
     const projectKey = getCurrentProjectStorageKey();
     const result = await writeToKeychain(projectKey, blob);
     if (result.ok) {
-      await migrateOnDiskJsonToKeychainBackup(getStoragePath());
+      await migrateOnDiskJsonToKeychainBackup(getStoragePath(), normalizedStorage);
       return;
     }
     log.warn("keychain: write failed; falling back to JSON for this save", {
@@ -598,14 +628,43 @@ export async function saveAccounts(storage: AccountStorageV3): Promise<void> {
 /**
  * Deletes the account storage file from disk.
  * Silently ignores if file doesn't exist.
+ *
+ * Ordering (F1 post-merge MEDIUM finding): unlink the on-disk JSON FIRST,
+ * then delete the keychain entry. If we cleared the keychain first and the
+ * unlink failed for a non-ENOENT reason (EACCES, EBUSY, filesystem drift),
+ * a subsequent load with opt-in still on would take the "no keychain entry,
+ * fall back to JSON" branch (see `loadAccountsInternal`) and resurrect the
+ * credentials from the still-present JSON file. Callers typically run
+ * `clearAccounts` to recover from a compromised token, so a silent
+ * resurrection is a meaningful failure mode.
+ *
+ * Fail-safe invariant: if the JSON unlink fails (non-ENOENT), we skip the
+ * keychain delete and log at `error`. Both copies remain in sync so the
+ * caller can retry safely. The operation is still best-effort (never
+ * throws) to preserve the existing contract above the storage layer.
  */
 export async function clearAccounts(): Promise<void> {
   return withStorageLock(async () => {
-    // Clear the keychain entry as well when the opt-in backend is active,
-    // otherwise a subsequent load would resurrect the "deleted" accounts
-    // from the keychain copy. Failures here are non-fatal: a stale
-    // keychain entry is cleaned up on the next successful write.
-    if (isKeychainOptInEnabled()) {
+    let jsonCleared = true;
+    try {
+      const path = getStoragePath();
+      await fs.unlink(path);
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code !== "ENOENT") {
+        jsonCleared = false;
+        log.error(
+          "Failed to clear account storage; skipping keychain delete to keep storage sides in sync. Caller should retry.",
+          { error: String(error) },
+        );
+      }
+    }
+
+    // Only delete the keychain entry after the on-disk copy is gone (or
+    // was already absent). This preserves atomicity-enough semantics: a
+    // partial failure leaves both sides present rather than clearing
+    // one side and letting a subsequent load rehydrate from the other.
+    if (jsonCleared && isKeychainOptInEnabled()) {
       try {
         const projectKey = getCurrentProjectStorageKey();
         await deleteFromKeychain(projectKey);
@@ -613,15 +672,6 @@ export async function clearAccounts(): Promise<void> {
         log.warn("keychain: delete during clearAccounts failed", {
           error: String(err),
         });
-      }
-    }
-    try {
-      const path = getStoragePath();
-      await fs.unlink(path);
-    } catch (error) {
-      const code = (error as NodeJS.ErrnoException).code;
-      if (code !== "ENOENT") {
-        log.error("Failed to clear account storage", { error: String(error) });
       }
     }
   });

--- a/lib/tools/codex-keychain.ts
+++ b/lib/tools/codex-keychain.ts
@@ -58,8 +58,20 @@ function normalizeSubcommand(raw: string | undefined): Subcommand {
 
 /**
  * List `<path>.migrated-to-keychain.<ts>` siblings of the current storage
- * path, sorted most-recent first by the embedded timestamp (fallback to
- * filename sort when the suffix is unparseable so we degrade gracefully).
+ * path, sorted most-recent first by `fs.stat().mtimeMs` (F1 post-merge
+ * MEDIUM finding). The previous implementation sorted the filenames
+ * lexicographically, which happens to produce the correct order when all
+ * filenames share the fixed-width ISO-8601 suffix
+ * (`YYYY-MM-DDTHH-MM-SS-mmmZ`) emitted by `migrateOnDiskJsonToKeychainBackup`
+ * in `lib/storage/load-save.ts`. Any format drift (locale epoch, test
+ * fixture with non-ISO suffix, future migration-suffix change) silently
+ * picks the alphabetically-last entry instead of the most-recent. Sorting
+ * by `mtimeMs` is format-independent and matches "most recent backup"
+ * exactly. The filename tiebreaker (rare: identical mtime) preserves the
+ * previous descending-lex behaviour so the function stays deterministic.
+ *
+ * Exported as `_findMigrationBackupsForTests` below so the sort order can
+ * be asserted without stubbing the tool closure.
  */
 async function findMigrationBackups(storagePath: string): Promise<string[]> {
 	const dir = dirname(storagePath);
@@ -72,8 +84,37 @@ async function findMigrationBackups(storagePath: string): Promise<string[]> {
 		return [];
 	}
 	const matches = entries.filter((name) => name.startsWith(prefix));
-	matches.sort((a, b) => (a < b ? 1 : a > b ? -1 : 0));
-	return matches.map((name) => join(dir, name));
+	const withMtime = await Promise.all(
+		matches.map(async (name) => {
+			const full = join(dir, name);
+			let mtimeMs = Number.NEGATIVE_INFINITY;
+			try {
+				const st = await fs.stat(full);
+				mtimeMs = st.mtimeMs;
+			} catch {
+				// Stat failure: keep -Infinity so the entry sorts last.
+				// This protects against a backup that disappeared between
+				// readdir and stat (race) without crashing the tool.
+			}
+			return { full, name, mtimeMs };
+		}),
+	);
+	withMtime.sort((a, b) => {
+		if (b.mtimeMs !== a.mtimeMs) return b.mtimeMs - a.mtimeMs;
+		return a.name < b.name ? 1 : a.name > b.name ? -1 : 0;
+	});
+	return withMtime.map((entry) => entry.full);
+}
+
+/**
+ * Test-only export for `findMigrationBackups`. Kept separate from the
+ * tool factory so the sort semantics can be asserted directly against a
+ * temp directory in `test/tools-codex-keychain.test.ts`.
+ */
+export async function _findMigrationBackupsForTests(
+	storagePath: string,
+): Promise<string[]> {
+	return findMigrationBackups(storagePath);
 }
 
 export function createCodexKeychainTool(ctx: ToolContext): ToolDefinition {
@@ -84,7 +125,7 @@ export function createCodexKeychainTool(ctx: ToolContext): ToolDefinition {
 	const { resolveUiRuntime } = ctx;
 	return tool({
 		description:
-			"Inspect and manage the opt-in OS-keychain credential backend. Subcommands: status (default), migrate, rollback.",
+			"Inspect and manage the opt-in OS-keychain credential backend. Subcommands: status (default), migrate, rollback. Rollback requires confirm=true when a current accounts JSON file exists alongside the backup (safety gate).",
 		args: {
 			command: tool.schema
 				.string()
@@ -92,8 +133,20 @@ export function createCodexKeychainTool(ctx: ToolContext): ToolDefinition {
 				.describe(
 					'Subcommand: "status" (default), "migrate", or "rollback".',
 				),
+			confirm: tool.schema
+				.boolean()
+				.optional()
+				.describe(
+					"rollback only: pass true to archive any current accounts JSON as `.pre-rollback.<ts>` before restoring the backup. Without confirm=true, rollback refuses if a current file exists.",
+				),
 		},
-		async execute({ command }: { command?: string }) {
+		async execute({
+			command,
+			confirm,
+		}: {
+			command?: string;
+			confirm?: boolean;
+		}) {
 			const ui = resolveUiRuntime();
 			const sub = normalizeSubcommand(command);
 			const optIn = isKeychainOptInEnabled();
@@ -210,6 +263,42 @@ export function createCodexKeychainTool(ctx: ToolContext): ToolDefinition {
 			// the backup back to the canonical storage path so the next load
 			// reads from disk again. clearAccounts handles both sides.
 			await clearAccounts();
+
+			// Silent-clobber guard (F1 post-merge MEDIUM finding). On POSIX,
+			// `fs.rename(backup, storagePath)` silently overwrites an
+			// existing destination. If `clearAccounts` failed to unlink the
+			// current JSON (EACCES/EBUSY) or a race write landed a new file
+			// between clearAccounts and rename, the user's current accounts
+			// would be silently discarded with no way to recover them.
+			// Require explicit `confirm=true` before overwriting; without
+			// it, refuse and surface the offending path.
+			let currentExists = false;
+			try {
+				await fs.access(storagePath);
+				currentExists = true;
+			} catch {
+				/* canonical path is clear; safe to rename */
+			}
+			let preRollbackArchive: string | null = null;
+			if (currentExists) {
+				if (!confirm) {
+					return [
+						`codex-keychain rollback: refusing to overwrite existing accounts file at ${storagePath}.`,
+						`Backup at ${mostRecent} was not restored.`,
+						"Pass confirm=true to archive the current file as .pre-rollback.<timestamp> and proceed, or move the current file aside and re-run.",
+					].join("\n");
+				}
+				const archiveSuffix = new Date()
+					.toISOString()
+					.replace(/[:.]/g, "-");
+				preRollbackArchive = `${storagePath}.pre-rollback.${archiveSuffix}`;
+				try {
+					await fs.rename(storagePath, preRollbackArchive);
+				} catch (err) {
+					return `codex-keychain rollback: failed to archive current accounts file at ${storagePath} -> ${preRollbackArchive}: ${(err as Error).message}. Backup at ${mostRecent} was not restored.`;
+				}
+			}
+
 			try {
 				await fs.rename(mostRecent, storagePath);
 			} catch (err) {
@@ -223,7 +312,7 @@ export function createCodexKeychainTool(ctx: ToolContext): ToolDefinition {
 				/* already deleted by clearAccounts */
 			}
 
-			return [
+			const lines: string[] = [
 				...formatUiHeader(ui, "Codex keychain rollback"),
 				"",
 				formatUiItem(
@@ -231,11 +320,23 @@ export function createCodexKeychainTool(ctx: ToolContext): ToolDefinition {
 					`Restored ${accountCount} account(s) from backup ${mostRecent}.`,
 				),
 				formatUiKeyValue(ui, "Active file", storagePath),
+			];
+			if (preRollbackArchive) {
+				lines.push(
+					formatUiKeyValue(
+						ui,
+						"Previous file archived at",
+						preRollbackArchive,
+					),
+				);
+			}
+			lines.push(
 				formatUiItem(
 					ui,
 					"To stop using the keychain backend, unset CODEX_KEYCHAIN (or set it to any value other than \"1\") before the next save.",
 				),
-			].join("\n");
+			);
+			return lines.join("\n");
 		},
 	});
 }

--- a/test/storage-keychain.test.ts
+++ b/test/storage-keychain.test.ts
@@ -333,6 +333,131 @@ describe("load-save integration with CODEX_KEYCHAIN", () => {
 		expect(existsSync(storagePath)).toBe(false);
 	});
 
+	// --- F1 post-merge review regression tests -----------------------------------
+	// Each test below is named against the finding it covers so the next
+	// reviewer can trace test -> review ledger without code archaeology.
+	// See docs/audits/_meta/f1-post-merge-review.md.
+
+	it("[HIGH] does not resurrect stale JSON after opt-in toggle off when backup rename fails", async () => {
+		// Seed: opt-in off, write a "stale" blob to the on-disk JSON. This
+		// is what an existing JSON-only user looks like before they flip
+		// CODEX_KEYCHAIN=1.
+		setOptIn(false);
+		const stale = makeStorage();
+		stale.accounts[0]!.accountId = "acct-stale";
+		await saveAccounts(stale);
+		expect(existsSync(storagePath)).toBe(true);
+
+		// Flip opt-in on. Force ONLY the backup rename to fail with a
+		// non-ENOENT error. The subsequent fallback write
+		// (writeAccountsToPathUnlocked) still needs a working fs.rename
+		// to complete its temp-file swap, so we intercept exactly one
+		// call with mockImplementationOnce.
+		setOptIn(true);
+		const renameSpy = vi
+			.spyOn(fs, "rename")
+			.mockImplementationOnce(async () => {
+				throw Object.assign(new Error("simulated EACCES on backup rename"), {
+					code: "EACCES",
+				});
+			});
+		try {
+			const fresh = makeStorage();
+			fresh.accounts[0]!.accountId = "acct-fresh";
+			await saveAccounts(fresh);
+		} finally {
+			renameSpy.mockRestore();
+		}
+
+		// Keychain holds the authoritative fresh blob.
+		const stored = mock.store.get(
+			`${KEYCHAIN_SERVICE_NAME}::${GLOBAL_KEYCHAIN_ACCOUNT_KEY}`,
+		);
+		expect(stored).toBeDefined();
+		expect(JSON.parse(stored!).accounts[0].accountId).toBe("acct-fresh");
+
+		// On-disk JSON still exists (backup rename failed) BUT its
+		// contents have been refreshed with the fresh blob. If the user
+		// now unsets CODEX_KEYCHAIN, loadAccounts reads from this file
+		// and sees "acct-fresh", not "acct-stale" — the HIGH-finding
+		// guarantee.
+		expect(existsSync(storagePath)).toBe(true);
+		const onDisk = JSON.parse(
+			await fs.readFile(storagePath, "utf-8"),
+		) as AccountStorageV3;
+		expect(onDisk.accounts[0]!.accountId).toBe("acct-fresh");
+	});
+
+	it("[MEDIUM] clearAccounts skips keychain delete if JSON unlink fails (keeps sides in sync)", async () => {
+		// Seed: opt-in on, write storage so BOTH sides hold the blob.
+		setOptIn(true);
+		await saveAccounts(makeStorage());
+		expect(mock.store.size).toBe(1);
+		// saveAccounts under opt-in renames the on-disk JSON into a backup
+		// immediately after the keychain write, so the canonical path is
+		// absent. We write a fresh JSON back in place to simulate a user
+		// who has both the keychain entry and an on-disk file (e.g. a
+		// race write that landed between rotation saves).
+		await fs.writeFile(
+			storagePath,
+			JSON.stringify(makeStorage(), null, 2),
+			{ encoding: "utf-8", mode: 0o600 },
+		);
+		expect(existsSync(storagePath)).toBe(true);
+
+		// Force unlink to throw EBUSY once. After the fix, clearAccounts
+		// should NOT delete the keychain entry so both sides remain in
+		// sync (caller can retry later). Before the fix, the keychain
+		// delete ran first and would have wiped the blob; a subsequent
+		// load with opt-in still on would then resurrect the credentials
+		// from the unlinkable JSON file.
+		const unlinkSpy = vi
+			.spyOn(fs, "unlink")
+			.mockImplementationOnce(async () => {
+				throw Object.assign(new Error("simulated EBUSY on unlink"), {
+					code: "EBUSY",
+				});
+			});
+		try {
+			await expect(clearAccounts()).resolves.toBeUndefined();
+		} finally {
+			unlinkSpy.mockRestore();
+		}
+
+		// Keychain blob survives because the unlink-first ordering skipped
+		// the keychain delete when the unlink failed.
+		expect(mock.store.size).toBe(1);
+		const stored = mock.store.get(
+			`${KEYCHAIN_SERVICE_NAME}::${GLOBAL_KEYCHAIN_ACCOUNT_KEY}`,
+		);
+		expect(stored).toBeDefined();
+
+		// No delete-op against the keychain was issued during the failed
+		// clearAccounts call.
+		const deleteCalls = mock.calls.filter(
+			(c) => c.op === "delete" && c.account === GLOBAL_KEYCHAIN_ACCOUNT_KEY,
+		);
+		expect(deleteCalls).toHaveLength(0);
+	});
+
+	it("[MEDIUM] clearAccounts unlinks JSON first, then keychain, in the happy path", async () => {
+		// Order check: the JSON file must be gone BEFORE the keychain
+		// delete runs. We can't directly observe fs.unlink timing without
+		// a spy, so verify the recorded keychain ops show delete occurred
+		// and the on-disk file is absent at call completion.
+		setOptIn(true);
+		await saveAccounts(makeStorage());
+
+		await clearAccounts();
+
+		expect(existsSync(storagePath)).toBe(false);
+		expect(mock.store.size).toBe(0);
+		const deleteCalls = mock.calls.filter(
+			(c) => c.op === "delete" && c.account === GLOBAL_KEYCHAIN_ACCOUNT_KEY,
+		);
+		expect(deleteCalls).toHaveLength(1);
+	});
+
 	it("corrupt keychain payload falls back to JSON read", async () => {
 		setOptIn(true);
 		// Pre-seed a valid on-disk JSON file.

--- a/test/tools-codex-keychain.test.ts
+++ b/test/tools-codex-keychain.test.ts
@@ -1,0 +1,368 @@
+/**
+ * Tests for `codex-keychain` tool rollback UX (F1 post-merge review).
+ *
+ * Covers two MEDIUM findings:
+ *   - Rollback must not silently clobber a live JSON file when one exists
+ *     alongside a `.migrated-to-keychain.<ts>` backup (`confirm`-flag gate).
+ *   - `findMigrationBackups` must sort by `mtimeMs`, not filename
+ *     lexicographically, so timestamp-format drift cannot pick the wrong
+ *     backup.
+ *
+ * The low-level keychain backend and load/save integration are covered in
+ * `test/storage-keychain.test.ts`; this file intentionally focuses on the
+ * tool surface and the backup-selection helper.
+ */
+
+import { promises as fs, existsSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+	_findMigrationBackupsForTests,
+	createCodexKeychainTool,
+} from "../lib/tools/codex-keychain.js";
+import type { ToolContext } from "../lib/tools/index.js";
+import type { UiRuntimeOptions } from "../lib/ui/runtime.js";
+import {
+	_resetBackendForTests,
+	_setBackendForTests,
+	KEYCHAIN_SERVICE_NAME,
+	GLOBAL_KEYCHAIN_ACCOUNT_KEY,
+	type KeychainBackend,
+} from "../lib/storage/keychain.js";
+import { setStoragePathDirect } from "../lib/storage/state.js";
+import type { AccountStorageV3 } from "../lib/storage.js";
+
+// -----------------------------------------------------------------------------
+// Shared fixtures
+// -----------------------------------------------------------------------------
+
+interface MockBackend extends KeychainBackend {
+	store: Map<string, string>;
+	calls: Array<{ op: string; service: string; account: string }>;
+}
+
+function createMockBackend(): MockBackend {
+	const store = new Map<string, string>();
+	const calls: MockBackend["calls"] = [];
+	const backend: MockBackend = {
+		store,
+		calls,
+		async get(service, account) {
+			calls.push({ op: "get", service, account });
+			return store.get(`${service}::${account}`) ?? null;
+		},
+		async set(service, account, secret) {
+			calls.push({ op: "set", service, account });
+			store.set(`${service}::${account}`, secret);
+		},
+		async delete(service, account) {
+			calls.push({ op: "delete", service, account });
+			return store.delete(`${service}::${account}`);
+		},
+		async isAvailable() {
+			calls.push({
+				op: "isAvailable",
+				service: KEYCHAIN_SERVICE_NAME,
+				account: "__availability_probe__",
+			});
+			return true;
+		},
+	};
+	return backend;
+}
+
+/**
+ * Minimal UiRuntimeOptions with `v2Enabled: false` so the format helpers
+ * degrade to plain strings without needing the full theme/color plumbing.
+ * The rollback tool's output is assertion-friendly in this mode.
+ */
+function plainUiRuntime(): UiRuntimeOptions {
+	return {
+		v2Enabled: false,
+		colorEnabled: false,
+		theme: {
+			colors: {
+				heading: "",
+				accent: "",
+				muted: "",
+				success: "",
+				warning: "",
+				danger: "",
+				reset: "",
+			},
+			glyphs: { bullet: "-" },
+		},
+	} as unknown as UiRuntimeOptions;
+}
+
+function buildCtx(): ToolContext {
+	const ctx = {
+		resolveUiRuntime: () => plainUiRuntime(),
+	};
+	return ctx as unknown as ToolContext;
+}
+
+function makeStorage(): AccountStorageV3 {
+	return {
+		version: 3,
+		activeIndex: 0,
+		accounts: [
+			{
+				refreshToken: "refresh-token-redacted",
+				accountId: "acct-1",
+				addedAt: 1,
+				lastUsed: 2,
+			},
+		],
+	};
+}
+
+const ORIGINAL_CODEX_KEYCHAIN = process.env.CODEX_KEYCHAIN;
+
+async function allocateStorageDir(): Promise<string> {
+	const dir = join(
+		tmpdir(),
+		`keychain-tool-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+	);
+	await fs.mkdir(dir, { recursive: true });
+	return dir;
+}
+
+// -----------------------------------------------------------------------------
+// Fix 4: findMigrationBackups mtime-aware sort
+// -----------------------------------------------------------------------------
+
+describe("findMigrationBackups (F1 MEDIUM: mtime-aware sort)", () => {
+	let storageDir: string;
+	let storagePath: string;
+
+	beforeEach(async () => {
+		storageDir = await allocateStorageDir();
+		storagePath = join(storageDir, "accounts.json");
+	});
+
+	afterEach(async () => {
+		try {
+			await fs.rm(storageDir, { recursive: true, force: true });
+		} catch {
+			/* ignore */
+		}
+	});
+
+	it("returns most-recent backup first based on mtimeMs, not lexicographic filename", async () => {
+		// Create two backup files whose NAMES sort in the opposite order
+		// from their MTIMES. Before the fix, the lexicographic sort picks
+		// the newer name; after the fix, the older mtime wins regardless
+		// of filename format.
+		const olderNameNewerMtime = `${storagePath}.migrated-to-keychain.zzz-legacy-format`;
+		const newerNameOlderMtime = `${storagePath}.migrated-to-keychain.2024-01-01T00-00-00-000Z`;
+
+		await fs.writeFile(olderNameNewerMtime, "{}", "utf-8");
+		await fs.writeFile(newerNameOlderMtime, "{}", "utf-8");
+
+		// Force mtimes: newer-mtime file is `olderNameNewerMtime`, older
+		// mtime is `newerNameOlderMtime`. fs.utimes takes seconds.
+		const newer = Math.floor(Date.now() / 1000);
+		const older = newer - 60 * 60; // 1 hour earlier
+		await fs.utimes(olderNameNewerMtime, newer, newer);
+		await fs.utimes(newerNameOlderMtime, older, older);
+
+		const result = await _findMigrationBackupsForTests(storagePath);
+		expect(result).toHaveLength(2);
+		// Most recent by mtime comes first.
+		expect(result[0]).toBe(olderNameNewerMtime);
+		expect(result[1]).toBe(newerNameOlderMtime);
+	});
+
+	it("falls back to descending filename sort on mtime tie (deterministic)", async () => {
+		// Identical mtimes -> tiebreak by reverse filename order for
+		// determinism. Matches the documented pre-fix behaviour for the
+		// normal ISO-8601 case.
+		const backupA = `${storagePath}.migrated-to-keychain.2024-06-15T10-00-00-000Z`;
+		const backupB = `${storagePath}.migrated-to-keychain.2024-06-15T11-00-00-000Z`;
+		await fs.writeFile(backupA, "{}", "utf-8");
+		await fs.writeFile(backupB, "{}", "utf-8");
+		const t = Math.floor(Date.now() / 1000);
+		await fs.utimes(backupA, t, t);
+		await fs.utimes(backupB, t, t);
+
+		const result = await _findMigrationBackupsForTests(storagePath);
+		expect(result[0]).toBe(backupB);
+		expect(result[1]).toBe(backupA);
+	});
+
+	it("returns empty array when the directory does not exist", async () => {
+		const phantom = join(storageDir, "nope", "nothing.json");
+		const result = await _findMigrationBackupsForTests(phantom);
+		expect(result).toEqual([]);
+	});
+});
+
+// -----------------------------------------------------------------------------
+// Fix 3: rollback silent-clobber guard (confirm=true required)
+// -----------------------------------------------------------------------------
+
+describe("codex-keychain rollback (F1 MEDIUM: confirm-flag clobber gate)", () => {
+	let storageDir: string;
+	let storagePath: string;
+	let mock: MockBackend;
+
+	beforeEach(async () => {
+		_resetBackendForTests();
+		mock = createMockBackend();
+		_setBackendForTests(mock);
+		storageDir = await allocateStorageDir();
+		storagePath = join(storageDir, "accounts.json");
+		setStoragePathDirect(storagePath);
+		// Opt-in on so clearAccounts targets both sides.
+		process.env.CODEX_KEYCHAIN = "1";
+	});
+
+	afterEach(async () => {
+		setStoragePathDirect(null);
+		_resetBackendForTests();
+		if (ORIGINAL_CODEX_KEYCHAIN === undefined) {
+			delete process.env.CODEX_KEYCHAIN;
+		} else {
+			process.env.CODEX_KEYCHAIN = ORIGINAL_CODEX_KEYCHAIN;
+		}
+		try {
+			await fs.rm(storageDir, { recursive: true, force: true });
+		} catch {
+			/* ignore */
+		}
+	});
+
+	async function seedBackup(accountId: string): Promise<string> {
+		const backupPath = `${storagePath}.migrated-to-keychain.2024-06-15T10-00-00-000Z`;
+		const body: AccountStorageV3 = makeStorage();
+		body.accounts[0]!.accountId = accountId;
+		await fs.writeFile(
+			backupPath,
+			JSON.stringify(body, null, 2),
+			"utf-8",
+		);
+		return backupPath;
+	}
+
+	async function seedCurrentJson(accountId: string): Promise<void> {
+		const body: AccountStorageV3 = makeStorage();
+		body.accounts[0]!.accountId = accountId;
+		await fs.writeFile(
+			storagePath,
+			JSON.stringify(body, null, 2),
+			"utf-8",
+		);
+	}
+
+	it("refuses to clobber a current JSON file without confirm=true", async () => {
+		await seedBackup("from-backup");
+		await seedCurrentJson("current-live");
+
+		// Simulate a race where clearAccounts cannot unlink the live file
+		// by making fs.unlink throw once. After the fix, the post-clear
+		// access check sees the file is still present and refuses rather
+		// than silently clobbering it via fs.rename on POSIX.
+		const { promises: fsp } = await import("node:fs");
+		const { vi } = await import("vitest");
+		const unlinkSpy = vi
+			.spyOn(fsp, "unlink")
+			.mockImplementationOnce(async () => {
+				throw Object.assign(new Error("simulated EACCES"), {
+					code: "EACCES",
+				});
+			});
+
+		try {
+			const t = createCodexKeychainTool(buildCtx());
+			const out = (await t.execute(
+				{ command: "rollback" },
+				{} as never,
+			)) as string;
+			expect(out).toMatch(/refusing to overwrite/i);
+			expect(out).toContain(storagePath);
+			expect(out).toMatch(/confirm=true/);
+		} finally {
+			unlinkSpy.mockRestore();
+		}
+
+		// Current JSON is untouched.
+		expect(existsSync(storagePath)).toBe(true);
+		const stillCurrent = JSON.parse(
+			await fs.readFile(storagePath, "utf-8"),
+		) as AccountStorageV3;
+		expect(stillCurrent.accounts[0]!.accountId).toBe("current-live");
+	});
+
+	it("archives the live JSON with .pre-rollback.<ts> suffix when confirm=true", async () => {
+		await seedBackup("from-backup");
+		await seedCurrentJson("current-live");
+
+		// Prevent unlink inside clearAccounts from clearing the live
+		// file so the archive path is exercised. Otherwise clearAccounts
+		// would succeed and there would be nothing to archive.
+		const { promises: fsp } = await import("node:fs");
+		const { vi } = await import("vitest");
+		const unlinkSpy = vi
+			.spyOn(fsp, "unlink")
+			.mockImplementationOnce(async () => {
+				throw Object.assign(new Error("simulated EACCES"), {
+					code: "EACCES",
+				});
+			});
+
+		let out: string;
+		try {
+			const t = createCodexKeychainTool(buildCtx());
+			out = (await t.execute(
+				{ command: "rollback", confirm: true },
+				{} as never,
+			)) as string;
+		} finally {
+			unlinkSpy.mockRestore();
+		}
+
+		expect(out).toMatch(/Restored/);
+		expect(out).toMatch(/pre-rollback\./);
+
+		// The canonical storage path now holds the restored backup
+		// contents; the previous live file was archived side-by-side.
+		const active = JSON.parse(
+			await fs.readFile(storagePath, "utf-8"),
+		) as AccountStorageV3;
+		expect(active.accounts[0]!.accountId).toBe("from-backup");
+
+		const entries = await fs.readdir(storageDir);
+		const archived = entries.find((name) =>
+			name.includes(".pre-rollback."),
+		);
+		expect(archived).toBeDefined();
+		const archivedBody = JSON.parse(
+			await fs.readFile(join(storageDir, archived!), "utf-8"),
+		) as AccountStorageV3;
+		expect(archivedBody.accounts[0]!.accountId).toBe("current-live");
+	});
+
+	it("normal rollback (no current file present) still succeeds without confirm=true", async () => {
+		// Sanity regression: the confirm gate must NOT break the common
+		// case where clearAccounts correctly unlinks the live file before
+		// the rename runs.
+		await seedBackup("from-backup");
+		// No seedCurrentJson call — canonical path starts empty.
+
+		const t = createCodexKeychainTool(buildCtx());
+		const out = (await t.execute(
+			{ command: "rollback" },
+			{} as never,
+		)) as string;
+		expect(out).toMatch(/Restored/);
+		expect(out).not.toMatch(/refusing/i);
+
+		const active = JSON.parse(
+			await fs.readFile(storagePath, "utf-8"),
+		) as AccountStorageV3;
+		expect(active.accounts[0]!.accountId).toBe("from-backup");
+	});
+});


### PR DESCRIPTION
## Summary

Follow-up to merged PR #132 (F1 OS-keychain opt-in backend). The oracle post-merge review at `docs/audits/_meta/f1-post-merge-review.md` flagged **1 HIGH + 3 MEDIUM + 4 LOW + 3 NIT**. This PR addresses the **HIGH + 3 MEDIUM**. The 4 LOW and 3 NIT are deferred (tracked below).

## HIGH — stale JSON resurrection across opt-in toggle

**File**: `lib/storage/load-save.ts` (`migrateOnDiskJsonToKeychainBackup` + `saveAccountsUnlocked`)

**Fix**: When the keychain write succeeds but the subsequent `fs.rename` of the on-disk JSON to its `.migrated-to-keychain.<ts>` backup fails, we now overwrite the on-disk file with the fresh normalized blob via `writeAccountsToPathUnlocked`. Previously a failed rename left the on-disk file holding stale V3 content; the keychain-backed load still saw fresh data (keychain wins), but if the user later unset `CODEX_KEYCHAIN` the stale on-disk file would silently resurrect as the authoritative source. The fix makes both sides converge even in the partial-migration window.

**Test**: `[HIGH] does not resurrect stale JSON after opt-in toggle off when backup rename fails` in `test/storage-keychain.test.ts`. Seeds a stale on-disk JSON, flips opt-in on, forces the first `fs.rename` call to throw EACCES, and asserts the on-disk file now contains the fresh `acct-fresh` blob rather than the original `acct-stale` blob.

## MEDIUM — `clearAccounts` ordering

**File**: `lib/storage/load-save.ts` (`clearAccounts`)

**Fix**: Reversed the ordering so the on-disk JSON is unlinked first, then the keychain entry is deleted. If the unlink fails for a non-ENOENT reason the keychain delete is skipped so both sides remain present for a safe retry. Previously the keychain was deleted first; a subsequent load with opt-in still on took the fall-back-to-JSON branch and resurrected the "cleared" credentials from the still-present JSON file.

**Tests**:
- `[MEDIUM] clearAccounts skips keychain delete if JSON unlink fails (keeps sides in sync)`
- `[MEDIUM] clearAccounts unlinks JSON first, then keychain, in the happy path`

## MEDIUM — rollback silent clobber of live JSON

**File**: `lib/tools/codex-keychain.ts` (rollback execute path)

**Fix**: Added a new `confirm` boolean arg. After `clearAccounts`, we `fs.access` the canonical storage path; if a live file still exists (clearAccounts unlink failed, or a race write landed between unlink and rename), rollback refuses to proceed without `confirm=true` and surfaces the offending path. With `confirm=true`, the live file is archived with a `.pre-rollback.<ts>` suffix before the backup is renamed into place. Previously the POSIX `fs.rename` would silently overwrite the live file.

**Tests** in `test/tools-codex-keychain.test.ts`:
- `refuses to clobber a current JSON file without confirm=true`
- `archives the live JSON with .pre-rollback.<ts> suffix when confirm=true`
- `normal rollback (no current file present) still succeeds without confirm=true` (regression guard)

## MEDIUM — rollback backup selection sort

**File**: `lib/tools/codex-keychain.ts` (`findMigrationBackups`)

**Fix**: Replaced the lexicographic filename sort with a numeric sort on `fs.stat().mtimeMs` (tiebreak: descending filename for determinism). The previous sort happened to be correct for the ISO-8601 timestamp suffix currently emitted, but silently picked the wrong backup for any format drift. Exported a test-only `_findMigrationBackupsForTests` helper so the order can be asserted without stubbing the tool closure.

**Tests**:
- `returns most-recent backup first based on mtimeMs, not lexicographic filename`
- `falls back to descending filename sort on mtime tie (deterministic)`
- `returns empty array when the directory does not exist`

## Deferred (tracked in review file)

4 LOW + 3 NIT findings deferred as non-blocking per the review rationale. Full details in `docs/audits/_meta/f1-post-merge-review.md`. Summary:

- **LOW** macOS first-run prompt on status probe (write-side-effect in `isAvailable`).
- **LOW** `chmod 0o600` not re-applied after rename to backup/restore.
- **LOW** availability probe account key not namespaced under `__probe:`.
- **LOW** `codex-keychain status` probes the keychain even when opt-in is unset.
- **NIT** `async` + `require-await` suppressions in the backend wrapper.
- **NIT** confused unavailable-backend test case at `test:188-203`.
- **NIT** caret range on `@napi-rs/keyring` credential dep.

## Audit refs

- `docs/audits/_meta/f1-post-merge-review.md` (committed in this PR).
- Follow-up to PR #132 (`ae75093` on `main`).

## Verification

| check | result |
|---|---|
| `npm run typecheck` | pass |
| `npm run lint` | pass |
| `npm test` | **2229 passed** (2220 baseline + 9 new) |
| `npm run build` | pass |

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---


<h3>Greptile Summary</h3>

addresses four post-merge findings from PR #132: the HIGH stale-JSON resurrection (overwrite on-disk with fresh blob when backup rename fails), the `clearAccounts` ordering flip (unlink JSON before keychain delete), the rollback clobber guard (`confirm=true` required when a live file exists alongside the backup), and the mtime-aware backup sort. the `load-save.ts` fixes are solid and well-tested.

one issue in the rollback execute path: when `confirm=true` successfully archives the live accounts file to `.pre-rollback.<ts>` but the subsequent backup rename fails (realistic on windows with EBUSY), the returned error string omits `preRollbackArchive` — the user has no way to locate their now-displaced accounts file.

<h3>Confidence Score: 4/5</h3>

safe to merge after fixing the missing preRollbackArchive path in the partial-rollback error message — one-line fix before the P1 creates a real data-location mystery on Windows

all four audit findings are correctly addressed and tested; the storage-layer fixes (HIGH + clearAccounts MEDIUM) are solid. score is 4 rather than 5 because of the P1 in the rollback confirm=true failure path — on windows, rename-after-archive can fail, leaving the user with no breadcrumb to their displaced accounts file

lib/tools/codex-keychain.ts lines 302-306 (missing preRollbackArchive in partial rollback error); test/tools-codex-keychain.test.ts (missing coverage for that failure path)

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| lib/storage/load-save.ts | HIGH fix (stale JSON resurrection) and MEDIUM fix (clearAccounts ordering) implemented correctly; fallback write and jsonCleared flag logic are sound |
| lib/tools/codex-keychain.ts | mtime-aware sort and confirm-flag clobber guard are correct, but partial rollback failure with confirm=true drops preRollbackArchive path from the error message (P1), and the unprotected window between clearAccounts and the final rename is a concurrency gap (P2) |
| test/storage-keychain.test.ts | HIGH and MEDIUM storage findings are well-covered; rename spy is scoped correctly with mockImplementationOnce so the fallback write path uses the real fs.rename |
| test/tools-codex-keychain.test.ts | mtime sort and confirm-flag tests are solid; missing a test for the archive-succeeds-but-backup-rename-fails path; vi imported dynamically instead of statically (style) |
| docs/audits/_meta/f1-post-merge-review.md | audit ledger tracking deferred LOW/NIT items; no code changes, informational only |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[rollback execute] --> B[findMigrationBackups\nmtime-aware sort]
    B --> C{backup found?}
    C -- no --> D[return: nothing to restore]
    C -- yes --> E[verify backup parses as V3]
    E --> F{valid?}
    F -- no --> G[return: corrupt backup]
    F -- yes --> H[clearAccounts\nunlink JSON first\nthen keychain]
    H --> I[fs.access storagePath]
    I --> J{currentExists?}
    J -- no --> M[rename backup to storagePath]
    J -- yes, no confirm --> K[return: refusing to clobber]
    J -- yes, confirm=true --> L[rename storagePath to preRollbackArchive]
    L --> L2{archive OK?}
    L2 -- fail --> N[return: archive failed]
    L2 -- ok --> M
    M --> M2{restore OK?}
    M2 -- fail --> O[return: rename failed - preRollbackArchive path missing from message]
    M2 -- ok --> P[best-effort deleteFromKeychain]
    P --> Q[return: Restored N accounts]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `lib/tools/codex-keychain.ts`, line 302-306 ([link](https://github.com/ndycode/oc-codex-multi-auth/blob/1df4c5670f8381fec551ef30568f57724097ee4d/lib/tools/codex-keychain.ts#L302-L306)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Orphaned accounts path on partial rollback failure**

   when `confirm=true` and the archive rename (`storagePath → preRollbackArchive`) succeeds but the backup rename (`mostRecent → storagePath`) fails (e.g. EBUSY on windows or a concurrent lock), the error message returned here contains no reference to `preRollbackArchive`. the user's live accounts have already been moved there — they're not lost, but the message gives them no way to find them. on windows where rename-on-busy is a real failure mode, this is a practical data-recovery gap.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: lib/tools/codex-keychain.ts
   Line: 302-306

   Comment:
   **Orphaned accounts path on partial rollback failure**

   when `confirm=true` and the archive rename (`storagePath → preRollbackArchive`) succeeds but the backup rename (`mostRecent → storagePath`) fails (e.g. EBUSY on windows or a concurrent lock), the error message returned here contains no reference to `preRollbackArchive`. the user's live accounts have already been moved there — they're not lost, but the message gives them no way to find them. on windows where rename-on-busy is a real failure mode, this is a practical data-recovery gap.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Foc-codex-multi-auth%22%20on%20the%20existing%20branch%20%22fix%2Ff1-post-merge-findings%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Ff1-post-merge-findings%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20lib%2Ftools%2Fcodex-keychain.ts%0ALine%3A%20302-306%0A%0AComment%3A%0A**Orphaned%20accounts%20path%20on%20partial%20rollback%20failure**%0A%0Awhen%20%60confirm%3Dtrue%60%20and%20the%20archive%20rename%20%28%60storagePath%20%E2%86%92%20preRollbackArchive%60%29%20succeeds%20but%20the%20backup%20rename%20%28%60mostRecent%20%E2%86%92%20storagePath%60%29%20fails%20%28e.g.%20EBUSY%20on%20windows%20or%20a%20concurrent%20lock%29%2C%20the%20error%20message%20returned%20here%20contains%20no%20reference%20to%20%60preRollbackArchive%60.%20the%20user's%20live%20accounts%20have%20already%20been%20moved%20there%20%E2%80%94%20they're%20not%20lost%2C%20but%20the%20message%20gives%20them%20no%20way%20to%20find%20them.%20on%20windows%20where%20rename-on-busy%20is%20a%20real%20failure%20mode%2C%20this%20is%20a%20practical%20data-recovery%20gap.%0A%0A%60%60%60suggestion%0A%7D%20catch%20%28err%29%20%7B%0A%20%20const%20archiveNote%20%3D%20preRollbackArchive%0A%20%20%20%20%3F%20%60%20Current%20accounts%20were%20archived%20at%20%24%7BpreRollbackArchive%7D%20%E2%80%94%20rename%20it%20back%20to%20%24%7BstoragePath%7D%20to%20recover.%60%0A%20%20%20%20%3A%20%22%22%3B%0A%20%20return%20%60codex-keychain%20rollback%3A%20failed%20to%20rename%20%24%7BmostRecent%7D%20-%3E%20%24%7BstoragePath%7D%3A%20%24%7B%28err%20as%20Error%29.message%7D.%24%7BarchiveNote%7D%60%3B%0A%7D%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>


2. `lib/tools/codex-keychain.ts`, line 242-313 ([link](https://github.com/ndycode/oc-codex-multi-auth/blob/1df4c5670f8381fec551ef30568f57724097ee4d/lib/tools/codex-keychain.ts#L242-L313)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Concurrency gap: storage lock not held across the full rollback sequence**

   `clearAccounts()` acquires and releases the storage lock, but the subsequent `fs.access → fs.rename(archive) → fs.rename(backup→canonical)` block runs outside any lock. a concurrent `saveAccounts` call can write a new accounts file between `clearAccounts()` completing and the final rename, which would silently overwrite fresh credentials. the confirm guard catches the race at the access-check step, but only when the race write lands before `fs.access` — not between access and the backup rename. this is a pre-existing architectural pattern from PR #132, but worth calling out explicitly since this PR adds more steps to the unprotected window.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: lib/tools/codex-keychain.ts
   Line: 242-313

   Comment:
   **Concurrency gap: storage lock not held across the full rollback sequence**

   `clearAccounts()` acquires and releases the storage lock, but the subsequent `fs.access → fs.rename(archive) → fs.rename(backup→canonical)` block runs outside any lock. a concurrent `saveAccounts` call can write a new accounts file between `clearAccounts()` completing and the final rename, which would silently overwrite fresh credentials. the confirm guard catches the race at the access-check step, but only when the race write lands before `fs.access` — not between access and the backup rename. this is a pre-existing architectural pattern from PR #132, but worth calling out explicitly since this PR adds more steps to the unprotected window.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Foc-codex-multi-auth%22%20on%20the%20existing%20branch%20%22fix%2Ff1-post-merge-findings%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Ff1-post-merge-findings%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20lib%2Ftools%2Fcodex-keychain.ts%0ALine%3A%20242-313%0A%0AComment%3A%0A**Concurrency%20gap%3A%20storage%20lock%20not%20held%20across%20the%20full%20rollback%20sequence**%0A%0A%60clearAccounts%28%29%60%20acquires%20and%20releases%20the%20storage%20lock%2C%20but%20the%20subsequent%20%60fs.access%20%E2%86%92%20fs.rename%28archive%29%20%E2%86%92%20fs.rename%28backup%E2%86%92canonical%29%60%20block%20runs%20outside%20any%20lock.%20a%20concurrent%20%60saveAccounts%60%20call%20can%20write%20a%20new%20accounts%20file%20between%20%60clearAccounts%28%29%60%20completing%20and%20the%20final%20rename%2C%20which%20would%20silently%20overwrite%20fresh%20credentials.%20the%20confirm%20guard%20catches%20the%20race%20at%20the%20access-check%20step%2C%20but%20only%20when%20the%20race%20write%20lands%20before%20%60fs.access%60%20%E2%80%94%20not%20between%20access%20and%20the%20backup%20rename.%20this%20is%20a%20pre-existing%20architectural%20pattern%20from%20PR%20%23132%2C%20but%20worth%20calling%20out%20explicitly%20since%20this%20PR%20adds%20more%20steps%20to%20the%20unprotected%20window.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Foc-codex-multi-auth%22%20on%20the%20existing%20branch%20%22fix%2Ff1-post-merge-findings%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Ff1-post-merge-findings%22.%0A%0AFix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Alib%2Ftools%2Fcodex-keychain.ts%3A302-306%0A**Orphaned%20accounts%20path%20on%20partial%20rollback%20failure**%0A%0Awhen%20%60confirm%3Dtrue%60%20and%20the%20archive%20rename%20%28%60storagePath%20%E2%86%92%20preRollbackArchive%60%29%20succeeds%20but%20the%20backup%20rename%20%28%60mostRecent%20%E2%86%92%20storagePath%60%29%20fails%20%28e.g.%20EBUSY%20on%20windows%20or%20a%20concurrent%20lock%29%2C%20the%20error%20message%20returned%20here%20contains%20no%20reference%20to%20%60preRollbackArchive%60.%20the%20user's%20live%20accounts%20have%20already%20been%20moved%20there%20%E2%80%94%20they're%20not%20lost%2C%20but%20the%20message%20gives%20them%20no%20way%20to%20find%20them.%20on%20windows%20where%20rename-on-busy%20is%20a%20real%20failure%20mode%2C%20this%20is%20a%20practical%20data-recovery%20gap.%0A%0A%60%60%60suggestion%0A%7D%20catch%20%28err%29%20%7B%0A%20%20const%20archiveNote%20%3D%20preRollbackArchive%0A%20%20%20%20%3F%20%60%20Current%20accounts%20were%20archived%20at%20%24%7BpreRollbackArchive%7D%20%E2%80%94%20rename%20it%20back%20to%20%24%7BstoragePath%7D%20to%20recover.%60%0A%20%20%20%20%3A%20%22%22%3B%0A%20%20return%20%60codex-keychain%20rollback%3A%20failed%20to%20rename%20%24%7BmostRecent%7D%20-%3E%20%24%7BstoragePath%7D%3A%20%24%7B%28err%20as%20Error%29.message%7D.%24%7BarchiveNote%7D%60%3B%0A%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%204%0Atest%2Ftools-codex-keychain.test.ts%3A268-270%0A**Dynamic%20%60vi%60%20import%20inside%20test%20body**%0A%0A%60vi%60%20is%20already%20part%20of%20vitest's%20static%20context%20%E2%80%94%20the%20dynamic%20%60await%20import%28%22vitest%22%29%60%20inside%20the%20test%20body%20is%20redundant%20and%20non-idiomatic.%20it%20works%20because%20vitest%20exports%20a%20singleton%2C%20but%20it%20obscures%20the%20dependency%20and%20can%20trip%20up%20editor%20tooling.%20the%20same%20pattern%20repeats%20in%20the%20%60archives%20the%20live%20JSON%60%20test%20at%20line%20~309.%0A%0Aadd%20%60vi%60%20to%20the%20static%20import%20at%20the%20top%20of%20the%20file%3A%0A%60%60%60%0Aimport%20%7B%20afterEach%2C%20beforeEach%2C%20describe%2C%20expect%2C%20it%2C%20vi%20%7D%20from%20%22vitest%22%3B%0A%60%60%60%0Athen%20remove%20both%20%60const%20%7B%20vi%20%7D%20%3D%20await%20import%28%22vitest%22%29%3B%60%20lines.%0A%0A%23%23%23%20Issue%203%20of%204%0Atest%2Ftools-codex-keychain.test.ts%3A299-346%0A**Missing%20test%3A%20archive%20succeeds%20but%20backup%20restore%20fails%20%28confirm%3Dtrue%29**%0A%0Athere's%20no%20vitest%20coverage%20for%20the%20path%20where%20%60fs.rename%28storagePath%2C%20preRollbackArchive%29%60%20succeeds%20but%20%60fs.rename%28mostRecent%2C%20storagePath%29%60%20then%20fails.%20that's%20exactly%20the%20failure%20mode%20where%20the%20P1%20comment%20above%20matters%20%E2%80%94%20the%20user's%20accounts%20have%20been%20moved%20but%20the%20error%20message%20doesn't%20say%20where.%20add%20a%20test%20that%20mocks%20the%20second%20rename%20to%20throw%20and%20asserts%20the%20error%20message%20contains%20%60preRollbackArchive%60.%0A%0A%23%23%23%20Issue%204%20of%204%0Alib%2Ftools%2Fcodex-keychain.ts%3A242-313%0A**Concurrency%20gap%3A%20storage%20lock%20not%20held%20across%20the%20full%20rollback%20sequence**%0A%0A%60clearAccounts%28%29%60%20acquires%20and%20releases%20the%20storage%20lock%2C%20but%20the%20subsequent%20%60fs.access%20%E2%86%92%20fs.rename%28archive%29%20%E2%86%92%20fs.rename%28backup%E2%86%92canonical%29%60%20block%20runs%20outside%20any%20lock.%20a%20concurrent%20%60saveAccounts%60%20call%20can%20write%20a%20new%20accounts%20file%20between%20%60clearAccounts%28%29%60%20completing%20and%20the%20final%20rename%2C%20which%20would%20silently%20overwrite%20fresh%20credentials.%20the%20confirm%20guard%20catches%20the%20race%20at%20the%20access-check%20step%2C%20but%20only%20when%20the%20race%20write%20lands%20before%20%60fs.access%60%20%E2%80%94%20not%20between%20access%20and%20the%20backup%20rename.%20this%20is%20a%20pre-existing%20architectural%20pattern%20from%20PR%20%23132%2C%20but%20worth%20calling%20out%20explicitly%20since%20this%20PR%20adds%20more%20steps%20to%20the%20unprotected%20window.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: lib/tools/codex-keychain.ts
Line: 302-306

Comment:
**Orphaned accounts path on partial rollback failure**

when `confirm=true` and the archive rename (`storagePath → preRollbackArchive`) succeeds but the backup rename (`mostRecent → storagePath`) fails (e.g. EBUSY on windows or a concurrent lock), the error message returned here contains no reference to `preRollbackArchive`. the user's live accounts have already been moved there — they're not lost, but the message gives them no way to find them. on windows where rename-on-busy is a real failure mode, this is a practical data-recovery gap.

```suggestion
} catch (err) {
  const archiveNote = preRollbackArchive
    ? ` Current accounts were archived at ${preRollbackArchive} — rename it back to ${storagePath} to recover.`
    : "";
  return `codex-keychain rollback: failed to rename ${mostRecent} -> ${storagePath}: ${(err as Error).message}.${archiveNote}`;
}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: test/tools-codex-keychain.test.ts
Line: 268-270

Comment:
**Dynamic `vi` import inside test body**

`vi` is already part of vitest's static context — the dynamic `await import("vitest")` inside the test body is redundant and non-idiomatic. it works because vitest exports a singleton, but it obscures the dependency and can trip up editor tooling. the same pattern repeats in the `archives the live JSON` test at line ~309.

add `vi` to the static import at the top of the file:
```
import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
```
then remove both `const { vi } = await import("vitest");` lines.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: test/tools-codex-keychain.test.ts
Line: 299-346

Comment:
**Missing test: archive succeeds but backup restore fails (confirm=true)**

there's no vitest coverage for the path where `fs.rename(storagePath, preRollbackArchive)` succeeds but `fs.rename(mostRecent, storagePath)` then fails. that's exactly the failure mode where the P1 comment above matters — the user's accounts have been moved but the error message doesn't say where. add a test that mocks the second rename to throw and asserts the error message contains `preRollbackArchive`.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: lib/tools/codex-keychain.ts
Line: 242-313

Comment:
**Concurrency gap: storage lock not held across the full rollback sequence**

`clearAccounts()` acquires and releases the storage lock, but the subsequent `fs.access → fs.rename(archive) → fs.rename(backup→canonical)` block runs outside any lock. a concurrent `saveAccounts` call can write a new accounts file between `clearAccounts()` completing and the final rename, which would silently overwrite fresh credentials. the confirm guard catches the race at the access-check step, but only when the race write lands before `fs.access` — not between access and the backup rename. this is a pre-existing architectural pattern from PR #132, but worth calling out explicitly since this PR adds more steps to the unprotected window.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(keychain): address F1 post-merge rev..."](https://github.com/ndycode/oc-codex-multi-auth/commit/1df4c5670f8381fec551ef30568f57724097ee4d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28833083)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->