### PR TITLE
fix(installer): handle UTF-8 BOM in existing opencode.json

### DIFF
--- a/scripts/install-oc-codex-multi-auth-core.js
+++ b/scripts/install-oc-codex-multi-auth-core.js
@@ -205,7 +205,7 @@ function mergeFullTemplate(modernTemplate, legacyTemplate) {
 
 async function readJson(filePath) {
 	const content = await readFile(filePath, "utf-8");
-	return JSON.parse(content);
+	return JSON.parse(content.charCodeAt(0) === 0xfeff ? content.slice(1) : content);
 }
 
 async function renameWithWindowsRetry(sourcePath, destinationPath) {

--- a/test/install-oc-codex-multi-auth.test.ts
+++ b/test/install-oc-codex-multi-auth.test.ts
@@ -117,6 +117,111 @@ describe("install-oc-codex-multi-auth script", () => {
 		);
 	});
 
+	it("parses BOM-prefixed existing config and preserves custom keys on merge", async () => {
+		vi.resetModules();
+		tempHome = await createTempHome();
+		const { runInstaller } = await import("../scripts/install-oc-codex-multi-auth-core.js");
+		const configDir = join(tempHome, ".config", "opencode");
+		const configPath = join(configDir, "opencode.json");
+
+		await mkdir(configDir, { recursive: true });
+		const existing = {
+			plugin: ["some-other-plugin"],
+			provider: {
+				openai: {
+					myCustomKey: "preserve-me",
+					models: {
+						"user-only-model": { name: "User Only Model" },
+					},
+				},
+			},
+		};
+		await writeFile(configPath, `\uFEFF${JSON.stringify(existing, null, 2)}`, "utf-8");
+
+		await expect(
+			runInstaller(["--no-cache-clear"], {
+				env: {
+					...process.env,
+					HOME: tempHome,
+					USERPROFILE: tempHome,
+				},
+			}),
+		).resolves.toMatchObject({
+			action: "install",
+			exitCode: 0,
+		});
+
+		const saved = JSON.parse(await readFile(configPath, "utf-8")) as {
+			plugin: string[];
+			provider: {
+				openai: {
+					myCustomKey?: string;
+					models: Record<string, unknown>;
+				};
+			};
+		};
+
+		expect(saved.plugin).toEqual(expect.arrayContaining(["some-other-plugin", "oc-codex-multi-auth"]));
+		expect(saved.provider.openai.myCustomKey).toBe("preserve-me");
+		expect(saved.provider.openai.models["user-only-model"]).toBeDefined();
+		expect(saved.provider.openai.models["gpt-5.4"]).toBeDefined();
+	});
+
+	it("parses BOM-less existing config and preserves custom keys on merge", async () => {
+		vi.resetModules();
+		tempHome = await createTempHome();
+		const { runInstaller } = await import("../scripts/install-oc-codex-multi-auth-core.js");
+		const configDir = join(tempHome, ".config", "opencode");
+		const configPath = join(configDir, "opencode.json");
+
+		await mkdir(configDir, { recursive: true });
+		await writeFile(
+			configPath,
+			JSON.stringify(
+				{
+					plugin: ["some-other-plugin"],
+					provider: {
+						openai: {
+							myCustomKey: "preserve-me",
+							models: {
+								"user-only-model": { name: "User Only Model" },
+							},
+						},
+					},
+				},
+				null,
+				2,
+			),
+			"utf-8",
+		);
+
+		await expect(
+			runInstaller(["--no-cache-clear"], {
+				env: {
+					...process.env,
+					HOME: tempHome,
+					USERPROFILE: tempHome,
+				},
+			}),
+		).resolves.toMatchObject({
+			action: "install",
+			exitCode: 0,
+		});
+
+		const saved = JSON.parse(await readFile(configPath, "utf-8")) as {
+			provider: {
+				openai: {
+					myCustomKey?: string;
+					models: Record<string, unknown>;
+				};
+			};
+		};
+
+		expect(saved.provider.openai.myCustomKey).toBe("preserve-me");
+		expect(saved.provider.openai.models["user-only-model"]).toBeDefined();
+		expect(saved.provider.openai.models["gpt-5.4"]).toBeDefined();
+	});
+
 	it("deep-merges provider.openai preserving user customizations while overwriting managed keys", async () => {
 		vi.resetModules();
 		tempHome = await createTempHome();


### PR DESCRIPTION
## Summary
Fixes a Windows installer edge case where an existing opencode.json saved as UTF-8 with BOM fails JSON.parse, causing the installer to log a parse warning and replace the config with the template instead of deep-merging.

## Repro
1. Create an existing ~/.config/opencode/opencode.json encoded with a leading UTF-8 BOM.
2. Run oc-codex-multi-auth.
3. Before this fix, the installer enters the parse-failure path and replaces the config instead of preserving user customizations.

## Fix
- Strip a single leading UTF-8 BOM (\uFEFF) before JSON.parse in eadJson(filePath).
- No behavior change for BOM-less files.

## Tests
- parses BOM-prefixed existing config and preserves custom keys on merge
- parses BOM-less existing config and preserves custom keys on merge

## Verification
- 
pm run typecheck
- 
pm run lint
- 
pm test
- 
pm run build

All passed locally.

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

strips a leading utf-8 bom (`\uFEFF`) before `JSON.parse` in `readJson`, fixing the windows edge case where an existing `opencode.json` saved as utf-8-with-bom caused a parse failure and silently replaced user config. two vitest cases are added covering both bom-prefixed and bom-less paths; the output bom-freedom check is implicit (would throw on `JSON.parse`) but not a named assertion.

<h3>Confidence Score: 5/5</h3>

safe to merge — targeted one-line fix with no behavior change for bom-less files and two new tests confirming correct merge behavior

only finding is a p2 suggestion to make the output bom-free assertion explicit; does not affect correctness or token safety

test/install-oc-codex-multi-auth.test.ts — add explicit charCodeAt(0) assertion for bom-free output

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| scripts/install-oc-codex-multi-auth-core.js | single-line bom-strip added to readJson; correct and safe for all callers (config, templates, cache package.json) |
| test/install-oc-codex-multi-auth.test.ts | two new vitest cases cover bom and bom-less paths; output bom-freedom is only implied, not explicitly asserted |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[readJson called] --> B[readFile as utf-8]
    B --> C{charCodeAt 0 === 0xFEFF?}
    C -->|yes - BOM present| D[content.slice 1]
    C -->|no - normal file| E[content unchanged]
    D --> F[JSON.parse]
    E --> F
    F -->|success| G[return parsed object]
    F -->|SyntaxError| H[caught by caller\nlog warning, use template]
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Foc-codex-multi-auth%22%20on%20the%20existing%20branch%20%22fix%2Finstaller-bom-json-parse%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Finstaller-bom-json-parse%22.%0A%0AFix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atest%2Finstall-oc-codex-multi-auth.test.ts%3A154%0A**no%20explicit%20bom-free%20assertion%20on%20output**%0A%0Athe%20bom%20test%20reads%20back%20the%20file%20with%20plain%20%60JSON.parse%28await%20readFile%28...%29%29%60%20which%20would%20throw%20a%20%60SyntaxError%60%20if%20a%20bom%20leaked%20into%20the%20written%20output%20%E2%80%94%20technically%20covering%20it%2C%20but%20only%20as%20an%20exception%20rather%20than%20a%20named%20assertion.%20on%20windows%2C%20if%20%60writeFileAtomic%60%20ever%20gains%20bom-aware%20encoding%20in%20the%20future%2C%20this%20silent%20assumption%20could%20regress%20silently.%20suggest%20adding%20an%20explicit%20check%3A%0A%0A%60%60%60suggestion%0A%09%09const%20rawContent%20%3D%20await%20readFile%28configPath%2C%20%22utf-8%22%29%3B%0A%09%09expect%28rawContent.charCodeAt%280%29%29.not.toBe%280xfeff%29%3B%0A%09%09const%20saved%20%3D%20JSON.parse%28rawContent%29%20as%20%7B%0A%60%60%60%0A%0A**Context%20Used%3A**%20speak%20in%20lowercase%2C%20concise%20sentences.%20act%20like%20th...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3Dinstruction-0%29%29%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: test/install-oc-codex-multi-auth.test.ts
Line: 154

Comment:
**no explicit bom-free assertion on output**

the bom test reads back the file with plain `JSON.parse(await readFile(...))` which would throw a `SyntaxError` if a bom leaked into the written output — technically covering it, but only as an exception rather than a named assertion. on windows, if `writeFileAtomic` ever gains bom-aware encoding in the future, this silent assumption could regress silently. suggest adding an explicit check:

```suggestion
		const rawContent = await readFile(configPath, "utf-8");
		expect(rawContent.charCodeAt(0)).not.toBe(0xfeff);
		const saved = JSON.parse(rawContent) as {
```

**Context Used:** speak in lowercase, concise sentences. act like th... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(installer): handle UTF-8 BOM in exis..."](https://github.com/ndycode/oc-codex-multi-auth/commit/c4c2ad724fdc9d7420782661d92439e7c7885304) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28849512)</sub>

<!-- /greptile_comment -->