### PR TITLE
Remove OpenSSF Scorecard badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ Badges: CI + OpenSSF Scorecard will turn green once Phase 3 Batch A (CI workflow
 [![npm downloads](https://img.shields.io/npm/dw/oc-codex-multi-auth.svg)](https://www.npmjs.com/package/oc-codex-multi-auth)
 [![Node.js Version](https://img.shields.io/node/v/oc-codex-multi-auth.svg)](https://nodejs.org)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/ndycode/oc-codex-multi-auth/badge)](https://securityscorecards.dev/viewer/?uri=github.com/ndycode/oc-codex-multi-auth)
 
 Use your ChatGPT Plus/Pro subscription inside OpenCode with OAuth login, GPT-5/Codex model presets, and multi-account failover.
 


### PR DESCRIPTION
Removed OpenSSF Scorecard badge from README.

<!-- Maintainer note: the anti-slop canary token is configured in .github/workflows/pr-quality.yml under blocked-terms. Keep the template and workflow in sync, and do not put the raw token in contributor-facing files. -->

## Summary

- What changed?
- Why is this needed?

## Testing

- [ ] `npm run lint`
- [ ] `npm run build`
- [ ] `npm test`
- [ ] Not applicable

## Compliance Confirmation

- [ ] This change stays within the repository scope and OpenAI Terms of Service expectations.
- [ ] This change uses official authentication flows only and does not add bypass, scraping, or credential-sharing behavior.
- [ ] I updated tests and documentation when the change affected users, maintainers, or repository behavior.

## Notes

- Linked issue:
- Follow-up work or rollout notes:

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

removes the opensf scorecard badge from `README.md`. this is a one-line documentation change with no code, logic, or security implications.

<h3>Confidence Score: 5/5</h3>

safe to merge — single-line readme badge removal with no functional or security impact

only change is removing one badge link from readme; no code, tests, tokens, or windows filesystem paths touched

no files require special attention

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| README.md | removes the opensf scorecard badge line; purely cosmetic, no functional impact |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[README.md badge section] --> B[CI badge]
    A --> C[npm downloads badge]
    A --> D[Node.js Version badge]
    A --> E[License badge]
    F[OpenSSF Scorecard badge] -. removed .-> A
```

<sub>Reviews (1): Last reviewed commit: ["Remove OpenSSF Scorecard badge"](https://github.com/ndycode/oc-codex-multi-auth/commit/a73f33682241fb9b1ac51da5bf7a62bba0a95ec0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28848830)</sub>

<!-- /greptile_comment -->