### PR TITLE
Clarify current official Codex model support and guard against accidental pruning

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -47,6 +47,7 @@ controls how much thinking the model does.
 | `gpt-5.1` | none, low, medium, high |
 
 The shipped config templates include 9 base model families and 34 shipped presets overall (34 modern variants or 34 legacy explicit entries). On OpenCode `v1.0.210+`, those 34 presets intentionally appear as 9 base model entries plus `--variant` values. `gpt-5.4-pro` ships in the templates but may still be entitlement-gated at runtime, while `gpt-5.3-codex-spark` remains a manual add-on for entitled workspaces only.
+The plugin intentionally keeps the older official Codex model IDs wired in runtime normalization and fallback handling: `gpt-5-codex`, `gpt-5.1-codex`, `gpt-5.1-codex-max`, `gpt-5.1-codex-mini`, `gpt-5.2-codex`, `gpt-5.3-codex`, and `gpt-5.3-codex-spark`. OpenAI can expose different subsets across API docs, Codex surfaces, and ChatGPT account/workspace entitlements, so template defaults and runtime support are not treated as the same thing.
 For context sizing, shipped templates use:
 - `gpt-5.4` and `gpt-5.4-pro`: `context=1050000`, `output=128000`
 - `gpt-5.4-mini`, `gpt-5.4-nano`, `gpt-5-codex`, `gpt-5.1-codex`, `gpt-5.1-codex-max`, and `gpt-5.1-codex-mini`: `context=400000`, `output=128000`

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -351,6 +351,8 @@ resolvedConfig: { reasoningEffort: 'low', ... }  ← Should show your options
 
 **Cause:** The selected model is currently not entitled for the active ChatGPT account/workspace.
 
+This does not automatically mean the model ID is deprecated or mapped incorrectly in the plugin. The runtime still preserves older official Codex IDs because different OpenAI surfaces and ChatGPT accounts can expose different subsets.
+
 **Solutions:**
 1. Re-auth/login to refresh workspace selection:
    ```bash

--- a/lib/request/helpers/model-map.ts
+++ b/lib/request/helpers/model-map.ts
@@ -30,6 +30,10 @@ function expandDatedAliases(prefix: string, target: string): Record<string, stri
 export const MODEL_MAP: Record<string, string> = {
 	// ============================================================================
 	// GPT-5 Codex Models (canonical stable family)
+	// Keep the broader Codex-family aliases below wired even when shipped
+	// templates prioritize newer defaults. OpenAI surfaces and ChatGPT
+	// entitlements drift independently, so removing these IDs from runtime
+	// normalization breaks officially documented model names for other accounts.
 	// ============================================================================
 	"gpt-5-codex": "gpt-5-codex",
 	"gpt-5-codex-none": "gpt-5-codex",

--- a/test/model-map.test.ts
+++ b/test/model-map.test.ts
@@ -100,6 +100,16 @@ describe("Model Map Module", () => {
       expect(MODEL_MAP["gpt-5.1-chat-latest"]).toBe("gpt-5.1");
     });
 
+    it("keeps the broader official codex family addressable", () => {
+      expect(MODEL_MAP["gpt-5-codex"]).toBe("gpt-5-codex");
+      expect(MODEL_MAP["gpt-5.1-codex"]).toBe("gpt-5-codex");
+      expect(MODEL_MAP["gpt-5.1-codex-max"]).toBe("gpt-5.1-codex-max");
+      expect(MODEL_MAP["gpt-5.1-codex-mini"]).toBe("gpt-5.1-codex-mini");
+      expect(MODEL_MAP["gpt-5.2-codex"]).toBe("gpt-5-codex");
+      expect(MODEL_MAP["gpt-5.3-codex"]).toBe("gpt-5-codex");
+      expect(MODEL_MAP["gpt-5.3-codex-spark"]).toBe("gpt-5-codex");
+    });
+
     it("keeps canonical GPT-5 codex mapping stable", () => {
       expect(MODEL_MAP["gpt-5-codex"]).toBe("gpt-5-codex");
     });


### PR DESCRIPTION
## Summary
- restore the branch tree so the plugin keeps the current official Codex-family model IDs wired in runtime normalization
- document that account/workspace entitlement failures are not the same thing as model deprecation
- add regression coverage so future cleanup does not silently prune the broader official Codex family

## Why
The earlier branch-wide prune/remap policy treated older Codex IDs as if they were fully deprecated. That does not match the current OpenAI model surface. Official OpenAI docs still expose broader Codex-family IDs even though a given ChatGPT account or workspace may only be entitled to a subset at runtime.

## Scope
This PR now keeps repo-wide runtime support intact for the current official Codex-family IDs and narrows the change to:
- runtime guardrail commentary
- docs clarification around entitlement vs support
- regression coverage for the broader Codex family

## Validation
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test`

## Notes
- The branch history was rebuilt and force-pushed so the PR now carries one clean commit for the aligned 4-file diff.
- This PR is intentionally not a host-specific model-prune policy.
- Unsupported-model handling should continue to be solved through account selection and fallback policy, not by deleting officially surfaced model IDs from the runtime.

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

this pr is a no-logic-change safeguard: it adds a comment in `model-map.ts` explaining why the broader codex-family aliases must remain wired, a regression test that pins all 7 official codex IDs against their current mappings, and two docs clarifications that distinguish runtime entitlement failures from model deprecation. all test assertions are consistent with the current map.

<h3>Confidence Score: 5/5</h3>

safe to merge — purely additive comment, test, and docs change with no logic mutations

no code logic changed; all new test assertions are verified correct against the existing model map; docs additions are accurate; no windows filesystem, token safety, or concurrency concerns introduced

no files require special attention

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/request/helpers/model-map.ts | comment-only change: adds a 4-line block explaining why the broader codex-family aliases must stay wired; no map entries added or removed |
| test/model-map.test.ts | adds regression test covering all 7 official codex-family IDs; assertions are correct against the current map; some overlap with existing per-family tests is intentional per pr intent |
| docs/configuration.md | adds a paragraph clarifying intentional retention of older codex IDs and distinguishing template defaults from runtime support |
| docs/troubleshooting.md | adds two-sentence clarification that a runtime entitlement failure does not mean the model id is deprecated or incorrectly mapped |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["config model ID\n(e.g. gpt-5.1-codex-high)"] --> B{Object.hasOwn\nMODEL_MAP?}
    B -- yes --> C["return MODEL_MAP[modelId]"]
    B -- no --> D["lowercase lookup\nfind key case-insensitively"]
    D -- found --> E["return MODEL_MAP[match]"]
    D -- not found --> F["return undefined"]
    C --> G["normalized API model name\n(e.g. gpt-5-codex)"]
    E --> G

    subgraph "Codex-family aliases preserved by this PR"
        H["gpt-5-codex → gpt-5-codex"]
        I["gpt-5.1-codex → gpt-5-codex"]
        J["gpt-5.2-codex → gpt-5-codex"]
        K["gpt-5.3-codex → gpt-5-codex"]
        L["gpt-5.3-codex-spark → gpt-5-codex"]
        M["gpt-5.1-codex-max → gpt-5.1-codex-max"]
        N["gpt-5.1-codex-mini → gpt-5.1-codex-mini"]
    end
```

<sub>Reviews (5): Last reviewed commit: ["Keep current official Codex model IDs ad..."](https://github.com/ndycode/oc-codex-multi-auth/commit/933e462dfe10288d3d5168363ea92ebae0ce5e38) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29278744)</sub>

<!-- /greptile_comment -->