### PR TITLE
fix: retry live upstream server_error payloads

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1993,11 +1993,11 @@ while (attempted.size < Math.max(1, accountCount)) {
 										return contextOverflowResult.response;
 									}
 
-									const { response: errorResponse, rateLimit, errorBody } =
-										await handleErrorResponse(response, {
-											requestCorrelationId,
-											threadId: threadIdCandidate,
-										});
+					const { response: errorResponse, rateLimit, errorBody, retryAsServerError } =
+						await handleErrorResponse(response, {
+							requestCorrelationId,
+							threadId: threadIdCandidate,
+						});
 
 			const workspaceDeactivated = isDeactivatedWorkspaceError(errorBody, response.status);
 				if (workspaceDeactivated) {
@@ -2216,9 +2216,12 @@ while (attempted.size < Math.max(1, accountCount)) {
 						logDebug(`[${PLUGIN_NAME}] Recoverable error detected: ${errorType}`);
 					}
 
-					// Handle 5xx server errors by rotating to another account
-					if (response.status >= 500 && response.status < 600) {
-						logWarn(`Server error ${response.status} for account ${account.index + 1}. Rotating to next account.`);
+					// Handle 5xx server errors, and exact overload payloads flagged by
+					// handleErrorResponse, by rotating to another account.
+					if (retryAsServerError || (response.status >= 500 && response.status < 600)) {
+						logWarn(
+							`Server error ${response.status} for account ${account.index + 1}. Rotating to next account.`,
+						);
 						runtimeMetrics.failedRequests++;
 						runtimeMetrics.serverErrors++;
 						runtimeMetrics.accountRotations++;

--- a/lib/request/fetch-helpers.ts
+++ b/lib/request/fetch-helpers.ts
@@ -308,26 +308,23 @@ function isServerOverloadedError(errorBody: unknown): boolean {
 	const maybeError = errorBody.error;
 	if (!isRecord(maybeError)) return false;
 
-	if (
-		typeof maybeError.code === "string" &&
-		(maybeError.code === "server_is_overloaded" || maybeError.code === "server_error")
-	) {
-		return true;
-	}
-
-	if (
-		typeof maybeError.type === "string" &&
-		(maybeError.type === "service_unavailable_error" || maybeError.type === "server_error")
-	) {
-		return true;
-	}
-
+	const code = typeof maybeError.code === "string" ? maybeError.code : undefined;
+	const type = typeof maybeError.type === "string" ? maybeError.type : undefined;
 	const maybeContext = maybeError.context;
-	return (
-		isRecord(maybeContext) &&
-		typeof maybeContext.type === "string" &&
-		(maybeContext.type === "service_unavailable_error" || maybeContext.type === "server_error")
-	);
+	const contextType =
+		isRecord(maybeContext) && typeof maybeContext.type === "string"
+			? maybeContext.type
+			: undefined;
+
+	if (code === "server_is_overloaded") {
+		return true;
+	}
+
+	if (type === "service_unavailable_error" || contextType === "service_unavailable_error") {
+		return true;
+	}
+
+	return code === "server_error" && (type === "server_error" || contextType === "server_error");
 }
 
 export function isDeactivatedWorkspaceError(errorBody: unknown, status?: number): boolean {

--- a/lib/request/fetch-helpers.ts
+++ b/lib/request/fetch-helpers.ts
@@ -34,6 +34,10 @@ export interface EntitlementError {
         message: string;
 }
 
+export interface ServerRetryInfo {
+	retryAsServerError?: boolean;
+}
+
 const CODEX_BASE_URL_OBJECT = new URL(CODEX_BASE_URL);
 const CODEX_BASE_PATH_PREFIX = CODEX_BASE_URL_OBJECT.pathname.endsWith("/")
 	? CODEX_BASE_URL_OBJECT.pathname.slice(0, -1)
@@ -265,6 +269,7 @@ export interface ErrorHandlingResult {
         response: Response;
         rateLimit?: RateLimitInfo;
         errorBody?: unknown;
+        retryAsServerError?: boolean;
 }
 
 export interface ErrorHandlingOptions {
@@ -299,6 +304,34 @@ function getStructuredErrorCode(errorBody: unknown): string | undefined {
 	}
 
 	return undefined;
+}
+
+function isServerOverloadedError(errorBody: unknown): boolean {
+	if (!isRecord(errorBody)) return false;
+
+	const maybeError = errorBody.error;
+	if (!isRecord(maybeError)) return false;
+
+	if (
+		typeof maybeError.code === "string" &&
+		(maybeError.code === "server_is_overloaded" || maybeError.code === "server_error")
+	) {
+		return true;
+	}
+
+	if (
+		typeof maybeError.type === "string" &&
+		(maybeError.type === "service_unavailable_error" || maybeError.type === "server_error")
+	) {
+		return true;
+	}
+
+	const maybeContext = maybeError.context;
+	return (
+		isRecord(maybeContext) &&
+		typeof maybeContext.type === "string" &&
+		(maybeContext.type === "service_unavailable_error" || maybeContext.type === "server_error")
+	);
 }
 
 export function isDeactivatedWorkspaceError(errorBody: unknown, status?: number): boolean {
@@ -599,6 +632,7 @@ export async function handleErrorResponse(
                 diagnostics,
         );
         const errorResponse = ensureJsonErrorResponse(finalResponse, normalizedError);
+        const retryAsServerError = isServerOverloadedError(errorBody);
 
         if (finalResponse.status === HTTP_STATUS.UNAUTHORIZED) {
                 logWarn("Codex upstream returned 401 Unauthorized", diagnostics);
@@ -610,7 +644,12 @@ export async function handleErrorResponse(
                 diagnostics,
         });
 
-        return { response: errorResponse, rateLimit, errorBody: normalizedError };
+        return {
+		response: errorResponse,
+		rateLimit,
+		errorBody: normalizedError,
+		retryAsServerError,
+	};
 }
 
 /**
@@ -694,6 +733,24 @@ function extractRateLimitInfoFromBody(
                 response.status === HTTP_STATUS.TOO_MANY_REQUESTS;
         const parsed = parseRateLimitBody(bodyText);
 
+		if (
+			isServerOverloadedError(
+				parsed
+					? {
+						error: {
+							code: parsed.code,
+							type: parsed.type,
+							context: parsed.contextType
+								? { type: parsed.contextType }
+								: undefined,
+						},
+					}
+					: undefined,
+			)
+		) {
+			return undefined;
+		}
+
         const haystack = `${parsed?.code ?? ""} ${bodyText}`.toLowerCase();
         
         // Entitlement errors should not be treated as rate limits
@@ -718,6 +775,9 @@ interface RateLimitErrorBody {
 	error?: {
 		code?: string | number;
 		type?: string;
+		context?: {
+			type?: string;
+		};
 		resets_at?: number;
 		reset_at?: number;
 		retry_after_ms?: number;
@@ -727,15 +787,17 @@ interface RateLimitErrorBody {
 
 function parseRateLimitBody(
 	body: string,
-): { code?: string; resetsAt?: number; retryAfterMs?: number } | undefined {
+): { code?: string; type?: string; contextType?: string; resetsAt?: number; retryAfterMs?: number } | undefined {
 	if (!body) return undefined;
 	try {
 		const parsed = JSON.parse(body) as RateLimitErrorBody;
 		const error = parsed?.error ?? {};
 		const code = (error.code ?? error.type ?? "").toString();
+		const type = typeof error.type === "string" ? error.type : undefined;
+		const contextType = typeof error.context?.type === "string" ? error.context.type : undefined;
 		const resetsAt = toNumber(error.resets_at ?? error.reset_at);
 		const retryAfterMs = toNumber(error.retry_after_ms ?? error.retry_after);
-		return { code, resetsAt, retryAfterMs };
+		return { code, type, contextType, resetsAt, retryAfterMs };
 	} catch {
 		return undefined;
 	}

--- a/lib/request/fetch-helpers.ts
+++ b/lib/request/fetch-helpers.ts
@@ -34,10 +34,6 @@ export interface EntitlementError {
         message: string;
 }
 
-export interface ServerRetryInfo {
-	retryAsServerError?: boolean;
-}
-
 const CODEX_BASE_URL_OBJECT = new URL(CODEX_BASE_URL);
 const CODEX_BASE_PATH_PREFIX = CODEX_BASE_URL_OBJECT.pathname.endsWith("/")
 	? CODEX_BASE_URL_OBJECT.pathname.slice(0, -1)

--- a/lib/request/fetch-helpers.ts
+++ b/lib/request/fetch-helpers.ts
@@ -324,7 +324,7 @@ function isServerOverloadedError(errorBody: unknown): boolean {
 		return true;
 	}
 
-	return code === "server_error" && (type === "server_error" || contextType === "server_error");
+	return code === "server_error" && type === "server_error";
 }
 
 export function isDeactivatedWorkspaceError(errorBody: unknown, status?: number): boolean {

--- a/test/fetch-helpers.test.ts
+++ b/test/fetch-helpers.test.ts
@@ -705,6 +705,22 @@ describe('Fetch Helpers Module', () => {
 			expect(rateLimit).toBeUndefined();
 		});
 
+		it('does not mark partial server_error payloads as server retry', async () => {
+			const partialPayloads = [
+				{ error: { type: 'server_error', message: 'type only' } },
+				{ error: { code: 'server_error', message: 'code only' } },
+				{ error: { code: 'server_error', type: 'other_error', message: 'mismatched type' } },
+			];
+
+			for (const body of partialPayloads) {
+				const response = new Response(JSON.stringify(body), { status: 400 });
+				const { rateLimit, retryAsServerError } = await handleErrorResponse(response);
+
+				expect(retryAsServerError).toBe(false);
+				expect(rateLimit).toBeUndefined();
+			}
+		});
+
 		it('handles Response that throws on clone (safeReadBody catch)', async () => {
 			const response = new Response('test', { status: 500 });
 			const originalClone = response.clone.bind(response);

--- a/test/fetch-helpers.test.ts
+++ b/test/fetch-helpers.test.ts
@@ -608,7 +608,7 @@ describe('Fetch Helpers Module', () => {
 		});
 	});
 
-		describe('handleErrorResponse edge cases', () => {
+	describe('handleErrorResponse edge cases', () => {
 		it('handles 404 with non-JSON body containing usage limit text', async () => {
 			const response = new Response('usage limit exceeded - please try again', { status: 404 });
 			

--- a/test/fetch-helpers.test.ts
+++ b/test/fetch-helpers.test.ts
@@ -608,7 +608,7 @@ describe('Fetch Helpers Module', () => {
 		});
 	});
 
-	describe('handleErrorResponse edge cases', () => {
+		describe('handleErrorResponse edge cases', () => {
 		it('handles 404 with non-JSON body containing usage limit text', async () => {
 			const response = new Response('usage limit exceeded - please try again', { status: 404 });
 			
@@ -635,6 +635,73 @@ describe('Fetch Helpers Module', () => {
 			const { response: result, rateLimit } = await handleErrorResponse(response);
 			
 			expect(result.status).toBe(429);
+			expect(rateLimit).toBeUndefined();
+		});
+
+		it('marks exact server overload payload as server retry, not rate limit', async () => {
+			const body = {
+				error: {
+					type: 'service_unavailable_error',
+					code: 'server_is_overloaded',
+					message: 'Our servers are currently overloaded. Please try again later.',
+					param: null,
+				},
+			};
+			const response = new Response(JSON.stringify(body), { status: 429 });
+
+			const { response: result, rateLimit, retryAsServerError } = await handleErrorResponse(response);
+
+			expect(result.status).toBe(429);
+			expect(retryAsServerError).toBe(true);
+			expect(rateLimit).toBeUndefined();
+		});
+
+		it('marks reduced service_unavailable_error payload as server retry, not rate limit', async () => {
+			const body = {
+				error: {
+					type: 'service_unavailable_error',
+					message: 'Our servers are currently overloaded. Please try again later.',
+				},
+			};
+			const response = new Response(JSON.stringify(body), { status: 429 });
+
+			const { rateLimit, retryAsServerError } = await handleErrorResponse(response);
+
+			expect(retryAsServerError).toBe(true);
+			expect(rateLimit).toBeUndefined();
+		});
+
+		it('marks reduced context.service_unavailable_error payload as server retry, not rate limit', async () => {
+			const body = {
+				error: {
+					context: {
+						type: 'service_unavailable_error',
+					},
+					message: 'Our servers are currently overloaded. Please try again later.',
+				},
+			};
+			const response = new Response(JSON.stringify(body), { status: 429 });
+
+			const { rateLimit, retryAsServerError } = await handleErrorResponse(response);
+
+			expect(retryAsServerError).toBe(true);
+			expect(rateLimit).toBeUndefined();
+		});
+
+		it('marks live server_error payload as server retry on non-5xx response', async () => {
+			const body = {
+				error: {
+					type: 'server_error',
+					code: 'server_error',
+					message: 'The server had an error processing your request.',
+				},
+			};
+			const response = new Response(JSON.stringify(body), { status: 400 });
+
+			const { response: result, rateLimit, retryAsServerError } = await handleErrorResponse(response);
+
+			expect(result.status).toBe(400);
+			expect(retryAsServerError).toBe(true);
 			expect(rateLimit).toBeUndefined();
 		});
 

--- a/test/fetch-helpers.test.ts
+++ b/test/fetch-helpers.test.ts
@@ -710,6 +710,7 @@ describe('Fetch Helpers Module', () => {
 				{ error: { type: 'server_error', message: 'type only' } },
 				{ error: { code: 'server_error', message: 'code only' } },
 				{ error: { code: 'server_error', type: 'other_error', message: 'mismatched type' } },
+				{ error: { code: 'server_error', context: { type: 'server_error' }, message: 'context only' } },
 			];
 
 			for (const body of partialPayloads) {

--- a/test/index-retry.test.ts
+++ b/test/index-retry.test.ts
@@ -26,12 +26,15 @@ vi.mock("../lib/request/fetch-helpers.js", () => ({
 	handleErrorResponse: async (response: Response) => {
 		try {
 			const body = await response.clone().json();
+			const error = body?.error;
+			const code = error?.code;
+			const type = error?.type;
+			const contextType = error?.context?.type;
 			if (
-				(
-					(body?.error?.type === "service_unavailable_error" &&
-						body?.error?.code === "server_is_overloaded") ||
-					(body?.error?.type === "server_error" && body?.error?.code === "server_error")
-				)
+				code === "server_is_overloaded" ||
+				type === "service_unavailable_error" ||
+				contextType === "service_unavailable_error" ||
+				(code === "server_error" && (type === "server_error" || contextType === "server_error"))
 			) {
 				return { response, errorBody: body, retryAsServerError: true };
 			}

--- a/test/index-retry.test.ts
+++ b/test/index-retry.test.ts
@@ -23,9 +23,32 @@ vi.mock("../lib/request/fetch-helpers.js", () => ({
 	shouldRefreshToken: () => false,
 	refreshAndUpdateToken: async (auth: any) => auth,
 	createCodexHeaders: () => new Headers(),
-	handleErrorResponse: async (response: Response) => ({ response }),
+	handleErrorResponse: async (response: Response) => {
+		try {
+			const body = await response.clone().json();
+			if (
+				body?.type === "error" &&
+				(
+					(body?.error?.type === "service_unavailable_error" &&
+						body?.error?.code === "server_is_overloaded") ||
+					(body?.error?.type === "server_error" && body?.error?.code === "server_error")
+				)
+			) {
+				return { response, errorBody: body, retryAsServerError: true };
+			}
+		} catch {
+			// Non-JSON responses are irrelevant to this focused retry regression.
+		}
+
+		return { response };
+	},
 	isDeactivatedWorkspaceError: () => false,
 	resolveUnsupportedCodexFallbackModel: () => undefined,
+	getUnsupportedCodexModelInfo: () => ({
+		isUnsupported: false,
+		unsupportedModel: undefined,
+		message: undefined,
+	}),
 	shouldFallbackToGpt52OnUnsupportedGpt53: () => false,
 	handleSuccessResponse: async (response: Response) => response,
 }));
@@ -37,19 +60,24 @@ vi.mock("../lib/request/request-transformer.js", () => ({
 vi.mock("../lib/accounts.js", () => {
 	class AccountManager {
 		private calls = 0;
+		private readonly accounts = [
+			null,
+			{ index: 0, accountId: "account-1", email: "user@example.com" },
+			{ index: 1, accountId: "account-2", email: "second@example.com" },
+		] as const;
 
 		static async loadFromDisk() {
 			return new AccountManager();
 		}
 
 		getAccountCount() {
-			return 1;
+			return 2;
 		}
 
 		getCurrentOrNextForFamily() {
+			const account = this.accounts[Math.min(this.calls, this.accounts.length - 1)];
 			this.calls += 1;
-			if (this.calls === 1) return null;
-			return { index: 0, accountId: "account-1", email: "user@example.com" };
+			return account;
 		}
 
 		getCurrentOrNextForFamilyHybrid() {
@@ -185,13 +213,13 @@ describe("OpenAIAuthPlugin rate-limit retry", () => {
 	});
 
 	it("waits and retries when all accounts are rate-limited", async () => {
-		const { OpenAIAuthPlugin } = await import("../index.js");
+		const { OpenAIAuthPlugin } = (await import("../index.js")) as any;
 		const client = {
 			tui: { showToast: vi.fn() },
 			auth: { set: vi.fn() },
 		} as any;
 
-		const plugin = await OpenAIAuthPlugin({ client });
+		const plugin = await OpenAIAuthPlugin({ client } as any);
 
 		const getAuth = async () => ({
 			type: "oauth" as const,
@@ -201,7 +229,7 @@ describe("OpenAIAuthPlugin rate-limit retry", () => {
 			multiAccount: true,
 		});
 
-		const sdk = (await plugin.auth.loader(getAuth, { options: {}, models: {} })) as any;
+		const sdk = (await (plugin.auth as any).loader(getAuth, { options: {}, models: {} } as any)) as any;
 
 		const fetchPromise = sdk.fetch("https://example.com", {});
 		expect(globalThis.fetch).not.toHaveBeenCalled();
@@ -210,6 +238,57 @@ describe("OpenAIAuthPlugin rate-limit retry", () => {
 
 		const response = await fetchPromise;
 		expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+		expect(response.status).toBe(200);
+	});
+
+	it("retries when the upstream returns a live server_error payload", async () => {
+		const { OpenAIAuthPlugin } = (await import("../index.js")) as any;
+		const client = {
+			tui: { showToast: vi.fn() },
+			auth: { set: vi.fn() },
+		} as any;
+
+		const plugin = await OpenAIAuthPlugin({ client } as any);
+
+		const getAuth = async () => ({
+			type: "oauth" as const,
+			access: "a",
+			refresh: "r",
+			expires: Date.now() + 60_000,
+			multiAccount: true,
+		});
+
+		const sdk = (await (plugin.auth as any).loader(getAuth, { options: {}, models: {} } as any)) as any;
+		const fetchMock = vi.mocked(globalThis.fetch);
+		fetchMock.mockReset();
+		fetchMock
+			.mockResolvedValueOnce(
+				new Response(
+					JSON.stringify({
+						type: "error",
+						sequence_number: 2,
+						error: {
+							type: "server_error",
+							code: "server_error",
+							message: "The server had an error processing your request.",
+							param: null,
+						},
+					}),
+					{ status: 400, headers: { "content-type": "application/json" } },
+				),
+			)
+			.mockResolvedValueOnce(new Response("ok", { status: 200 }));
+
+		const fetchPromise = sdk.fetch("https://example.com", {});
+		expect(fetchMock).not.toHaveBeenCalled();
+
+		await vi.advanceTimersByTimeAsync(1500);
+		expect(fetchMock).toHaveBeenCalled();
+
+		await vi.runAllTimersAsync();
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+
+		const response = await fetchPromise;
 		expect(response.status).toBe(200);
 	});
 });

--- a/test/index-retry.test.ts
+++ b/test/index-retry.test.ts
@@ -27,7 +27,6 @@ vi.mock("../lib/request/fetch-helpers.js", () => ({
 		try {
 			const body = await response.clone().json();
 			if (
-				body?.type === "error" &&
 				(
 					(body?.error?.type === "service_unavailable_error" &&
 						body?.error?.code === "server_is_overloaded") ||
@@ -265,7 +264,6 @@ describe("OpenAIAuthPlugin rate-limit retry", () => {
 			.mockResolvedValueOnce(
 				new Response(
 					JSON.stringify({
-						type: "error",
 						sequence_number: 2,
 						error: {
 							type: "server_error",

--- a/test/index-retry.test.ts
+++ b/test/index-retry.test.ts
@@ -34,7 +34,7 @@ vi.mock("../lib/request/fetch-helpers.js", () => ({
 				code === "server_is_overloaded" ||
 				type === "service_unavailable_error" ||
 				contextType === "service_unavailable_error" ||
-				(code === "server_error" && (type === "server_error" || contextType === "server_error"))
+				(code === "server_error" && type === "server_error")
 			) {
 				return { response, errorBody: body, retryAsServerError: true };
 			}


### PR DESCRIPTION
Fixes #138

## Summary

- Treat live `error.type === error.code === "server_error"` responses as server-retryable alongside the existing overload variants.
- Keep those payloads off the rate-limit path and cover the non-5xx retry flow in `test/fetch-helpers.test.ts` and `test/index-retry.test.ts`.

## Testing

- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm test`
- [ ] Not applicable

## Compliance Confirmation

- [x] This change stays within the repository scope and OpenAI Terms of Service expectations.
- [x] This change uses official authentication flows only and does not add bypass, scraping, or credential-sharing behavior.
- [x] I updated tests and documentation when the change affected users, maintainers, or repository behavior.

## Notes

- Linked issue: #138
- Follow-up work or rollout notes: Built from a fresh `main` worktree and kept the unrelated storage-test changes out of this branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced detection of server overload and error conditions by recognizing specific error payloads, treating them similarly to standard server errors for retry and account rotation purposes.
  * Improved rate-limit detection to differentiate between rate-limit and server-overload responses.

* **Improvements**
  * Extended error handling logic to capture additional server error scenarios beyond HTTP 5xx status codes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

this pr extends account-rotation retry logic to cover live `server_error` payloads (where `error.code === error.type === \"server_error\"`) that arrive on non-5xx responses, and prevents those payloads from being misclassified as rate limits. the `isServerOverloadedError` helper is well-structured and the unit coverage is solid; the two p2 notes below are about a pre-vs-post-normalisation asymmetry and a `parseRateLimitBody` code-fallback quirk, neither of which causes incorrect behaviour in the current payload shapes.

<h3>Confidence Score: 5/5</h3>

safe to merge — all findings are p2 style/consistency notes with no impact on correctness or token safety

the core logic (isServerOverloadedError, retryAsServerError flag, rate-limit exclusion) is correct for the stated payload shapes; the pre-normalisation body asymmetry and code-fallback quirk are harmless under current real-world payloads; unit and integration coverage covers the primary cases

lib/request/fetch-helpers.ts — pre-normalisation body check and parseRateLimitBody code-fallback asymmetry worth a follow-up cleanup; index.ts — indentation drift around the new destructuring block

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/request/fetch-helpers.ts | adds `isServerOverloadedError` helper and wires `retryAsServerError` into `handleErrorResponse`; minor asymmetry between pre- and post-normalisation body used for the check, and `parseRateLimitBody` code-fallback creates a silent mismatch in the rate-limit exclusion path |
| index.ts | extends server-error rotation condition to include `retryAsServerError` flag; logic is correct but the destructured block has inconsistent indentation compared to its surrounding scope |
| test/fetch-helpers.test.ts | good unit coverage for all `isServerOverloadedError` branches including partial-payload negatives and the rate-limit vs server-retry distinction |
| test/index-retry.test.ts | adds end-to-end retry test for `server_error` payload; mock faithfully mirrors the real detection logic but only covers one of the three overload paths at integration level |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[upstream response] --> B{response.ok?}
    B -- yes --> C[handleSuccessResponse]
    B -- no --> D[handleErrorResponse]
    D --> E[parse body → errorBody]
    E --> F[isServerOverloadedError\nerrorBody]
    F --> G[retryAsServerError = true/false]
    E --> H[extractRateLimitInfoFromBody]
    H --> I{isServerOverloadedError\nreconstructed from parsed?}
    I -- yes --> J[rateLimit = undefined]
    I -- no --> K[rateLimit = RateLimitInfo]
    G & J & K --> L[return ErrorHandlingResult]
    L --> M{retryAsServerError\nOR status 5xx?}
    M -- yes --> N[rotate account\nrecordFailure\ncircuitBreaker]
    M -- no --> O{rateLimit?}
    O -- yes --> P[backoff & retry]
    O -- no --> Q[return errorResponse]
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Foc-codex-multi-auth%22%20on%20the%20existing%20branch%20%22fix%2Fretry-server-error-live-payload%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fretry-server-error-live-payload%22.%0A%0AFix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Alib%2Frequest%2Ffetch-helpers.ts%3A628%0A**%60retryAsServerError%60%20evaluated%20against%20pre-normalisation%20body**%0A%0A%60isServerOverloadedError%60%20is%20called%20on%20the%20raw%20%60errorBody%60%20%28line%20628%29%2C%20but%20the%20value%20returned%20to%20callers%20is%20%60normalizedError%60%20%28line%20643%29.%20if%20%60normalizeErrorPayload%60%20restructures%20the%20%60error%60%20envelope%20%28e.g.%2C%20flattens%20or%20renames%20fields%29%2C%20the%20check%20could%20silently%20miss%20payloads%20that%20the%20normalised%20form%20would%20have%20caught.%20recommend%20calling%20it%20on%20%60normalizedError%60%20for%20consistency%2C%20since%20that%20is%20what%20callers%20inspect.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20const%20retryAsServerError%20%3D%20isServerOverloadedError%28normalizedError%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%204%0Alib%2Frequest%2Ffetch-helpers.ts%3A729-745%0A**%60parsed.code%60%20fallback%20may%20incorrectly%20match%20type-only%20payloads**%0A%0A%60parseRateLimitBody%60%20sets%20%60code%20%3D%20%28error.code%20%3F%3F%20error.type%20%3F%3F%20%22%22%29.toString%28%29%60%2C%20so%20for%20a%20payload%20with%20only%20%60%7B%20error%3A%20%7B%20type%3A%20%22server_error%22%20%7D%20%7D%60%20%28no%20explicit%20%60code%60%29%2C%20%60parsed.code%60%20becomes%20%60%22server_error%22%60.%20when%20that%20value%20is%20forwarded%20into%20the%20reconstructed%20%60isServerOverloadedError%60%20call%2C%20%60code%20%3D%3D%3D%20%22server_error%22%20%26%26%20type%20%3D%3D%3D%20%22server_error%22%60%20evaluates%20to%20%60true%60%2C%20silently%20excluding%20such%20payloads%20from%20rate-limit%20classification.%20in%20practice%20this%20is%20harmless%20%28type-only%20%60server_error%60%20isn't%20a%20rate%20limit%29%2C%20but%20it's%20an%20invisible%20asymmetry%3A%20the%20same%20payload%20gets%20%60retryAsServerError%3A%20false%60%20from%20%60handleErrorResponse%60%20yet%20is%20treated%20as%20overloaded%20in%20the%20rate-limit%20exclusion%20path.%20consider%20using%20%60error.code%60%20directly%20%28without%20the%20type%20fallback%29%20when%20reconstructing%20the%20object%20for%20%60isServerOverloadedError%60.%0A%0A%23%23%23%20Issue%203%20of%204%0Aindex.ts%3A1996-2000%0A**Indentation%20de-indented%20relative%20to%20surrounding%20scope**%0A%0Athe%20destructuring%20block%20dropped%20from%20the%20surrounding%20nesting%20level%20%28which%20uses%20%60%5Ct%5Ct%5Ct%5Ct%5Ct%5Ct%5Ct%5Ct%60%29%20to%20a%20shallower%20indent%2C%20making%20it%20visually%20inconsistent%20with%20adjacent%20lines%20like%20the%20%60contextOverflowResult%60%20check%20above%20and%20the%20%60workspaceDeactivated%60%20block%20below.%20no%20runtime%20impact%2C%20but%20can%20mislead%20reviewers%20about%20control-flow%20scope.%0A%0A%23%23%23%20Issue%204%20of%204%0Atest%2Findex-retry.test.ts%3A242-295%0A**missing%20vitest%20coverage%20for%20%60server_is_overloaded%60%20and%20%60service_unavailable_error%60%20at%20integration%20level**%0A%0Athe%20new%20integration%20test%20only%20exercises%20the%20%60code%20%3D%3D%3D%20%22server_error%22%20%26%26%20type%20%3D%3D%3D%20%22server_error%22%60%20branch.%20the%20other%20two%20%60isServerOverloadedError%60%20paths%20%28%60code%20%3D%3D%3D%20%22server_is_overloaded%22%60%2C%20%60type%2FcontextType%20%3D%3D%3D%20%22service_unavailable_error%22%60%29%20have%20unit%20coverage%20in%20%60fetch-helpers.test.ts%60%20but%20no%20corresponding%20%60index-retry%60%20scenario%20confirming%20that%20account%20rotation%20fires%20end-to-end%20for%20those%20payloads.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: lib/request/fetch-helpers.ts
Line: 628

Comment:
**`retryAsServerError` evaluated against pre-normalisation body**

`isServerOverloadedError` is called on the raw `errorBody` (line 628), but the value returned to callers is `normalizedError` (line 643). if `normalizeErrorPayload` restructures the `error` envelope (e.g., flattens or renames fields), the check could silently miss payloads that the normalised form would have caught. recommend calling it on `normalizedError` for consistency, since that is what callers inspect.

```suggestion
        const retryAsServerError = isServerOverloadedError(normalizedError);
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: lib/request/fetch-helpers.ts
Line: 729-745

Comment:
**`parsed.code` fallback may incorrectly match type-only payloads**

`parseRateLimitBody` sets `code = (error.code ?? error.type ?? "").toString()`, so for a payload with only `{ error: { type: "server_error" } }` (no explicit `code`), `parsed.code` becomes `"server_error"`. when that value is forwarded into the reconstructed `isServerOverloadedError` call, `code === "server_error" && type === "server_error"` evaluates to `true`, silently excluding such payloads from rate-limit classification. in practice this is harmless (type-only `server_error` isn't a rate limit), but it's an invisible asymmetry: the same payload gets `retryAsServerError: false` from `handleErrorResponse` yet is treated as overloaded in the rate-limit exclusion path. consider using `error.code` directly (without the type fallback) when reconstructing the object for `isServerOverloadedError`.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: index.ts
Line: 1996-2000

Comment:
**Indentation de-indented relative to surrounding scope**

the destructuring block dropped from the surrounding nesting level (which uses `\t\t\t\t\t\t\t\t`) to a shallower indent, making it visually inconsistent with adjacent lines like the `contextOverflowResult` check above and the `workspaceDeactivated` block below. no runtime impact, but can mislead reviewers about control-flow scope.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: test/index-retry.test.ts
Line: 242-295

Comment:
**missing vitest coverage for `server_is_overloaded` and `service_unavailable_error` at integration level**

the new integration test only exercises the `code === "server_error" && type === "server_error"` branch. the other two `isServerOverloadedError` paths (`code === "server_is_overloaded"`, `type/contextType === "service_unavailable_error"`) have unit coverage in `fetch-helpers.test.ts` but no corresponding `index-retry` scenario confirming that account rotation fires end-to-end for those payloads.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["Constrain server\_error retries to exact ..."](https://github.com/ndycode/oc-codex-multi-auth/commit/138c4f3fa92e5a08c0987eb2e3d23e974124d101) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29261915)</sub>

<!-- /greptile_comment -->