### PR TITLE
fix(keychain): F1 LOW + NIT polish from post-merge review

### DIFF
--- a/lib/storage/keychain.ts
+++ b/lib/storage/keychain.ts
@@ -63,6 +63,14 @@ export const KEYCHAIN_SERVICE_NAME = "oc-codex-multi-auth";
 export const GLOBAL_KEYCHAIN_ACCOUNT_KEY = "accounts:global";
 
 /**
+ * Reserved account key used exclusively by the availability probe. Kept
+ * double-underscored and service-suffixed so a future refactor that drops
+ * the `accounts:` prefix on real entries (or adds a different prefix) still
+ * cannot collide with this probe (F1 post-merge LOW finding).
+ */
+export const KEYCHAIN_PROBE_ACCOUNT_KEY = `__probe__@${KEYCHAIN_SERVICE_NAME}`;
+
+/**
  * Minimal abstraction over the native `@napi-rs/keyring` `Entry` API.
  * Declared as an interface so tests can inject a deterministic in-memory
  * backend without touching the real OS keychain.
@@ -103,62 +111,65 @@ async function loadNativeBackend(): Promise<KeychainBackend | null> {
 			return null;
 		}
 		// @napi-rs/keyring's `Entry` methods are synchronous by design (they
-		// delegate to native OS keychain calls). The async wrapper below
-		// exists so the backend interface can be mocked with in-memory
-		// Promise-returning stubs in tests without paying for an extra
-		// microtask in production. The `require-await` warnings are
-		// intentional — suppress at the method level to keep intent explicit.
+		// delegate to native OS keychain calls). The backend interface is
+		// Promise-typed so it can be mocked with in-memory Promise-returning
+		// stubs in tests, so each method returns `Promise.resolve(...)` of
+		// the native sync result. Using non-async methods keeps
+		// `@typescript-eslint/require-await` satisfied without per-method
+		// suppressions while the Promise-returning interface stays intact.
 		const backend: KeychainBackend = {
-			// eslint-disable-next-line @typescript-eslint/require-await
-			async get(service, account) {
+			get(service, account) {
 				try {
 					const entry = new mod.Entry(service, account);
 					const value = entry.getPassword();
-					return value ?? null;
+					return Promise.resolve(value ?? null);
 				} catch (err) {
 					log.warn("keychain: read failed", {
 						service,
 						account,
 						error: (err as Error).message,
 					});
-					return null;
+					return Promise.resolve(null);
 				}
 			},
-			// eslint-disable-next-line @typescript-eslint/require-await
-			async set(service, account, secret) {
+			set(service, account, secret) {
 				const entry = new mod.Entry(service, account);
 				entry.setPassword(secret);
+				return Promise.resolve();
 			},
-			// eslint-disable-next-line @typescript-eslint/require-await
-			async delete(service, account) {
+			delete(service, account) {
 				try {
 					const entry = new mod.Entry(service, account);
-					return entry.deletePassword();
+					return Promise.resolve(entry.deletePassword());
 				} catch (err) {
 					log.warn("keychain: delete failed", {
 						service,
 						account,
 						error: (err as Error).message,
 					});
-					return false;
+					return Promise.resolve(false);
 				}
 			},
-			// eslint-disable-next-line @typescript-eslint/require-await
-			async isAvailable() {
-				// Round-trip a throwaway entry under a reserved account key so
-				// we actually exercise the OS keychain rather than trusting
-				// that import succeeded. Any throw = unavailable.
-				const probeAccount = "__availability_probe__";
+			isAvailable() {
+				// Round-trip a throwaway entry under a reserved, namespaced
+				// account key so we actually exercise the OS keychain rather
+				// than trusting that import succeeded. The key is prefixed
+				// with the service name so a future refactor that drops the
+				// `accounts:` prefix on real entries cannot collide with
+				// this probe (F1 post-merge LOW finding).
 				try {
-					const entry = new mod.Entry(KEYCHAIN_SERVICE_NAME, probeAccount);
+					const entry = new mod.Entry(
+						KEYCHAIN_SERVICE_NAME,
+						KEYCHAIN_PROBE_ACCOUNT_KEY,
+					);
 					entry.setPassword("probe");
 					entry.deletePassword();
-					return true;
+					return Promise.resolve(true);
 				} catch (err) {
 					log.warn("keychain: availability probe failed", {
 						error: (err as Error).message,
 					});
-					return false;
+					return Promise.resolve(false);
 				}
 			},
 		};
@@ -265,8 +276,20 @@ export async function deleteFromKeychain(
  * to confirm the OS keychain is reachable and unlocked. Used by the
  * `codex-keychain status` tool to give the operator a clear yes/no signal
  * instead of waiting until the next real save.
+ *
+ * Gated on the opt-in flag (F1 post-merge LOW finding): with
+ * `CODEX_KEYCHAIN` unset the probe is a no-op that returns `false` without
+ * touching the OS keychain. This preserves the "unset -> zero keychain code
+ * path" invariant the feature advertises and avoids the first-run macOS
+ * "allow/always allow" prompt that `entry.setPassword` can otherwise
+ * trigger for users who run `codex-keychain status` without opting in.
+ *
+ * Pass `env` to override the opt-in lookup in tests.
  */
-export async function keychainIsAvailable(): Promise<boolean> {
+export async function keychainIsAvailable(
+	env: NodeJS.ProcessEnv = process.env,
+): Promise<boolean> {
+	if (!isKeychainOptInEnabled(env)) return false;
 	const backend = await getBackend();
 	if (!backend) return false;
 	return backend.isAvailable();

--- a/lib/storage/load-save.ts
+++ b/lib/storage/load-save.ts
@@ -526,6 +526,22 @@ async function migrateOnDiskJsonToKeychainBackup(
   const backup = `${path}.migrated-to-keychain.${timestamp}`;
   try {
     await fs.rename(path, backup);
+    // Re-apply 0o600 after rename (F1 post-merge LOW finding). POSIX
+    // preserves mode across a rename in-place, but if the filesystem layer
+    // or a prior process ever changed the mode (cp from a world-readable
+    // source, umask drift on a foreign mount, manual `touch`) the backup
+    // could end up group/world-readable. Re-chmod is a cheap belt-and-
+    // braces guard. Windows ignores POSIX mode bits, so skip there.
+    if (process.platform !== "win32") {
+      try {
+        await fs.chmod(backup, 0o600);
+      } catch (chmodErr) {
+        log.warn("keychain: failed to chmod backup to 0o600 after rename", {
+          backup,
+          error: String(chmodErr),
+        });
+      }
+    }
     log.info("keychain: migrated on-disk JSON to keychain; original preserved for rollback", {
       from: path,
       backup,

--- a/lib/tools/codex-keychain.ts
+++ b/lib/tools/codex-keychain.ts
@@ -160,18 +160,26 @@ export function createCodexKeychainTool(ctx: ToolContext): ToolDefinition {
 			})();
 
 			if (sub === "status") {
-				const available = await keychainIsAvailable();
+				// When opt-in is off, skip the probe entirely (F1 post-merge
+				// LOW finding). Probing under an unset `CODEX_KEYCHAIN`
+				// violates the "unset -> no keychain code path" invariant
+				// and can trigger a first-run macOS "allow/always allow"
+				// prompt for users who run `codex-keychain status` without
+				// opting in. `keychainIsAvailable` already short-circuits
+				// on the opt-in check; we surface that explicitly here so
+				// the status line reads "not checked; CODEX_KEYCHAIN unset"
+				// instead of the misleading "keychain unavailable".
+				const available = optIn ? await keychainIsAvailable() : false;
 				const keychainHasEntry = optIn
 					? (await readFromKeychain(projectKey)) !== null
 					: false;
-				const activeBackend =
-					optIn && available && keychainHasEntry
+				const activeBackend = !optIn
+					? "JSON (keychain disabled; CODEX_KEYCHAIN unset)"
+					: available && keychainHasEntry
 						? "keychain"
-						: optIn && available
+						: available
 							? "keychain (empty, JSON fallback)"
-							: optIn && !available
-								? "JSON (keychain unavailable)"
-								: "JSON";
+							: "JSON (keychain unavailable)";
 
 				const lines: string[] = [];
 				lines.push(...formatUiHeader(ui, "Codex keychain status"));
@@ -188,7 +196,7 @@ export function createCodexKeychainTool(ctx: ToolContext): ToolDefinition {
 					formatUiKeyValue(
 						ui,
 						"Keychain reachable",
-						available ? "yes" : "no",
+						optIn ? (available ? "yes" : "no") : "not checked (opt-in off)",
 					),
 				);
 				lines.push(
@@ -303,6 +311,20 @@ export function createCodexKeychainTool(ctx: ToolContext): ToolDefinition {
 				await fs.rename(mostRecent, storagePath);
 			} catch (err) {
 				return `codex-keychain rollback: failed to rename ${mostRecent} -> ${storagePath}: ${(err as Error).message}`;
+			}
+			// Re-apply 0o600 after rollback rename (F1 post-merge LOW
+			// finding). Mirror the chmod applied on the backup-write path
+			// so a restored file can never end up group/world-readable even
+			// if the backup's mode drifted between migration and rollback.
+			// Windows ignores POSIX mode bits, so skip there.
+			if (process.platform !== "win32") {
+				try {
+					await fs.chmod(storagePath, 0o600);
+				} catch {
+					/* non-fatal: file is restored, mode drift is a hardening
+					 * nicety. Swallow to avoid failing the rollback on a
+					 * permission-sensitive mount. */
+				}
 			}
 			// Best-effort keychain delete in case opt-in is still on; the
 			// storage layer will honour that on subsequent saves.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "6.0.0",
       "license": "MIT",
       "dependencies": {
-        "@napi-rs/keyring": "^1.2.0",
+        "@napi-rs/keyring": "~1.2.0",
         "@openauthjs/openauth": "^0.4.3",
         "@opencode-ai/plugin": "^1.2.9",
         "hono": "4.12.14",

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "vitest": "^4.0.18"
   },
   "dependencies": {
-    "@napi-rs/keyring": "^1.2.0",
+    "@napi-rs/keyring": "~1.2.0",
     "@openauthjs/openauth": "^0.4.3",
     "@opencode-ai/plugin": "^1.2.9",
     "hono": "4.12.14",

--- a/test/storage-keychain.test.ts
+++ b/test/storage-keychain.test.ts
@@ -27,6 +27,7 @@ import {
 	deleteFromKeychain,
 	GLOBAL_KEYCHAIN_ACCOUNT_KEY,
 	isKeychainOptInEnabled,
+	KEYCHAIN_PROBE_ACCOUNT_KEY,
 	KEYCHAIN_SERVICE_NAME,
 	keychainIsAvailable,
 	readFromKeychain,
@@ -158,6 +159,25 @@ describe("lib/storage/keychain: low-level backend", () => {
 		});
 	});
 
+	describe("[LOW] KEYCHAIN_PROBE_ACCOUNT_KEY namespacing", () => {
+		it("is service-suffixed and cannot collide with real account keys", () => {
+			// F1 post-merge LOW finding: a future refactor that drops the
+			// `accounts:` prefix on real entries must still not collide
+			// with the probe. We assert both a structural invariant (the
+			// probe key contains the service name) and a
+			// collision-impossibility invariant (no real account key the
+			// build helper could emit equals the probe key).
+			expect(KEYCHAIN_PROBE_ACCOUNT_KEY).toContain(KEYCHAIN_SERVICE_NAME);
+			expect(KEYCHAIN_PROBE_ACCOUNT_KEY).not.toBe(GLOBAL_KEYCHAIN_ACCOUNT_KEY);
+			expect(KEYCHAIN_PROBE_ACCOUNT_KEY).not.toBe(
+				buildKeychainAccountKey("some-project"),
+			);
+			// The previous probe value (`__availability_probe__`) was not
+			// service-suffixed; make sure we moved off that literal.
+			expect(KEYCHAIN_PROBE_ACCOUNT_KEY).not.toBe("__availability_probe__");
+		});
+	});
+
 	describe("read/write/delete happy path", () => {
 		it("stores and retrieves the V3 JSON blob under the project key", async () => {
 			const mock = createMockBackend();
@@ -185,21 +205,37 @@ describe("lib/storage/keychain: low-level backend", () => {
 			expect(del).toBe(false);
 		});
 
-		it("readFromKeychain returns null when backend is unavailable", async () => {
-			_setBackendForTests(null);
-			_resetBackendForTests();
-			// Force backend resolution to fail by injecting a null backend
-			// after reset. The module will try to load the real module; on
-			// CI without @napi-rs/keyring builds this would return null too.
-			// We simulate via _setBackendForTests(null)+reset so the lazy
-			// loader runs and finds nothing to memoize, then returns null.
+		it("readFromKeychain returns null when a mock backend has no entry for the key", async () => {
+			// Direct branch: backend is present, `get` returns null because
+			// nothing was ever written. This covers the common "no entry"
+			// read path through the mock. Renamed from the original
+			// "when backend is unavailable" title, which asserted this
+			// mock-returns-null case while claiming to cover the
+			// `cachedBackend === null` branch (F1 post-merge NIT finding).
 			const mock = createMockBackend();
-			mock.store.set("irrelevant", "value");
-			// For this assertion we still need a mock: a null backend would
-			// take the "unavailable" branch. Use a mock whose get returns null.
 			_setBackendForTests(mock);
 			const read = await readFromKeychain("never-written-key");
 			expect(read).toBeNull();
+		});
+
+		it("readFromKeychain returns null when the native backend cannot load", async () => {
+			// Genuinely-unavailable branch (`keychain.ts:211`: `if (!backend)
+			// return null`). Replace `@napi-rs/keyring` with an empty module
+			// via `vi.doMock` so `loadNativeBackend` sees
+			// `typeof mod.Entry !== "function"`, logs a warning, and
+			// memoizes `null`. `vi.resetModules` + dynamic import forces a
+			// fresh load of `keychain.ts` so it picks up the doMock.
+			await vi.resetModules();
+			vi.doMock("@napi-rs/keyring", () => ({}));
+			try {
+				const fresh = await import("../lib/storage/keychain.js");
+				fresh._resetBackendForTests();
+				const read = await fresh.readFromKeychain("any-key");
+				expect(read).toBeNull();
+			} finally {
+				vi.doUnmock("@napi-rs/keyring");
+				await vi.resetModules();
+			}
 		});
 	});
 
@@ -215,14 +251,32 @@ describe("lib/storage/keychain: low-level backend", () => {
 			expect(mock.store.size).toBe(0);
 		});
 
-		it("keychainIsAvailable reflects the backend probe", async () => {
+		it("keychainIsAvailable reflects the backend probe when opt-in is on", async () => {
 			const mock = createMockBackend();
 			mock.available = false;
 			_setBackendForTests(mock);
-			expect(await keychainIsAvailable()).toBe(false);
+			// Pass an explicit env so the probe gate evaluates to on
+			// regardless of the test runner's ambient CODEX_KEYCHAIN value.
+			const enabledEnv = { CODEX_KEYCHAIN: "1" } as NodeJS.ProcessEnv;
+			expect(await keychainIsAvailable(enabledEnv)).toBe(false);
 
 			mock.available = true;
-			expect(await keychainIsAvailable()).toBe(true);
+			expect(await keychainIsAvailable(enabledEnv)).toBe(true);
+		});
+
+		it("[LOW] keychainIsAvailable returns false without probing when opt-in is off", async () => {
+			// F1 post-merge LOW finding: `codex-keychain status` used to
+			// call `keychainIsAvailable()` unconditionally, which writes a
+			// throwaway entry to the OS keychain and can pop a macOS
+			// "allow/always allow" prompt for users who never set
+			// CODEX_KEYCHAIN. Gate guarantees: (a) returns false when
+			// opt-in is off, (b) never invokes the backend probe.
+			const mock = createMockBackend();
+			_setBackendForTests(mock);
+			const disabledEnv = {} as NodeJS.ProcessEnv; // CODEX_KEYCHAIN unset
+			expect(await keychainIsAvailable(disabledEnv)).toBe(false);
+			const probeCalls = mock.calls.filter((c) => c.op === "isAvailable");
+			expect(probeCalls).toHaveLength(0);
 		});
 	});
 });
@@ -439,6 +493,36 @@ describe("load-save integration with CODEX_KEYCHAIN", () => {
 		);
 		expect(deleteCalls).toHaveLength(0);
 	});
+
+	it.skipIf(process.platform === "win32")(
+		"[LOW] backup file is chmod 0o600 after migration rename (POSIX)",
+		async () => {
+			// F1 post-merge LOW finding: after the atomic-rename of the
+			// legacy on-disk JSON to `.migrated-to-keychain.<ts>`, the
+			// backup must be re-chmodded to 0o600 so any mode drift between
+			// migration and rollback cannot leave the backup group/world-
+			// readable. Windows ignores POSIX mode bits so skip there.
+			setOptIn(false);
+			await saveAccounts(makeStorage());
+			expect(existsSync(storagePath)).toBe(true);
+			// Force an artificial 0o644 on the live file so we can detect
+			// whether the post-rename chmod actually ran. If the fix is
+			// absent, the backup inherits 0o644 and this assertion fails.
+			await fs.chmod(storagePath, 0o644);
+
+			setOptIn(true);
+			await saveAccounts(makeStorage());
+
+			const entries = await fs.readdir(storageDir);
+			const backupName = entries.find((name) =>
+				name.startsWith("accounts.json.migrated-to-keychain."),
+			);
+			expect(backupName).toBeDefined();
+			const st = await fs.stat(join(storageDir, backupName!));
+			// Mask to the low 9 permission bits to ignore file-type bits.
+			expect(st.mode & 0o777).toBe(0o600);
+		},
+	);
 
 	it("[MEDIUM] clearAccounts unlinks JSON first, then keychain, in the happy path", async () => {
 		// Order check: the JSON file must be gone BEFORE the keychain

--- a/test/tools-codex-keychain.test.ts
+++ b/test/tools-codex-keychain.test.ts
@@ -345,6 +345,37 @@ describe("codex-keychain rollback (F1 MEDIUM: confirm-flag clobber gate)", () =>
 		expect(archivedBody.accounts[0]!.accountId).toBe("current-live");
 	});
 
+	it("[LOW] status does not probe the keychain when CODEX_KEYCHAIN is unset", async () => {
+		// F1 post-merge LOW finding: `codex-keychain status` used to call
+		// `keychainIsAvailable()` unconditionally, which writes a throwaway
+		// probe entry to the OS keychain and can pop a first-run macOS
+		// "allow/always allow" prompt for users who never opted in. The
+		// fix gates the probe on `isKeychainOptInEnabled`. Here we flip
+		// opt-in off for the duration of the test and assert the backend
+		// never records an isAvailable call, while the status output
+		// explicitly surfaces the disabled-by-opt-in state.
+		delete process.env.CODEX_KEYCHAIN;
+
+		// Reset recorded calls on the shared mock so this assertion is
+		// independent of any earlier rollback fixtures in the describe.
+		mock.calls.length = 0;
+
+		const t = createCodexKeychainTool(buildCtx());
+		const out = (await t.execute(
+			{ command: "status" },
+			{} as never,
+		)) as string;
+
+		// No probe was issued against the mock backend.
+		const probeCalls = mock.calls.filter((c) => c.op === "isAvailable");
+		expect(probeCalls).toHaveLength(0);
+
+		// Status output reflects opt-in state, not a false "unavailable".
+		expect(out).toMatch(/CODEX_KEYCHAIN/);
+		expect(out).toMatch(/(unset|disabled)/i);
+		expect(out).toMatch(/not checked|disabled/i);
+	});
+
 	it("normal rollback (no current file present) still succeeds without confirm=true", async () => {
 		// Sanity regression: the confirm gate must NOT break the common
 		// case where clearAccounts correctly unlinks the live file before


### PR DESCRIPTION
## Summary

Closes out the remaining **4 LOW + 3 NIT** findings from oracle's
post-merge review of PR #132
(`docs/audits/_meta/f1-post-merge-review.md`). The HIGH + 3 MEDIUM
were addressed in PR #133 (merged). This PR lands the rest in a
small follow-up so the F1 ledger is fully closed.

## LOW (behavior-adjacent, 4)

- **macOS prompt on status probe** — `codex-keychain status` used
  to call `entry.setPassword("probe")` unconditionally, which can
  trigger a first-run macOS "allow/always allow" prompt when
  `CODEX_KEYCHAIN` is unset. Now gates the probe on
  `isKeychainOptInEnabled()`.
- **`status` bypasses opt-in gate** — same root cause as above;
  additionally, the status output now explicitly surfaces
  `CODEX_KEYCHAIN: unset/disabled` + `Keychain reachable: not
  checked (opt-in off)` instead of the misleading "keychain
  unavailable" line.
- **probe account key not namespaced** — renamed the probe account
  from `__availability_probe__` to
  `__probe__@oc-codex-multi-auth` and exported it as
  `KEYCHAIN_PROBE_ACCOUNT_KEY` so a future refactor that drops the
  `accounts:` prefix on real entries cannot silently collide with
  the probe.
- **chmod 0o600 not re-applied after rename** — both the
  migration-backup rename (`.migrated-to-keychain.<ts>`) and the
  rollback restore rename now re-chmod the file to `0o600` on
  POSIX. Windows ignores POSIX mode bits so the chmod is skipped
  there.

## NIT (style, 3)

- **async/eslint-disable style** — the `@napi-rs/keyring` backend
  wrapper's four `async` methods + per-method
  `@typescript-eslint/require-await` suppressions have been
  rewrapped as plain methods returning `Promise.resolve(...)` of
  the native sync result. Same observable behavior, zero lint
  suppressions.
- **confused test case** — the old `readFromKeychain returns null
  when backend is unavailable` test set a mock and asserted that
  a missing key returned null (which is the mock-returns-null
  branch, not the backend-unavailable branch). Split into two
  honestly-labelled tests: a mock-returns-null case and a genuine
  backend-unavailable case that uses `vi.doMock("@napi-rs/keyring")`
  + `vi.resetModules` to force `loadNativeBackend` to see an empty
  module shape and memoize `null`.
- **caret range on credential dep** — tightened
  `@napi-rs/keyring` from `^1.2.0` to `~1.2.0` so minor bumps go
  through an explicit review. No version change lands in this PR;
  lockfile still SHA-512 pins `1.2.0` across all 12 platform
  variants.

## Tests

- 5 new assertions in `test/storage-keychain.test.ts` and
  `test/tools-codex-keychain.test.ts`, one per LOW fix plus the
  NIT test split.
- `2233 passed`, `1 skipped` (the skipped case is the POSIX-only
  chmod assertion on Windows; the assertion is real on POSIX CI).
  Baseline before this PR was `2229`.

## Audit refs

- `docs/audits/_meta/f1-post-merge-review.md` — review ledger
  untouched; this PR closes its LOW + NIT sections.
- Follow-up to **PR #133** which closed the HIGH + 3 MEDIUM.

## Verification

```
npm run typecheck   # pass
npm run lint        # pass
npm test            # 2233 passed, 1 skipped (win32 chmod case)
npm run build       # pass
```

## Scope guard

- no new `as any` / `@ts-ignore`
- no force-push
- no scope expansion beyond the 7 listed findings
- no major bump on `@napi-rs/keyring`
- hooks not skipped

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

this pr closes the remaining 4 LOW + 3 NIT findings from the f1 post-merge audit: gates the availability probe behind `isKeychainOptInEnabled`, namespaces the probe account key, re-chmods renamed files to 0o600 on posix, improves rollback status output, removes `async`/`require-await` suppressions from the native backend wrapper, splits a misleading test, and tightens the `@napi-rs/keyring` semver range to `~1.2.0`. all 7 listed findings are addressed and verified with 4 new targeted tests. two minor consistency issues remain — both p2.

<h3>Confidence Score: 5/5</h3>

safe to merge — all 7 audit findings correctly addressed; remaining items are p2 polish

all low + nit findings are landed cleanly with targeted test coverage. the two p2 findings (stale mock account key, missing chmod on pre-rollback archive) are consistency/hardening nits, not present defects — the live accounts file is already written with 0o600 so token exposure requires prior mode drift. no new `as any`, no scope expansion, no skipped hooks.

lib/tools/codex-keychain.ts (missing chmod on pre-rollback archive) and both test files (stale probe account key in mock isAvailable)

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/storage/keychain.ts | exports `KEYCHAIN_PROBE_ACCOUNT_KEY`, rewraps four async backend methods as sync methods returning `Promise.resolve(...)`, and gates `keychainIsAvailable` behind the opt-in flag — all correct |
| lib/storage/load-save.ts | adds posix chmod 0o600 on the migration-backup rename in `migrateOnDiskJsonToKeychainBackup` with a non-fatal warn on failure — correctly skips on win32 |
| lib/tools/codex-keychain.ts | status now gates on `optIn` before probing, rollback chmods the restored file — but the `.pre-rollback.<ts>` archive rename is missing the matching chmod; token safety gap in the confirm=true path |
| test/storage-keychain.test.ts | adds 4 well-labelled tests (probe namespacing, backend-unavailable split, opt-in gate, posix chmod) — mock `isAvailable` still records the old `"__availability_probe__"` key instead of `KEYCHAIN_PROBE_ACCOUNT_KEY` |
| test/tools-codex-keychain.test.ts | adds the LOW status-no-probe test and rollback confirm-gate tests — mock `isAvailable` also records the stale probe key; no mode assertion on the pre-rollback archive |
| package.json | tightens `@napi-rs/keyring` from `^1.2.0` to `~1.2.0`; no version change in this pr, lockfile still pins 1.2.0 |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[codex-keychain status] --> B{isKeychainOptInEnabled?}
    B -- no --> C[available = false\nkeychainHasEntry = false]
    C --> D[show: CODEX_KEYCHAIN unset/disabled\nKeychain reachable: not checked]
    B -- yes --> E[keychainIsAvailable]
    E --> F{backend probed ok?}
    F -- no --> G[available = false]
    F -- yes --> H[available = true\nreadFromKeychain projectKey]
    H --> I{entry exists?}
    I -- yes --> J[activeBackend = keychain]
    I -- no --> K[activeBackend = keychain empty JSON fallback]
    G --> L[activeBackend = JSON keychain unavailable]
    J & K & L --> M[render status lines]

    N[codex-keychain rollback confirm=true] --> O[findMigrationBackups by mtimeMs]
    O --> P[clearAccounts unlink JSON then keychain]
    P --> Q{storagePath still exists?}
    Q -- no --> R[rename backup -> storagePath\nchmod 0o600 storagePath]
    Q -- yes, confirm=true --> S[rename storagePath -> preRollbackArchive\n⚠ no chmod here]
    S --> T[rename backup -> storagePath\nchmod 0o600 storagePath]
    R & T --> U[deleteFromKeychain best-effort]
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Foc-codex-multi-auth%22%20on%20the%20existing%20branch%20%22fix%2Ff1-polish-low-nit%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Ff1-polish-low-nit%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Atest%2Fstorage-keychain.test.ts%3A84-86%0A**Stale%20probe%20account%20key%20in%20mock%20%60isAvailable%60**%0A%0Athe%20mock%20records%20%60account%3A%20%22__availability_probe__%22%60%20%E2%80%94%20the%20old%20key%20before%20this%20PR%20renamed%20it.%20it%20should%20use%20%60KEYCHAIN_PROBE_ACCOUNT_KEY%60%20%28already%20imported%20at%20line%2030%29%20so%20the%20call%20log%20is%20consistent%20with%20the%20real%20backend.%20no%20current%20test%20asserts%20on%20%60c.account%60%20when%20%60c.op%20%3D%3D%3D%20%22isAvailable%22%60%2C%20but%20the%20mismatch%20will%20silently%20produce%20wrong%20data%20if%20someone%20adds%20such%20an%20assertion%20later.%0A%0A%60%60%60suggestion%0A%09%09async%20isAvailable%28%29%20%7B%0A%09%09%09%09calls.push%28%7B%20op%3A%20%22isAvailable%22%2C%20service%3A%20KEYCHAIN_SERVICE_NAME%2C%20account%3A%20KEYCHAIN_PROBE_ACCOUNT_KEY%20%7D%29%3B%0A%09%09%09%09return%20backend.available%3B%0A%09%09%09%7D%2C%0A%60%60%60%0A%0Asame%20stale%20value%20appears%20in%20%60test%2Ftools-codex-keychain.test.ts%60%20line%2067%20%E2%80%94%20that%20file%20would%20need%20%60KEYCHAIN_PROBE_ACCOUNT_KEY%60%20added%20to%20its%20import%20from%20%60keychain.js%60.%0A%0A%23%23%23%20Issue%202%20of%202%0Alib%2Ftools%2Fcodex-keychain.ts%3A299-308%0A**Missing%20chmod%20on%20the%20%60.pre-rollback.%3Cts%3E%60%20archive%20%E2%80%94%20token%20safety%20gap**%0A%0Athe%20restored%20file%20%28%60storagePath%60%29%20gets%20re-chmodded%20to%200o600%2C%20but%20the%20live%20file%20that%20was%20just%20renamed%20to%20%60preRollbackArchive%60%20does%20not.%20the%20live%20file%20should%20already%20be%200o600%20%28written%20by%20%60writeAccountsToPathUnlocked%60%29%2C%20but%20if%20mode%20bits%20drifted%20%28umask%20drift%2C%20%60cp%60%20from%20a%20world-readable%20source%2C%20foreign%20mount%29%2C%20the%20archive%20could%20be%20group%2Fworld-readable%20and%20expose%20oauth%20tokens.%20the%20migration-backup%20path%20in%20%60load-save.ts%60%20applies%20the%20same%20belt-and-braces%20chmod%20after%20its%20rename%3B%20consistency%20suggests%20doing%20the%20same%20here.%20there's%20also%20no%20vitest%20coverage%20asserting%20%60st.mode%20%26%200o777%20%3D%3D%3D%200o600%60%20on%20the%20pre-rollback%20archive%20path.%0A%0A%60%60%60suggestion%0A%09%09%09%09try%20%7B%0A%09%09%09%09%09await%20fs.rename%28storagePath%2C%20preRollbackArchive%29%3B%0A%09%09%09%09%09if%20%28process.platform%20!%3D%3D%20%22win32%22%29%20%7B%0A%09%09%09%09%09%09try%20%7B%0A%09%09%09%09%09%09%09await%20fs.chmod%28preRollbackArchive%2C%200o600%29%3B%0A%09%09%09%09%09%09%7D%20catch%20%7B%0A%09%09%09%09%09%09%09%2F*%20non-fatal%3B%20archive%20is%20written%2C%20mode%20drift%20is%20a%20hardening%20nicety%20*%2F%0A%09%09%09%09%09%09%7D%0A%09%09%09%09%09%7D%0A%09%09%09%09%7D%20catch%20%28err%29%20%7B%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: test/storage-keychain.test.ts
Line: 84-86

Comment:
**Stale probe account key in mock `isAvailable`**

the mock records `account: "__availability_probe__"` — the old key before this PR renamed it. it should use `KEYCHAIN_PROBE_ACCOUNT_KEY` (already imported at line 30) so the call log is consistent with the real backend. no current test asserts on `c.account` when `c.op === "isAvailable"`, but the mismatch will silently produce wrong data if someone adds such an assertion later.

```suggestion
		async isAvailable() {
				calls.push({ op: "isAvailable", service: KEYCHAIN_SERVICE_NAME, account: KEYCHAIN_PROBE_ACCOUNT_KEY });
				return backend.available;
			},
```

same stale value appears in `test/tools-codex-keychain.test.ts` line 67 — that file would need `KEYCHAIN_PROBE_ACCOUNT_KEY` added to its import from `keychain.js`.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: lib/tools/codex-keychain.ts
Line: 299-308

Comment:
**Missing chmod on the `.pre-rollback.<ts>` archive — token safety gap**

the restored file (`storagePath`) gets re-chmodded to 0o600, but the live file that was just renamed to `preRollbackArchive` does not. the live file should already be 0o600 (written by `writeAccountsToPathUnlocked`), but if mode bits drifted (umask drift, `cp` from a world-readable source, foreign mount), the archive could be group/world-readable and expose oauth tokens. the migration-backup path in `load-save.ts` applies the same belt-and-braces chmod after its rename; consistency suggests doing the same here. there's also no vitest coverage asserting `st.mode & 0o777 === 0o600` on the pre-rollback archive path.

```suggestion
				try {
					await fs.rename(storagePath, preRollbackArchive);
					if (process.platform !== "win32") {
						try {
							await fs.chmod(preRollbackArchive, 0o600);
						} catch {
							/* non-fatal; archive is written, mode drift is a hardening nicety */
						}
					}
				} catch (err) {
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test(keychain): cover F1 post-merge LOW ..."](https://github.com/ndycode/oc-codex-multi-auth/commit/dbad9190a869a302651df484c1c760d973fe75b0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28833865)</sub>

<!-- /greptile_comment -->