### PR TITLE
fix(retry): treat server overload responses as retryable

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -2219,6 +2219,17 @@ while (attempted.size < Math.max(1, accountCount)) {
 					// Handle 5xx server errors, and exact overload payloads flagged by
 					// handleErrorResponse, by rotating to another account.
 					if (retryAsServerError || (response.status >= 500 && response.status < 600)) {
+						if (retryAsServerError && rateLimit) {
+							accountManager.markRateLimitedWithReason(
+								account,
+								rateLimit.retryAfterMs,
+								modelFamily,
+								parseRateLimitReason(rateLimit.code),
+								model,
+							);
+							account.lastSwitchReason = "rate-limit";
+							accountManager.saveToDiskDebounced();
+						}
 						logWarn(
 							`Server error ${response.status} for account ${account.index + 1}. Rotating to next account.`,
 						);

--- a/index.ts
+++ b/index.ts
@@ -2230,13 +2230,17 @@ while (attempted.size < Math.max(1, accountCount)) {
 							account.lastSwitchReason = "rate-limit";
 							accountManager.saveToDiskDebounced();
 						}
+						const retryableServerLabel =
+							retryAsServerError && response.status < 500
+								? `Retryable server overload (HTTP ${response.status})`
+								: `Server error ${response.status}`;
 						logWarn(
-							`Server error ${response.status} for account ${account.index + 1}. Rotating to next account.`,
+							`${retryableServerLabel} for account ${account.index + 1}. Rotating to next account.`,
 						);
 						runtimeMetrics.failedRequests++;
 						runtimeMetrics.serverErrors++;
 						runtimeMetrics.accountRotations++;
-						runtimeMetrics.lastError = `HTTP ${response.status}`;
+						runtimeMetrics.lastError = retryableServerLabel;
 						runtimeMetrics.lastErrorCategory = "server";
 						accountManager.refundToken(account, modelFamily, model);
 						accountManager.recordFailure(account, modelFamily, model);

--- a/index.ts
+++ b/index.ts
@@ -1993,11 +1993,11 @@ while (attempted.size < Math.max(1, accountCount)) {
 										return contextOverflowResult.response;
 									}
 
-									const { response: errorResponse, rateLimit, errorBody } =
-										await handleErrorResponse(response, {
-											requestCorrelationId,
-											threadId: threadIdCandidate,
-										});
+					const { response: errorResponse, rateLimit, errorBody, retryAsServerError } =
+						await handleErrorResponse(response, {
+							requestCorrelationId,
+							threadId: threadIdCandidate,
+						});
 
 			const workspaceDeactivated = isDeactivatedWorkspaceError(errorBody, response.status);
 				if (workspaceDeactivated) {
@@ -2216,9 +2216,12 @@ while (attempted.size < Math.max(1, accountCount)) {
 						logDebug(`[${PLUGIN_NAME}] Recoverable error detected: ${errorType}`);
 					}
 
-					// Handle 5xx server errors by rotating to another account
-					if (response.status >= 500 && response.status < 600) {
-						logWarn(`Server error ${response.status} for account ${account.index + 1}. Rotating to next account.`);
+					// Handle 5xx server errors, and exact overload payloads flagged by
+					// handleErrorResponse, by rotating to another account.
+					if (retryAsServerError || (response.status >= 500 && response.status < 600)) {
+						logWarn(
+							`Server error ${response.status} for account ${account.index + 1}. Rotating to next account.`,
+						);
 						runtimeMetrics.failedRequests++;
 						runtimeMetrics.serverErrors++;
 						runtimeMetrics.accountRotations++;

--- a/lib/request/fetch-helpers.ts
+++ b/lib/request/fetch-helpers.ts
@@ -312,9 +312,15 @@ function isServerOverloadedError(errorBody: unknown): boolean {
 	const maybeError = errorBody.error;
 	if (!isRecord(maybeError)) return false;
 
+	if (typeof maybeError.code === "string" && maybeError.code === "server_is_overloaded") {
+		return true;
+	}
+
+	const maybeContext = maybeError.context;
 	return (
-		typeof maybeError.code === "string" &&
-		maybeError.code === "server_is_overloaded"
+		isRecord(maybeContext) &&
+		typeof maybeContext.type === "string" &&
+		maybeContext.type === "service_unavailable_error"
 	);
 }
 
@@ -716,6 +722,10 @@ function extractRateLimitInfoFromBody(
         const isStatusRateLimit =
                 response.status === HTTP_STATUS.TOO_MANY_REQUESTS;
         const parsed = parseRateLimitBody(bodyText);
+
+		if (isServerOverloadedError(parsed ? { error: { code: parsed.code } } : undefined)) {
+			return undefined;
+		}
 
         const haystack = `${parsed?.code ?? ""} ${bodyText}`.toLowerCase();
         

--- a/lib/request/fetch-helpers.ts
+++ b/lib/request/fetch-helpers.ts
@@ -316,6 +316,10 @@ function isServerOverloadedError(errorBody: unknown): boolean {
 		return true;
 	}
 
+	if (typeof maybeError.type === "string" && maybeError.type === "service_unavailable_error") {
+		return true;
+	}
+
 	const maybeContext = maybeError.context;
 	return (
 		isRecord(maybeContext) &&
@@ -723,7 +727,21 @@ function extractRateLimitInfoFromBody(
                 response.status === HTTP_STATUS.TOO_MANY_REQUESTS;
         const parsed = parseRateLimitBody(bodyText);
 
-		if (isServerOverloadedError(parsed ? { error: { code: parsed.code } } : undefined)) {
+		if (
+			isServerOverloadedError(
+				parsed
+					? {
+						error: {
+							code: parsed.code,
+							type: parsed.type,
+							context: parsed.contextType
+								? { type: parsed.contextType }
+								: undefined,
+						},
+					}
+					: undefined,
+			)
+		) {
 			return undefined;
 		}
 
@@ -751,6 +769,9 @@ interface RateLimitErrorBody {
 	error?: {
 		code?: string | number;
 		type?: string;
+		context?: {
+			type?: string;
+		};
 		resets_at?: number;
 		reset_at?: number;
 		retry_after_ms?: number;
@@ -760,15 +781,17 @@ interface RateLimitErrorBody {
 
 function parseRateLimitBody(
 	body: string,
-): { code?: string; resetsAt?: number; retryAfterMs?: number } | undefined {
+): { code?: string; type?: string; contextType?: string; resetsAt?: number; retryAfterMs?: number } | undefined {
 	if (!body) return undefined;
 	try {
 		const parsed = JSON.parse(body) as RateLimitErrorBody;
 		const error = parsed?.error ?? {};
 		const code = (error.code ?? error.type ?? "").toString();
+		const type = typeof error.type === "string" ? error.type : undefined;
+		const contextType = typeof error.context?.type === "string" ? error.context.type : undefined;
 		const resetsAt = toNumber(error.resets_at ?? error.reset_at);
 		const retryAfterMs = toNumber(error.retry_after_ms ?? error.retry_after);
-		return { code, resetsAt, retryAfterMs };
+		return { code, type, contextType, resetsAt, retryAfterMs };
 	} catch {
 		return undefined;
 	}

--- a/lib/request/fetch-helpers.ts
+++ b/lib/request/fetch-helpers.ts
@@ -34,10 +34,6 @@ export interface EntitlementError {
         message: string;
 }
 
-export interface ServerRetryInfo {
-	retryAsServerError?: boolean;
-}
-
 const CODEX_BASE_URL_OBJECT = new URL(CODEX_BASE_URL);
 const CODEX_BASE_PATH_PREFIX = CODEX_BASE_URL_OBJECT.pathname.endsWith("/")
 	? CODEX_BASE_URL_OBJECT.pathname.slice(0, -1)
@@ -726,24 +722,23 @@ function extractRateLimitInfoFromBody(
         const isStatusRateLimit =
                 response.status === HTTP_STATUS.TOO_MANY_REQUESTS;
         const parsed = parseRateLimitBody(bodyText);
+        const isServerOverload = isServerOverloadedError(
+                parsed
+                        ? {
+                                        error: {
+                                                code: parsed.code,
+                                                type: parsed.type,
+                                                context: parsed.contextType
+                                                        ? { type: parsed.contextType }
+                                                        : undefined,
+                                        },
+                                }
+                        : undefined,
+        );
 
-		if (
-			isServerOverloadedError(
-				parsed
-					? {
-						error: {
-							code: parsed.code,
-							type: parsed.type,
-							context: parsed.contextType
-								? { type: parsed.contextType }
-								: undefined,
-						},
-					}
-					: undefined,
-			)
-		) {
-			return undefined;
-		}
+        if (isServerOverload && !isStatusRateLimit) {
+                return undefined;
+        }
 
         const haystack = `${parsed?.code ?? ""} ${bodyText}`.toLowerCase();
         
@@ -754,6 +749,7 @@ function extractRateLimitInfoFromBody(
         
         const isRateLimit =
                 isStatusRateLimit ||
+                isServerOverload ||
                 /usage_limit_reached|rate_limit_exceeded|rate_limit|usage limit/i.test(
                         haystack,
                 );

--- a/lib/request/fetch-helpers.ts
+++ b/lib/request/fetch-helpers.ts
@@ -34,6 +34,10 @@ export interface EntitlementError {
         message: string;
 }
 
+export interface ServerRetryInfo {
+	retryAsServerError?: boolean;
+}
+
 const CODEX_BASE_URL_OBJECT = new URL(CODEX_BASE_URL);
 const CODEX_BASE_PATH_PREFIX = CODEX_BASE_URL_OBJECT.pathname.endsWith("/")
 	? CODEX_BASE_URL_OBJECT.pathname.slice(0, -1)
@@ -265,6 +269,7 @@ export interface ErrorHandlingResult {
         response: Response;
         rateLimit?: RateLimitInfo;
         errorBody?: unknown;
+        retryAsServerError?: boolean;
 }
 
 export interface ErrorHandlingOptions {
@@ -299,6 +304,18 @@ function getStructuredErrorCode(errorBody: unknown): string | undefined {
 	}
 
 	return undefined;
+}
+
+function isServerOverloadedError(errorBody: unknown): boolean {
+	if (!isRecord(errorBody)) return false;
+
+	const maybeError = errorBody.error;
+	if (!isRecord(maybeError)) return false;
+
+	return (
+		typeof maybeError.code === "string" &&
+		maybeError.code === "server_is_overloaded"
+	);
 }
 
 export function isDeactivatedWorkspaceError(errorBody: unknown, status?: number): boolean {
@@ -599,6 +616,7 @@ export async function handleErrorResponse(
                 diagnostics,
         );
         const errorResponse = ensureJsonErrorResponse(finalResponse, normalizedError);
+        const retryAsServerError = isServerOverloadedError(errorBody);
 
         if (finalResponse.status === HTTP_STATUS.UNAUTHORIZED) {
                 logWarn("Codex upstream returned 401 Unauthorized", diagnostics);
@@ -610,7 +628,12 @@ export async function handleErrorResponse(
                 diagnostics,
         });
 
-        return { response: errorResponse, rateLimit, errorBody: normalizedError };
+        return {
+		response: errorResponse,
+		rateLimit,
+		errorBody: normalizedError,
+		retryAsServerError,
+	};
 }
 
 /**

--- a/lib/request/fetch-helpers.ts
+++ b/lib/request/fetch-helpers.ts
@@ -307,6 +307,9 @@ function isServerOverloadedError(errorBody: unknown): boolean {
 
 	const maybeError = errorBody.error;
 	if (!isRecord(maybeError)) return false;
+	const maybeMessage = typeof maybeError.message === "string"
+		? maybeError.message.toLowerCase()
+		: "";
 
 	if (typeof maybeError.code === "string" && maybeError.code === "server_is_overloaded") {
 		return true;
@@ -320,7 +323,8 @@ function isServerOverloadedError(errorBody: unknown): boolean {
 	return (
 		isRecord(maybeContext) &&
 		typeof maybeContext.type === "string" &&
-		maybeContext.type === "service_unavailable_error"
+		maybeContext.type === "service_unavailable_error" &&
+		/overloaded|try again later/.test(maybeMessage)
 	);
 }
 
@@ -622,7 +626,7 @@ export async function handleErrorResponse(
                 diagnostics,
         );
         const errorResponse = ensureJsonErrorResponse(finalResponse, normalizedError);
-        const retryAsServerError = isServerOverloadedError(errorBody);
+        const retryAsServerError = isServerOverloadedError(normalizedError);
 
         if (finalResponse.status === HTTP_STATUS.UNAUTHORIZED) {
                 logWarn("Codex upstream returned 401 Unauthorized", diagnostics);
@@ -721,20 +725,9 @@ function extractRateLimitInfoFromBody(
 ): RateLimitInfo | undefined {
         const isStatusRateLimit =
                 response.status === HTTP_STATUS.TOO_MANY_REQUESTS;
-        const parsed = parseRateLimitBody(bodyText);
-        const isServerOverload = isServerOverloadedError(
-                parsed
-                        ? {
-                                        error: {
-                                                code: parsed.code,
-                                                type: parsed.type,
-                                                context: parsed.contextType
-                                                        ? { type: parsed.contextType }
-                                                        : undefined,
-                                        },
-                                }
-                        : undefined,
-        );
+        const parsedErrorBody = parseStructuredErrorBody(bodyText);
+        const parsed = parseRateLimitBody(parsedErrorBody);
+        const isServerOverload = isServerOverloadedError(parsedErrorBody);
 
         if (isServerOverload && !isStatusRateLimit) {
                 return undefined;
@@ -776,18 +769,22 @@ interface RateLimitErrorBody {
 }
 
 function parseRateLimitBody(
-	body: string,
+	parsedBody: RateLimitErrorBody | undefined,
 ): { code?: string; type?: string; contextType?: string; resetsAt?: number; retryAfterMs?: number } | undefined {
+	if (!parsedBody) return undefined;
+	const error = parsedBody.error ?? {};
+	const code = (error.code ?? error.type ?? "").toString();
+	const type = typeof error.type === "string" ? error.type : undefined;
+	const contextType = typeof error.context?.type === "string" ? error.context.type : undefined;
+	const resetsAt = toNumber(error.resets_at ?? error.reset_at);
+	const retryAfterMs = toNumber(error.retry_after_ms ?? error.retry_after);
+	return { code, type, contextType, resetsAt, retryAfterMs };
+}
+
+function parseStructuredErrorBody(body: string): RateLimitErrorBody | undefined {
 	if (!body) return undefined;
 	try {
-		const parsed = JSON.parse(body) as RateLimitErrorBody;
-		const error = parsed?.error ?? {};
-		const code = (error.code ?? error.type ?? "").toString();
-		const type = typeof error.type === "string" ? error.type : undefined;
-		const contextType = typeof error.context?.type === "string" ? error.context.type : undefined;
-		const resetsAt = toNumber(error.resets_at ?? error.reset_at);
-		const retryAfterMs = toNumber(error.retry_after_ms ?? error.retry_after);
-		return { code, type, contextType, resetsAt, retryAfterMs };
+		return JSON.parse(body) as RateLimitErrorBody;
 	} catch {
 		return undefined;
 	}
@@ -798,6 +795,9 @@ type ErrorPayload = {
                 message: string;
                 type?: string;
                 code?: string | number;
+                context?: {
+                        type?: string;
+                };
                 unsupported_model?: string;
                 diagnostics?: ErrorDiagnostics;
         };
@@ -860,6 +860,12 @@ function normalizeErrorPayload(
                         }
                         if (typeof maybeError.code === "string" || typeof maybeError.code === "number") {
                                 payload.error.code = maybeError.code;
+                        }
+                        if (
+                                isRecord(maybeError.context) &&
+                                typeof maybeError.context.type === "string"
+                        ) {
+                                payload.error.context = { type: maybeError.context.type };
                         }
                         if (diagnostics && Object.keys(diagnostics).length > 0) {
                                 payload.error.diagnostics = diagnostics;

--- a/lib/types/napi-rs-keyring.d.ts
+++ b/lib/types/napi-rs-keyring.d.ts
@@ -1,0 +1,8 @@
+declare module "@napi-rs/keyring" {
+	export class Entry {
+		constructor(service: string, account: string);
+		getPassword(): string | null;
+		setPassword(secret: string): void;
+		deletePassword(): boolean;
+	}
+}

--- a/lib/types/napi-rs-keyring.d.ts
+++ b/lib/types/napi-rs-keyring.d.ts
@@ -1,6 +1,6 @@
 declare module "@napi-rs/keyring" {
 	export class Entry {
-		constructor(service: string, account: string);
+		constructor(service: string, username: string);
 		getPassword(): string | null;
 		setPassword(secret: string): void;
 		deletePassword(): boolean;

--- a/test/fetch-helpers.test.ts
+++ b/test/fetch-helpers.test.ts
@@ -608,7 +608,7 @@ describe('Fetch Helpers Module', () => {
 		});
 	});
 
-	describe('handleErrorResponse edge cases', () => {
+		describe('handleErrorResponse edge cases', () => {
 		it('handles 404 with non-JSON body containing usage limit text', async () => {
 			const response = new Response('usage limit exceeded - please try again', { status: 404 });
 			
@@ -635,6 +635,24 @@ describe('Fetch Helpers Module', () => {
 			const { response: result, rateLimit } = await handleErrorResponse(response);
 			
 			expect(result.status).toBe(429);
+			expect(rateLimit).toBeUndefined();
+		});
+
+		it('marks exact server overload payload as server retry, not rate limit', async () => {
+			const body = {
+				error: {
+					type: 'service_unavailable_error',
+					code: 'server_is_overloaded',
+					message: 'Our servers are currently overloaded. Please try again later.',
+					param: null,
+				},
+			};
+			const response = new Response(JSON.stringify(body), { status: 429 });
+
+			const { response: result, rateLimit, retryAsServerError } = await handleErrorResponse(response);
+
+			expect(result.status).toBe(429);
+			expect(retryAsServerError).toBe(true);
 			expect(rateLimit).toBeUndefined();
 		});
 

--- a/test/fetch-helpers.test.ts
+++ b/test/fetch-helpers.test.ts
@@ -656,6 +656,38 @@ describe('Fetch Helpers Module', () => {
 			expect(rateLimit).toBeUndefined();
 		});
 
+		it('marks reduced service_unavailable_error payload as server retry, not rate limit', async () => {
+			const body = {
+				error: {
+					type: 'service_unavailable_error',
+					message: 'Our servers are currently overloaded. Please try again later.',
+				},
+			};
+			const response = new Response(JSON.stringify(body), { status: 429 });
+
+			const { rateLimit, retryAsServerError } = await handleErrorResponse(response);
+
+			expect(retryAsServerError).toBe(true);
+			expect(rateLimit).toBeUndefined();
+		});
+
+		it('marks reduced context.service_unavailable_error payload as server retry, not rate limit', async () => {
+			const body = {
+				error: {
+					context: {
+						type: 'service_unavailable_error',
+					},
+					message: 'Our servers are currently overloaded. Please try again later.',
+				},
+			};
+			const response = new Response(JSON.stringify(body), { status: 429 });
+
+			const { rateLimit, retryAsServerError } = await handleErrorResponse(response);
+
+			expect(retryAsServerError).toBe(true);
+			expect(rateLimit).toBeUndefined();
+		});
+
 		it('handles Response that throws on clone (safeReadBody catch)', async () => {
 			const response = new Response('test', { status: 500 });
 			const originalClone = response.clone.bind(response);

--- a/test/fetch-helpers.test.ts
+++ b/test/fetch-helpers.test.ts
@@ -640,6 +640,7 @@ describe('Fetch Helpers Module', () => {
 
 		it('marks exact server overload payload as server retry and preserves retry-after', async () => {
 			const body = {
+				type: 'error',
 				error: {
 					type: 'service_unavailable_error',
 					code: 'server_is_overloaded',
@@ -687,6 +688,23 @@ describe('Fetch Helpers Module', () => {
 			const { rateLimit, retryAsServerError } = await handleErrorResponse(response);
 
 			expect(retryAsServerError).toBe(true);
+			expect(rateLimit?.retryAfterMs).toBe(60000);
+		});
+
+		it('does not treat context.service_unavailable_error without overload wording as server retry', async () => {
+			const body = {
+				error: {
+					context: {
+						type: 'service_unavailable_error',
+					},
+					message: 'Service temporarily unavailable.',
+				},
+			};
+			const response = new Response(JSON.stringify(body), { status: 429 });
+
+			const { rateLimit, retryAsServerError } = await handleErrorResponse(response);
+
+			expect(retryAsServerError).toBe(false);
 			expect(rateLimit?.retryAfterMs).toBe(60000);
 		});
 

--- a/test/fetch-helpers.test.ts
+++ b/test/fetch-helpers.test.ts
@@ -638,12 +638,13 @@ describe('Fetch Helpers Module', () => {
 			expect(rateLimit).toBeUndefined();
 		});
 
-		it('marks exact server overload payload as server retry, not rate limit', async () => {
+		it('marks exact server overload payload as server retry and preserves retry-after', async () => {
 			const body = {
 				error: {
 					type: 'service_unavailable_error',
 					code: 'server_is_overloaded',
 					message: 'Our servers are currently overloaded. Please try again later.',
+					retry_after_ms: 1750,
 					param: null,
 				},
 			};
@@ -653,10 +654,11 @@ describe('Fetch Helpers Module', () => {
 
 			expect(result.status).toBe(429);
 			expect(retryAsServerError).toBe(true);
-			expect(rateLimit).toBeUndefined();
+			expect(rateLimit?.retryAfterMs).toBe(1750);
+			expect(rateLimit?.code).toBe('server_is_overloaded');
 		});
 
-		it('marks reduced service_unavailable_error payload as server retry, not rate limit', async () => {
+		it('marks reduced service_unavailable_error payload as server retry and preserves fallback backoff', async () => {
 			const body = {
 				error: {
 					type: 'service_unavailable_error',
@@ -668,10 +670,10 @@ describe('Fetch Helpers Module', () => {
 			const { rateLimit, retryAsServerError } = await handleErrorResponse(response);
 
 			expect(retryAsServerError).toBe(true);
-			expect(rateLimit).toBeUndefined();
+			expect(rateLimit?.retryAfterMs).toBe(60000);
 		});
 
-		it('marks reduced context.service_unavailable_error payload as server retry, not rate limit', async () => {
+		it('marks reduced context.service_unavailable_error payload as server retry and preserves fallback backoff', async () => {
 			const body = {
 				error: {
 					context: {
@@ -685,7 +687,7 @@ describe('Fetch Helpers Module', () => {
 			const { rateLimit, retryAsServerError } = await handleErrorResponse(response);
 
 			expect(retryAsServerError).toBe(true);
-			expect(rateLimit).toBeUndefined();
+			expect(rateLimit?.retryAfterMs).toBe(60000);
 		});
 
 		it('handles Response that throws on clone (safeReadBody catch)', async () => {

--- a/test/index-retry.test.ts
+++ b/test/index-retry.test.ts
@@ -41,6 +41,7 @@ vi.mock("../lib/request/fetch-helpers.js", () => ({
 	},
 	isDeactivatedWorkspaceError: () => false,
 	resolveUnsupportedCodexFallbackModel: () => undefined,
+	getUnsupportedCodexModelInfo: () => undefined,
 	shouldFallbackToGpt52OnUnsupportedGpt53: () => false,
 	handleSuccessResponse: async (response: Response) => response,
 }));
@@ -272,7 +273,7 @@ describe("OpenAIAuthPlugin rate-limit retry", () => {
 		await vi.advanceTimersByTimeAsync(1500);
 		expect(fetchMock).toHaveBeenCalledTimes(1);
 
-		await vi.advanceTimersByTimeAsync(1500);
+		await vi.runAllTimersAsync();
 		expect(fetchMock).toHaveBeenCalledTimes(2);
 
 		const response = await fetchPromise;

--- a/test/index-retry.test.ts
+++ b/test/index-retry.test.ts
@@ -23,7 +23,22 @@ vi.mock("../lib/request/fetch-helpers.js", () => ({
 	shouldRefreshToken: () => false,
 	refreshAndUpdateToken: async (auth: any) => auth,
 	createCodexHeaders: () => new Headers(),
-	handleErrorResponse: async (response: Response) => ({ response }),
+	handleErrorResponse: async (response: Response) => {
+		try {
+			const body = await response.clone().json();
+			if (
+				body?.type === "error" &&
+				body?.error?.type === "service_unavailable_error" &&
+				body?.error?.code === "server_is_overloaded"
+			) {
+				return { response, errorBody: body, retryAsServerError: true };
+			}
+		} catch {
+			// Non-JSON responses are irrelevant to this focused retry regression.
+		}
+
+		return { response };
+	},
 	isDeactivatedWorkspaceError: () => false,
 	resolveUnsupportedCodexFallbackModel: () => undefined,
 	shouldFallbackToGpt52OnUnsupportedGpt53: () => false,
@@ -185,13 +200,13 @@ describe("OpenAIAuthPlugin rate-limit retry", () => {
 	});
 
 	it("waits and retries when all accounts are rate-limited", async () => {
-		const { OpenAIAuthPlugin } = await import("../index.js");
+		const { OpenAIAuthPlugin } = (await import("../index.js")) as any;
 		const client = {
 			tui: { showToast: vi.fn() },
 			auth: { set: vi.fn() },
 		} as any;
 
-		const plugin = await OpenAIAuthPlugin({ client });
+		const plugin = await OpenAIAuthPlugin({ client } as any);
 
 		const getAuth = async () => ({
 			type: "oauth" as const,
@@ -201,7 +216,7 @@ describe("OpenAIAuthPlugin rate-limit retry", () => {
 			multiAccount: true,
 		});
 
-		const sdk = (await plugin.auth.loader(getAuth, { options: {}, models: {} })) as any;
+		const sdk = (await (plugin.auth as any).loader(getAuth, { options: {}, models: {} } as any)) as any;
 
 		const fetchPromise = sdk.fetch("https://example.com", {});
 		expect(globalThis.fetch).not.toHaveBeenCalled();
@@ -210,6 +225,57 @@ describe("OpenAIAuthPlugin rate-limit retry", () => {
 
 		const response = await fetchPromise;
 		expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+		expect(response.status).toBe(200);
+	});
+
+	it("retries when the upstream returns server overload payload", async () => {
+		const { OpenAIAuthPlugin } = (await import("../index.js")) as any;
+		const client = {
+			tui: { showToast: vi.fn() },
+			auth: { set: vi.fn() },
+		} as any;
+
+		const plugin = await OpenAIAuthPlugin({ client } as any);
+
+		const getAuth = async () => ({
+			type: "oauth" as const,
+			access: "a",
+			refresh: "r",
+			expires: Date.now() + 60_000,
+			multiAccount: true,
+		});
+
+		const sdk = (await (plugin.auth as any).loader(getAuth, { options: {}, models: {} } as any)) as any;
+		const fetchMock = vi.mocked(globalThis.fetch);
+		fetchMock.mockReset();
+		fetchMock
+			.mockResolvedValueOnce(
+				new Response(
+					JSON.stringify({
+						type: "error",
+						sequence_number: 2,
+						error: {
+							type: "service_unavailable_error",
+							code: "server_is_overloaded",
+							message: "Our servers are currently overloaded. Please try again later.",
+							param: null,
+						},
+					}),
+					{ status: 400, headers: { "content-type": "application/json" } },
+				),
+			)
+			.mockResolvedValueOnce(new Response("ok", { status: 200 }));
+
+		const fetchPromise = sdk.fetch("https://example.com", {});
+		expect(fetchMock).not.toHaveBeenCalled();
+
+		await vi.advanceTimersByTimeAsync(1500);
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+
+		await vi.advanceTimersByTimeAsync(1500);
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+
+		const response = await fetchPromise;
 		expect(response.status).toBe(200);
 	});
 });

--- a/test/index-retry.test.ts
+++ b/test/index-retry.test.ts
@@ -41,7 +41,11 @@ vi.mock("../lib/request/fetch-helpers.js", () => ({
 	},
 	isDeactivatedWorkspaceError: () => false,
 	resolveUnsupportedCodexFallbackModel: () => undefined,
-	getUnsupportedCodexModelInfo: () => undefined,
+	getUnsupportedCodexModelInfo: () => ({
+		isUnsupported: false,
+		unsupportedModel: undefined,
+		message: undefined,
+	}),
 	shouldFallbackToGpt52OnUnsupportedGpt53: () => false,
 	handleSuccessResponse: async (response: Response) => response,
 }));
@@ -53,19 +57,24 @@ vi.mock("../lib/request/request-transformer.js", () => ({
 vi.mock("../lib/accounts.js", () => {
 	class AccountManager {
 		private calls = 0;
+		private readonly accounts = [
+			null,
+			{ index: 0, accountId: "account-1", email: "user@example.com" },
+			{ index: 1, accountId: "account-2", email: "second@example.com" },
+		] as const;
 
 		static async loadFromDisk() {
 			return new AccountManager();
 		}
 
 		getAccountCount() {
-			return 1;
+			return 2;
 		}
 
 		getCurrentOrNextForFamily() {
+			const account = this.accounts[Math.min(this.calls, this.accounts.length - 1)];
 			this.calls += 1;
-			if (this.calls === 1) return null;
-			return { index: 0, accountId: "account-1", email: "user@example.com" };
+			return account;
 		}
 
 		getCurrentOrNextForFamilyHybrid() {

--- a/test/index-retry.test.ts
+++ b/test/index-retry.test.ts
@@ -28,8 +28,11 @@ vi.mock("../lib/request/fetch-helpers.js", () => ({
 			const body = await response.clone().json();
 			if (
 				body?.type === "error" &&
-				body?.error?.type === "service_unavailable_error" &&
-				body?.error?.code === "server_is_overloaded"
+				(
+					body?.error?.code === "server_is_overloaded" ||
+					body?.error?.type === "service_unavailable_error" ||
+					body?.error?.context?.type === "service_unavailable_error"
+				)
 			) {
 				return { response, errorBody: body, retryAsServerError: true };
 			}
@@ -238,7 +241,32 @@ describe("OpenAIAuthPlugin rate-limit retry", () => {
 		expect(response.status).toBe(200);
 	});
 
-	it("retries when the upstream returns server overload payload", async () => {
+	it.each([
+		[
+			"code + type overload payload",
+			{
+				type: "error",
+				sequence_number: 2,
+				error: {
+					type: "service_unavailable_error",
+					code: "server_is_overloaded",
+					message: "Our servers are currently overloaded. Please try again later.",
+					param: null,
+				},
+			},
+		],
+		[
+			"type-only overload payload",
+			{
+				type: "error",
+				sequence_number: 2,
+				error: {
+					type: "service_unavailable_error",
+					message: "Our servers are currently overloaded. Please try again later.",
+				},
+			},
+		],
+	])("retries when the upstream returns %s", async (_label, overloadPayload) => {
 		const { OpenAIAuthPlugin } = (await import("../index.js")) as any;
 		const client = {
 			tui: { showToast: vi.fn() },
@@ -261,16 +289,7 @@ describe("OpenAIAuthPlugin rate-limit retry", () => {
 		fetchMock
 			.mockResolvedValueOnce(
 				new Response(
-					JSON.stringify({
-						type: "error",
-						sequence_number: 2,
-						error: {
-							type: "service_unavailable_error",
-							code: "server_is_overloaded",
-							message: "Our servers are currently overloaded. Please try again later.",
-							param: null,
-						},
-					}),
+					JSON.stringify(overloadPayload),
 					{ status: 400, headers: { "content-type": "application/json" } },
 				),
 			)

--- a/test/index-retry.test.ts
+++ b/test/index-retry.test.ts
@@ -280,7 +280,7 @@ describe("OpenAIAuthPlugin rate-limit retry", () => {
 		expect(fetchMock).not.toHaveBeenCalled();
 
 		await vi.advanceTimersByTimeAsync(1500);
-		expect(fetchMock).toHaveBeenCalledTimes(1);
+		expect(fetchMock).toHaveBeenCalled();
 
 		await vi.runAllTimersAsync();
 		expect(fetchMock).toHaveBeenCalledTimes(2);

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -2427,6 +2427,140 @@ describe("OpenAIOAuthPlugin fetch handler", () => {
 		expect(await response.text()).toContain("server errors or auth issues");
 	});
 
+	it("retries single-account overloads when retry-after is preserved on server overloads", async () => {
+		const fetchHelpers = await import("../lib/request/fetch-helpers.js");
+		const accountsModule = await import("../lib/accounts.js");
+		const { AccountManager } = accountsModule;
+
+		vi.useFakeTimers();
+
+		try {
+			const overloadedAccount = {
+				index: 0,
+				accountId: "acc-1",
+				email: "user@example.com",
+				refreshToken: "refresh-1",
+			};
+
+			let rateLimitedUntil = 0;
+			const markRateLimitedWithReason = vi.fn(
+				(_account: typeof overloadedAccount, retryAfterMs: number) => {
+				rateLimitedUntil = Date.now() + retryAfterMs;
+				},
+			);
+			const customManager = {
+				getAccountCount: () => 1,
+				getCurrentOrNextForFamilyHybrid: () => overloadedAccount,
+				getSelectionExplainability: () => [
+					{
+						index: 0,
+						enabled: true,
+						isCurrentForFamily: true,
+						eligible: true,
+						reasons: ["eligible"],
+						healthScore: 100,
+						tokensAvailable: 50,
+						lastUsed: Date.now(),
+					},
+				],
+				toAuthDetails: () => ({
+					type: "oauth" as const,
+					access: "access-overloaded",
+					refresh: overloadedAccount.refreshToken,
+					expires: Date.now() + 60_000,
+				}),
+				hasRefreshToken: () => true,
+				saveToDiskDebounced: vi.fn(),
+				updateFromAuth: vi.fn(),
+				clearAuthFailures: vi.fn(),
+				incrementAuthFailures: vi.fn(() => 1),
+				markAccountCoolingDown: vi.fn(),
+				markRateLimitedWithReason,
+				recordRateLimit: vi.fn(),
+				consumeToken: vi.fn(() => true),
+				refundToken: vi.fn(),
+				markSwitched: vi.fn(),
+				removeAccount: vi.fn(() => false),
+				removeAccountsWithSameRefreshToken: vi.fn(() => 0),
+				recordFailure: vi.fn(),
+				recordSuccess: vi.fn(),
+				getMinWaitTimeForFamily: vi.fn(() => Math.max(0, rateLimitedUntil - Date.now())),
+				shouldShowAccountToast: vi.fn(() => false),
+				markToastShown: vi.fn(),
+				setActiveIndex: vi.fn(() => overloadedAccount),
+				getAccountsSnapshot: vi.fn(() => [overloadedAccount]),
+			};
+			vi.spyOn(AccountManager, "loadFromDisk").mockResolvedValueOnce(customManager as never);
+			vi.mocked(fetchHelpers.createCodexHeaders).mockImplementation(
+				(_init, _accountId, accessToken) =>
+					new Headers({ "x-test-access-token": String(accessToken) }),
+			);
+			vi.mocked(fetchHelpers.handleErrorResponse).mockResolvedValueOnce({
+				response: new Response(
+					JSON.stringify({
+						error: {
+							context: {
+								type: "service_unavailable_error",
+							},
+							message: "Our servers are currently overloaded. Please try again later.",
+							retry_after_ms: 1000,
+						},
+					}),
+					{ status: 429 },
+				),
+				rateLimit: { retryAfterMs: 1000, code: "server_is_overloaded" },
+				errorBody: {
+					error: {
+						context: {
+							type: "service_unavailable_error",
+						},
+					},
+				},
+				retryAsServerError: true,
+			});
+
+			globalThis.fetch = vi
+				.fn()
+				.mockResolvedValueOnce(
+					new Response(
+						JSON.stringify({
+							error: {
+								context: {
+									type: "service_unavailable_error",
+								},
+								message: "Our servers are currently overloaded. Please try again later.",
+								retry_after_ms: 1000,
+							},
+						}),
+						{ status: 429 },
+					),
+				)
+				.mockResolvedValueOnce(new Response(JSON.stringify({ content: "ok" }), { status: 200 }));
+
+			const { sdk } = await setupPlugin();
+			const fetchPromise = sdk.fetch!("https://api.openai.com/v1/chat", {
+				method: "POST",
+				body: JSON.stringify({ model: "gpt-5.1" }),
+			});
+
+			await vi.advanceTimersByTimeAsync(1500);
+
+			const response = await fetchPromise;
+			expect(response.status).toBe(200);
+			expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+			expect(markRateLimitedWithReason).toHaveBeenCalledWith(
+				overloadedAccount,
+				1000,
+				"gpt-5.1",
+				"unknown",
+				"gpt-5.1",
+			);
+			expect(customManager.getMinWaitTimeForFamily).toHaveBeenCalled();
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
 	it("cools down the account when grouped auth removal removes zero entries", async () => {
 		const fetchHelpers = await import("../lib/request/fetch-helpers.js");
 		const { AccountManager } = await import("../lib/accounts.js");

--- a/test/storage.test.ts
+++ b/test/storage.test.ts
@@ -128,16 +128,18 @@ describe("storage", () => {
       await fs.mkdir(testWorkDir, { recursive: true });
       testStoragePath = join(testWorkDir, "accounts-" + Math.random().toString(36).slice(2) + ".json");
       setStoragePathDirect(testStoragePath);
+      await clearAccounts();
     });
 
     afterEach(async () => {
+      await clearAccounts();
       setStoragePathDirect(null);
       await fs.rm(testWorkDir, { recursive: true, force: true });
     });
 
     it("should export accounts to a file", async () => {
       const storage = {
-        version: 3,
+        version: 3 as const,
         activeIndex: 0,
         accounts: [{ accountId: "test", refreshToken: "ref", addedAt: 1, lastUsed: 2 }]
       };
@@ -160,7 +162,7 @@ describe("storage", () => {
     it("defaults to non-destructive export (force=false) and refuses to overwrite", async () => {
       // Arrange: populate storage and a pre-existing export target.
       const storage = {
-        version: 3,
+        version: 3 as const,
         activeIndex: 0,
         accounts: [{ accountId: "test", refreshToken: "ref", addedAt: 1, lastUsed: 2 }],
       };
@@ -180,7 +182,7 @@ describe("storage", () => {
 
     it("should import accounts from a file and merge", async () => {
       const existing = {
-        version: 3,
+        version: 3 as const,
         activeIndex: 0,
         accounts: [{ accountId: "existing", refreshToken: "ref1", addedAt: 1, lastUsed: 2 }]
       };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,7 +25,8 @@
   },
   "include": [
     "index.ts",
-    "lib/**/*.ts"
+    "lib/**/*.ts",
+    "lib/**/*.d.ts"
   ],
   "exclude": [
     "node_modules",


### PR DESCRIPTION
## Summary
- treat structured `service_unavailable_error` / `server_is_overloaded` payloads as server-retryable even when the HTTP status is not 5xx
- add helper and plugin retry regressions so overload responses stay on the server retry path instead of being misclassified as rate limits
- include two small green-gate follow-ups: isolate a leaking storage import/export test and add a type shim for the optional `@napi-rs/keyring` module so the suite and typecheck stay green

## Verification
- npm test -- test/fetch-helpers.test.ts test/index-retry.test.ts
- npm test
- npm run lint
- npm run typecheck

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added secure keyring integration for credential storage.

* **Improvements**
  * Server overload responses now automatically trigger retries with account rotation.
  * Enhanced detection of service unavailability conditions for improved error handling.

* **Tests**
  * Expanded test coverage for server overload scenarios, automatic retry behavior, and account storage operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

this pr fixes misclassification of anthropic `service_unavailable_error` / `server_is_overloaded` payloads (typically arriving as 429s) so they route through the server-error rotation path instead of the rate-limit path. the implementation adds `isServerOverloadedError`, threads `retryAsServerError` through `handleErrorResponse`, and extends the server-error branch in `index.ts` to also apply rate-limit backoff metadata when an overload 429 carries a `retry_after_ms`. the previous review's concern about `context.type` being checked before `maybeError.type` is now resolved — the correct field order is in place.

<h3>Confidence Score: 5/5</h3>

safe to merge — all remaining findings are p2 style/coverage observations with no correctness impact

the core detection logic is correct and well-tested at both unit and integration level; the prior p1 concern about `context.type` field ordering is fixed; no p0/p1 issues remain

test/index-retry.test.ts — mock drift on top-level type check; index.ts — missing 5xx overload regression test

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/request/fetch-helpers.ts | adds `isServerOverloadedError` helper and `retryAsServerError` flag; `context.type` branch previously flagged in review is now properly ordered after the direct `type` check; one redundant term in `isRateLimit` expression |
| index.ts | server error branch extended to handle `retryAsServerError` flag; rate-limit marking + server-error accounting applied together for overload 429s; indentation around the new destructure is inconsistent with surrounding code |
| test/fetch-helpers.test.ts | four new overload regression tests; correctly exercises `code+type`, `type-only`, `context.type`, and negative case; stray extra-indent on describe block |
| test/index-retry.test.ts | adds `it.each` overload retry integration tests; mock `handleErrorResponse` gates on top-level `type: "error"` which the real function doesn't require — minor drift risk |
| test/index.test.ts | adds single-account overload retry integration test with mocked `handleErrorResponse` and custom `AccountManager`; exercises `markRateLimitedWithReason` and `getMinWaitTimeForFamily` call paths |
| test/storage.test.ts | adds `clearAccounts()` calls in beforeEach/afterEach to prevent state leakage; narrows `version: 3` to `3 as const` for type correctness |
| lib/types/napi-rs-keyring.d.ts | new ambient module declaration shim for optional `@napi-rs/keyring` so typecheck passes without the native binary installed |
| tsconfig.json | adds `lib/**/*.d.ts` to include so the new keyring shim is picked up by typecheck; adds trailing newline |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[upstream response] --> B{HTTP status}
    B -- "5xx" --> SE[server error path]
    B -- "429" --> C{isServerOverloadedError?}
    B -- "other" --> RL[rate-limit / other path]

    C -- "yes\nerror.code=server_is_overloaded\nor error.type=service_unavailable_error\nor context.type+overload msg" --> D[retryAsServerError=true]
    C -- "no" --> RL

    D --> E{rateLimit present?}
    E -- "yes" --> F[markRateLimitedWithReason\naccount.lastSwitchReason=rate-limit\nsaveToDiskDebounced]
    E -- "no" --> SE
    F --> SE

    SE --> G[runtimeMetrics.serverErrors++\naccountRotations++\ncircuitBreaker.recordFailure\nrefundToken / recordFailure]
    G --> H{consumeRetryBudget server?}
    H -- "budget ok" --> I[break → rotate account → retry]
    H -- "exhausted" --> J[return errorResponse]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: lib/request/fetch-helpers.ts
Line: 743-748

Comment:
**redundant `isServerOverload` term in `isRateLimit` OR chain**

the early-return guard on line 732 (`if (isServerOverload && !isStatusRateLimit) return undefined`) means by the time we reach the `isRateLimit` expression, `isServerOverload` can only be `true` when `isStatusRateLimit` is also `true`. adding `isServerOverload` to the OR chain doesn't change the result — `isStatusRateLimit` already covers it. harmless, but adds noise to the intent signal.

```suggestion
        const isRateLimit =
                isStatusRateLimit ||
                /usage_limit_reached|rate_limit_exceeded|rate_limit|usage limit/i.test(
                        haystack,
                );
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: test/index-retry.test.ts
Line: 31-48

Comment:
**mock detection logic diverges from real `isServerOverloadedError`**

the mock adds a top-level `body?.type === "error"` gate that the real `isServerOverloadedError` doesn't require — the real function only inspects `errorBody.error.*`. any future payload without a top-level `type: "error"` field would slip through the mock as `retryAsServerError: false` while the real path would correctly flag it. the unit-level tests in `fetch-helpers.test.ts` cover this correctly (those payloads omit the top-level `type`), so this is a mock-drift risk rather than a current failure.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: test/fetch-helpers.test.ts
Line: 611

Comment:
**stray indentation change on describe block**

the `describe('handleErrorResponse edge cases')` block was re-indented with an extra tab on line 611. minor but inconsistent with the rest of the file's style.

```suggestion
	describe('handleErrorResponse edge cases', () => {
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: index.ts
Line: 2221-2231

Comment:
**missing vitest coverage: true 5xx overload case**

there's no test for `retryAsServerError = true` when `response.status >= 500` (e.g., a 503 with `server_is_overloaded` payload). in that scenario the code calls `markRateLimitedWithReason` AND `recordFailure` + `circuitBreaker.recordFailure()` in the same pass — double-penalising the account. worth adding a regression to confirm that path doesn't cause unintended breaker tripping or token accounting drift.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (4): Last reviewed commit: ["fix(retry): align overload handling with..."](https://github.com/ndycode/oc-codex-multi-auth/commit/e96b14e1986a7b8c3b006beb0bf00ae28bbe793d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29257880)</sub>

<!-- /greptile_comment -->