### PR TITLE
chore(release): prepare v6.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- (placeholder for next release)
+
+## [6.1.3] - 2026-04-24
+
+### Added
 - Explicit `gpt-5.5-fast` / `gpt-5.5-fast-{none,low,medium,high,xhigh}` entries in the model map, normalizing to `gpt-5.5`. Without the explicit map entry, picking OpenCode's built-in `GPT-5.5 Fast` catalog item fell through the regex fallback with no per-model config lookup, which contributed to the `All N account(s) failed (server errors or auth issues)` symptom.
 - Scoped auto-fallback for GPT-5.5: when the backend returns `model_not_supported_with_chatgpt_account` for `gpt-5.5`, the plugin now routes the retry to `gpt-5.4` automatically, even without `unsupportedCodexPolicy: "fallback"` or `CODEX_AUTH_UNSUPPORTED_MODEL_POLICY=fallback`. Opt out with `CODEX_AUTH_DISABLE_GPT55_AUTO_FALLBACK=1`. Legacy family fallback behavior is unchanged.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oc-codex-multi-auth",
-  "version": "6.1.2",
+  "version": "6.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oc-codex-multi-auth",
-      "version": "6.1.2",
+      "version": "6.1.3",
       "license": "MIT",
       "dependencies": {
         "@napi-rs/keyring": "~1.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oc-codex-multi-auth",
-  "version": "6.1.2",
+  "version": "6.1.3",
   "description": "OpenCode plugin for Codex-first GPT-5 workflows with ChatGPT Plus/Pro OAuth, multi-account rotation, and guided setup",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Summary

- Bump package metadata to `6.1.3`
- Move the GPT-5.5 routing fixes from `Unreleased` into the `6.1.3` changelog section

## Verification

- `npm run typecheck`
- Published `oc-codex-multi-auth@6.1.3` to npm with `latest` dist-tag

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

standard release-prep bump from `6.1.2` → `6.1.3`. the GPT-5.5 routing fixes (explicit `gpt-5.5-fast` model-map entries and scoped auto-fallback to `gpt-5.4`) and the `gpt-5.5-pro` removal are correctly promoted from `[Unreleased]` to `[6.1.3] - 2026-04-24`; `package.json` and `package-lock.json` are in sync.

<h3>Confidence Score: 5/5</h3>

safe to merge — purely metadata and changelog, no logic changes

all three changed files are release-metadata only; version is consistent across package.json and package-lock.json; changelog date matches release date; no token-handling, windows path, or concurrency code touched; no vitest coverage changes needed for a release-prep commit

no files require special attention

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| CHANGELOG.md | moves GPT-5.5 routing entries from [Unreleased] into [6.1.3] dated 2026-04-24 and adds an empty placeholder for the next release — looks correct |
| package.json | version field bumped from 6.1.2 → 6.1.3, no other changes |
| package-lock.json | top-level name/version fields bumped to 6.1.3, lockfileVersion 3 retained, dependency tree untouched |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[incoming model id] --> B{in explicit model map?}
    B -- yes --> C[resolve to canonical id e.g. gpt-5.5]
    B -- no --> D[regex fallback — no per-model config]
    C --> E{backend response}
    E -- ok --> F[return response]
    E -- model_not_supported_with_chatgpt_account AND canonical == gpt-5.5 --> G{CODEX_AUTH_DISABLE_GPT55_AUTO_FALLBACK=1?}
    G -- no --> H[auto-retry with gpt-5.4]
    G -- yes --> I[surface error to caller]
    H --> F
```

<sub>Reviews (1): Last reviewed commit: ["chore(release): prepare v6.1.3"](https://github.com/ndycode/oc-codex-multi-auth/commit/dd3d81a2ed52329c370a63616491f13926baae3e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29597776)</sub>

<!-- /greptile_comment -->