### PR TITLE
fix(config): expose gpt-5.5-fast selectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - (placeholder for next release)
 
+## [6.1.4] - 2026-04-24
+
+### Fixed
+- Ship the `gpt-5.5-fast` modern config entry and explicit `gpt-5.5-fast-{none,low,medium,high,xhigh}` legacy selectors so OpenCode resolves `openai/gpt-5.5-fast-medium` before plugin routing.
+- Clear OpenCode's newer package cache layout at `~/.cache/opencode/packages/{oc-codex-multi-auth,oc-chatgpt-multi-auth}@latest` during installer cache refresh.
+- Normalize stale managed file-path and `file:///.../node_modules/...` plugin entries back to the official `oc-codex-multi-auth` package name when the installer runs.
+
 ## [6.1.3] - 2026-04-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Use your ChatGPT Plus/Pro subscription inside OpenCode with OAuth login, GPT-5/C
 ## What This Project Does
 
 - Adds an OpenCode plugin that authenticates with ChatGPT Plus/Pro through official OAuth
-- Ships ready-to-use GPT-5.5 templates, explicit `gpt-5.5-medium` / `gpt-5.5-high` selectors, `gpt-5-codex`, and related GPT-5 families
+- Ships ready-to-use GPT-5.5 templates, explicit `gpt-5.5-medium` / `gpt-5.5-fast-medium` / `gpt-5.5-high` selectors, `gpt-5-codex`, and related GPT-5 families
 - Routes requests through a stateless Codex-compatible request pipeline with automatic token refresh
 - Supports multi-account rotation, per-project account storage, and guided onboarding commands
 
@@ -43,15 +43,16 @@ What the installer does:
 
 By default, the installer now writes a full catalog config that includes both:
 - modern base model entries such as `gpt-5.5` for `--variant` workflows
-- explicit preset entries such as `gpt-5.5-medium` / `gpt-5.5-high` so the shipped catalog is visible directly in model pickers
+- explicit preset entries such as `gpt-5.5-medium` / `gpt-5.5-fast-medium` / `gpt-5.5-high` so the shipped catalog is visible directly in model pickers
 
-Tested live on OpenCode `1.14.22`: explicit GPT-5.5 model IDs like `openai/gpt-5.5-medium` and `openai/gpt-5.5-high` work directly. Some OpenCode releases still reject bare `openai/gpt-5.5` on the CLI even when the base config entry exists in the effective config.
+Tested live on OpenCode `1.14.22`: explicit GPT-5.5 model IDs like `openai/gpt-5.5-medium`, `openai/gpt-5.5-fast-medium`, and `openai/gpt-5.5-high` work directly. Some OpenCode releases still reject bare `openai/gpt-5.5` on the CLI even when the base config entry exists in the effective config.
 
 ## Example Usage
 
 ```bash
 # General GPT-5 workflow
 opencode run "Summarize the failing test and suggest a fix" --model=openai/gpt-5.5-medium
+opencode run "Summarize the failing test and suggest a fix" --model=openai/gpt-5.5-fast-medium
 
 # Codex-focused workflow
 opencode run "Refactor the retry logic and update the tests" --model=openai/gpt-5-codex --variant=high

--- a/config/README.md
+++ b/config/README.md
@@ -6,8 +6,8 @@ This directory contains the official OpenCode config templates for `oc-codex-mul
 
 | File | OpenCode version | Description |
 |------|------------------|-------------|
-| [`opencode-modern.json`](./opencode-modern.json) | **v1.0.210+** | Variant-based config: 9 base models with 34 total presets |
-| [`opencode-legacy.json`](./opencode-legacy.json) | **v1.0.209 and below** | Legacy explicit entries: 34 individual model definitions |
+| [`opencode-modern.json`](./opencode-modern.json) | **v1.0.210+** | Variant-based config: 9 base models with 36 total presets |
+| [`opencode-legacy.json`](./opencode-legacy.json) | **v1.0.209 and below** | Legacy explicit entries: 36 individual model definitions |
 
 The installer currently uses a merged full-catalog mode by default so users get both the modern base entries and the explicit preset entries without having to hand-edit `opencode.json`.
 
@@ -36,10 +36,10 @@ opencode --version
 OpenCode v1.0.210+ added model `variants`, so one model entry can expose multiple reasoning levels. That keeps modern config much smaller while preserving the same effective presets.
 
 Both templates include:
-- GPT-5.5, GPT-5.5 Pro, GPT-5.4 Mini, GPT-5.4 Nano, GPT-5 Codex, GPT-5.1, GPT-5.1 Codex, GPT-5.1 Codex Max, GPT-5.1 Codex Mini
+- GPT-5.5, GPT-5.5 Fast, GPT-5.4 Mini, GPT-5.4 Nano, GPT-5 Codex, GPT-5.1, GPT-5.1 Codex, GPT-5.1 Codex Max, GPT-5.1 Codex Mini
 - Reasoning variants per model family
 - `store: false` and `include: ["reasoning.encrypted_content"]`
-- Context metadata (`gpt-5.5`/`gpt-5.5-pro`: 1,050,000; `gpt-5.4-mini`/`gpt-5.4-nano`/Codex models: 400,000; `gpt-5.1`: 272,000; all output: 128,000)
+- Context metadata (`gpt-5.5`/`gpt-5.5-fast`: 1,050,000; `gpt-5.4-mini`/`gpt-5.4-nano`/Codex models: 400,000; `gpt-5.1`: 272,000; all output: 128,000)
 
 Use `opencode debug config` to verify that these template entries were merged into your effective config. On tested OpenCode `1.14.22`, `opencode models openai` exposes explicit GPT-5.5 entries such as `gpt-5.5-medium` / `gpt-5.5-high`, while bare `gpt-5.5` may still be omitted or rejected by provider lookup even when it exists in the effective config.
 
@@ -59,6 +59,7 @@ Recommended real-session selectors (tested on OpenCode `1.14.22`):
 
 ```bash
 opencode run "task" --model=openai/gpt-5.5-medium
+opencode run "task" --model=openai/gpt-5.5-fast-medium
 opencode run "task" --model=openai/gpt-5-codex --variant=high
 ```
 
@@ -79,13 +80,12 @@ Current defaults are strict entitlement handling:
 - set `unsupportedCodexPolicy: "fallback"` (or `CODEX_AUTH_UNSUPPORTED_MODEL_POLICY=fallback`) to enable automatic fallback retries
 - `fallbackToGpt52OnUnsupportedGpt53: true` keeps the legacy `gpt-5.3-codex -> gpt-5.2-codex` edge inside fallback mode
 - `gpt-5.5 -> gpt-5.4` is included by default for accounts/workspaces that do not yet expose GPT-5.5
-- `gpt-5.5-pro -> gpt-5.5` is included by default in fallback mode
+- user-typed `gpt-5.5-pro*` is canonicalized to `gpt-5.5` before fallback because GPT-5.5 Pro is ChatGPT-only, not a Codex-routable model
 - `gpt-5.4-pro -> gpt-5.4` remains available for older manual configs
 - `unsupportedCodexFallbackChain` lets you override fallback order per model
 
 Default fallback chain (when policy is `fallback`):
 - `gpt-5.5 -> gpt-5.4`
-- `gpt-5.5-pro -> gpt-5.5`
 - `gpt-5.4-pro -> gpt-5.4` (if you manually select `gpt-5.4-pro`)
 - `gpt-5.3-codex -> gpt-5-codex -> gpt-5.2-codex`
 - `gpt-5.3-codex-spark -> gpt-5-codex -> gpt-5.3-codex -> gpt-5.2-codex` (only relevant if Spark IDs are added manually)

--- a/config/opencode-legacy.json
+++ b/config/opencode-legacy.json
@@ -140,6 +140,131 @@
             "store": false
           }
         },
+        "gpt-5.5-fast-none": {
+          "name": "GPT 5.5 Fast None (OAuth)",
+          "limit": {
+            "context": 1050000,
+            "output": 128000
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "options": {
+            "reasoningEffort": "none",
+            "reasoningSummary": "auto",
+            "textVerbosity": "medium",
+            "include": [
+              "reasoning.encrypted_content"
+            ],
+            "store": false
+          }
+        },
+        "gpt-5.5-fast-low": {
+          "name": "GPT 5.5 Fast Low (OAuth)",
+          "limit": {
+            "context": 1050000,
+            "output": 128000
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "options": {
+            "reasoningEffort": "low",
+            "reasoningSummary": "auto",
+            "textVerbosity": "medium",
+            "include": [
+              "reasoning.encrypted_content"
+            ],
+            "store": false
+          }
+        },
+        "gpt-5.5-fast-medium": {
+          "name": "GPT 5.5 Fast Medium (OAuth)",
+          "limit": {
+            "context": 1050000,
+            "output": 128000
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "options": {
+            "reasoningEffort": "medium",
+            "reasoningSummary": "auto",
+            "textVerbosity": "medium",
+            "include": [
+              "reasoning.encrypted_content"
+            ],
+            "store": false
+          }
+        },
+        "gpt-5.5-fast-high": {
+          "name": "GPT 5.5 Fast High (OAuth)",
+          "limit": {
+            "context": 1050000,
+            "output": 128000
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "options": {
+            "reasoningEffort": "high",
+            "reasoningSummary": "detailed",
+            "textVerbosity": "medium",
+            "include": [
+              "reasoning.encrypted_content"
+            ],
+            "store": false
+          }
+        },
+        "gpt-5.5-fast-xhigh": {
+          "name": "GPT 5.5 Fast Extra High (OAuth)",
+          "limit": {
+            "context": 1050000,
+            "output": 128000
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "options": {
+            "reasoningEffort": "xhigh",
+            "reasoningSummary": "detailed",
+            "textVerbosity": "medium",
+            "include": [
+              "reasoning.encrypted_content"
+            ],
+            "store": false
+          }
+        },
         "gpt-5.4-mini-none": {
           "name": "GPT 5.4 Mini None (OAuth)",
           "limit": {

--- a/config/opencode-modern.json
+++ b/config/opencode-modern.json
@@ -58,6 +58,49 @@
             }
           }
         },
+        "gpt-5.5-fast": {
+          "name": "GPT 5.5 Fast (OAuth)",
+          "limit": {
+            "context": 1050000,
+            "output": 128000
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "variants": {
+            "none": {
+              "reasoningEffort": "none",
+              "reasoningSummary": "auto",
+              "textVerbosity": "medium"
+            },
+            "low": {
+              "reasoningEffort": "low",
+              "reasoningSummary": "auto",
+              "textVerbosity": "medium"
+            },
+            "medium": {
+              "reasoningEffort": "medium",
+              "reasoningSummary": "auto",
+              "textVerbosity": "medium"
+            },
+            "high": {
+              "reasoningEffort": "high",
+              "reasoningSummary": "detailed",
+              "textVerbosity": "medium"
+            },
+            "xhigh": {
+              "reasoningEffort": "xhigh",
+              "reasoningSummary": "detailed",
+              "textVerbosity": "medium"
+            }
+          }
+        },
         "gpt-5.4-mini": {
           "name": "GPT 5.4 Mini (OAuth)",
           "limit": {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -35,6 +35,7 @@ controls how much thinking the model does.
 | model | supported values |
 |-------|------------------|
 | `gpt-5.5` | none, low, medium, high, xhigh |
+| `gpt-5.5-fast` | none, low, medium, high, xhigh |
 | `gpt-5.4` | none, low, medium, high, xhigh |
 | `gpt-5.4-mini` | none, low, medium, high, xhigh |
 | `gpt-5.4-pro` | low, medium, high, xhigh (optional/manual model) |
@@ -47,24 +48,24 @@ controls how much thinking the model does.
 | `gpt-5.1-codex-mini` | medium, high |
 | `gpt-5.1` | none, low, medium, high |
 
-The shipped config templates include 9 base model families and 34 shipped presets overall (34 modern variants or 34 legacy explicit entries). On OpenCode `v1.0.210+`, those 34 presets intentionally appear as 9 base model entries plus `--variant` values. `gpt-5.5-pro` is ChatGPT-only (not routed by this plugin), while `gpt-5.3-codex-spark` remains a manual add-on for entitled workspaces only.
+The shipped config templates include 9 base model families and 36 shipped presets overall (36 modern variants or 36 legacy explicit entries). On OpenCode `v1.0.210+`, those 36 presets intentionally appear as 9 base model entries plus `--variant` values. `gpt-5.5-pro` is ChatGPT-only (not routed by this plugin), while `gpt-5.3-codex-spark` remains a manual add-on for entitled workspaces only.
 For context sizing, shipped templates use:
-- `gpt-5.5`: `context=1050000`, `output=128000`
+- `gpt-5.5` and `gpt-5.5-fast`: `context=1050000`, `output=128000`
 - `gpt-5.4-mini`, `gpt-5.4-nano`, `gpt-5-codex`, `gpt-5.1-codex`, `gpt-5.1-codex-max`, and `gpt-5.1-codex-mini`: `context=400000`, `output=128000`
 - `gpt-5.1`: `context=272000`, `output=128000`
 
 model normalization aliases:
-- `gpt-5.5*` and user-typed `gpt-5.5-pro*` normalize to the public Codex model id `gpt-5.5`
+- `gpt-5.5*`, `gpt-5.5-fast*`, and user-typed `gpt-5.5-pro*` normalize to the public Codex model id `gpt-5.5`
 - legacy `gpt-5` maps to `gpt-5.5`; legacy `gpt-5-mini` / `gpt-5-nano` map to `gpt-5.4-mini` / `gpt-5.4-nano`
 - snapshot ids `gpt-5.4-2026-03-05*`, `gpt-5.4-mini-2026-03-05*`, and `gpt-5.4-pro-2026-03-05*` map to stable `gpt-5.4` / `gpt-5.4-mini` / `gpt-5.4-pro`
-- `opencode debug config` is the reliable way to confirm merged custom/template model entries; on tested OpenCode `1.14.22`, `opencode models openai` exposes explicit GPT-5.5 entries like `gpt-5.5-medium` / `gpt-5.5-high`, while bare `gpt-5.5` can still be omitted or rejected by provider lookup
+- `opencode debug config` is the reliable way to confirm merged custom/template model entries; on tested OpenCode `1.14.22`, `opencode models openai` exposes explicit GPT-5.5 entries like `gpt-5.5-medium`, `gpt-5.5-fast-medium`, and `gpt-5.5-high`, while bare `gpt-5.5` can still be omitted or rejected by provider lookup
 
 if your OpenCode runtime supports global compaction tuning, you can set:
 - `model_context_window = 1000000`
 - `model_auto_compact_token_limit = 900000`
 
 tested live selector note:
-- OpenCode `1.14.22` accepted `openai/gpt-5.5-medium` and `openai/gpt-5.5-high` in real sessions
+- OpenCode `1.14.22` accepted `openai/gpt-5.5-medium`, `openai/gpt-5.5-fast-medium`, and `openai/gpt-5.5-high` in real sessions
 - the same runtime rejected bare `openai/gpt-5.5` with `ProviderModelNotFoundError`
 - use explicit shipped GPT-5.5 preset IDs for reliable CLI verification today
 
@@ -73,7 +74,7 @@ what they mean:
 - `low` - light reasoning, fastest
 - `medium` - balanced (default)
 - `high` - deep reasoning
-- `xhigh` - max depth for complex tasks (default for legacy `gpt-5.3-codex` / `gpt-5.2-codex` aliases and `gpt-5.1-codex-max`; available for `gpt-5.5`, `gpt-5.4`, and optional `gpt-5.4-pro`)
+- `xhigh` - max depth for complex tasks (default for legacy `gpt-5.3-codex` / `gpt-5.2-codex` aliases and `gpt-5.1-codex-max`; available for `gpt-5.5`, `gpt-5.5-fast`, `gpt-5.4`, and optional `gpt-5.4-pro`)
 
 ### Reasoning Summary
 

--- a/docs/development/CONFIG_FLOW.md
+++ b/docs/development/CONFIG_FLOW.md
@@ -67,8 +67,8 @@ Important detail:
 It currently ships:
 
 - 9 base model families
-- 34 total variants
-- `gpt-5.5` and `gpt-5.5-pro` at 1,050,000 context / 128,000 output
+- 36 total variants
+- `gpt-5.5` and `gpt-5.5-fast` at 1,050,000 context / 128,000 output
 - `gpt-5.4-mini`, `gpt-5.4-nano`, and Codex families at 400,000 context / 128,000 output
 - `gpt-5.1` at 272,000 context / 128,000 output
 - `store: false` plus `include: ["reasoning.encrypted_content"]`
@@ -78,7 +78,7 @@ It currently ships:
 The default installer mode combines:
 
 - the 9 modern base model entries from `config/opencode-modern.json`
-- the 34 explicit preset entries from `config/opencode-legacy.json`
+- the 36 explicit preset entries from `config/opencode-legacy.json`
 
 That hybrid install mode is what fixes the "only 9 models" complaint without removing `--variant` support.
 
@@ -114,6 +114,7 @@ Full/default install, tested live on OpenCode `1.14.22`, uses:
 
 ```bash
 opencode run "task" --model=openai/gpt-5.5-medium
+opencode run "task" --model=openai/gpt-5.5-fast-medium
 ```
 
 If your OpenCode release exposes bare base entries, the compact modern template also supports:
@@ -128,8 +129,8 @@ opencode run "task" --model=openai/gpt-5.5 --variant=high
 
 It currently ships:
 
-- 34 explicit model entries
-- separate model IDs such as `gpt-5.5-medium`, `gpt-5.5-high`, and `gpt-5.4-mini-xhigh`
+- 36 explicit model entries
+- separate model IDs such as `gpt-5.5-medium`, `gpt-5.5-fast-medium`, `gpt-5.5-high`, and `gpt-5.4-mini-xhigh`
 - the same OpenAI provider defaults (`store: false`, `reasoning.encrypted_content`)
 
 Legacy OpenCode selection uses:

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -25,7 +25,7 @@ See [config/README.md](../config/README.md) for the template split.
 
 ## What models are included by default?
 
-The shipped templates focus on current GPT-5 and Codex families such as `gpt-5.5`, `gpt-5.5-pro`, `gpt-5.4-mini`, `gpt-5-codex`, and `gpt-5.1-*`. Optional or entitlement-gated model IDs can be added manually when your workspace supports them.
+The shipped templates focus on current GPT-5 and Codex families such as `gpt-5.5`, `gpt-5.5-fast`, `gpt-5.4-mini`, `gpt-5-codex`, and `gpt-5.1-*`. Optional or entitlement-gated model IDs can be added manually when your workspace supports them. `gpt-5.5-pro` is ChatGPT-only and is not routed through this Codex plugin.
 
 ## Can I use multiple accounts?
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -30,10 +30,10 @@ opencode run "Explain this repository" --model=openai/gpt-5.5-medium
 The installer updates `~/.config/opencode/opencode.json`, backs up the previous config, normalizes the plugin entry to `oc-codex-multi-auth`, and clears the cached plugin copy so OpenCode reinstalls the latest package.
 
 By default, the installer writes a full catalog config so you get both:
-- modern base model entries such as `gpt-5.5` for `--variant` workflows
-- explicit preset entries such as `gpt-5.5-medium` / `gpt-5.5-high` so the full shipped catalog is visible directly in pickers
+- modern base model entries such as `gpt-5.5` and `gpt-5.5-fast` for `--variant` workflows
+- explicit preset entries such as `gpt-5.5-medium` / `gpt-5.5-fast-medium` / `gpt-5.5-high` so the full shipped catalog is visible directly in pickers
 
-Tested live on OpenCode `1.14.22`: use explicit GPT-5.5 selectors like `openai/gpt-5.5-medium` or `openai/gpt-5.5-high` for real-session verification. Bare `openai/gpt-5.5 --variant=...` may or may not work depending on your OpenCode release.
+Tested live on OpenCode `1.14.22`: use explicit GPT-5.5 selectors like `openai/gpt-5.5-medium`, `openai/gpt-5.5-fast-medium`, or `openai/gpt-5.5-high` for real-session verification. Bare `openai/gpt-5.5 --variant=...` may or may not work depending on your OpenCode release.
 
 If you prefer the compact variant-only config on OpenCode `v1.0.210+`, use:
 
@@ -115,11 +115,11 @@ The repository ships two supported templates:
 | `v1.0.209` and earlier | [`config/opencode-legacy.json`](../config/opencode-legacy.json) |
 
 The templates include the supported GPT-5/Codex families, required `store: false` handling, and `reasoning.encrypted_content` for multi-turn sessions.
-Current templates expose 9 shipped base model families and 34 shipped presets overall (34 modern variants or 34 legacy explicit entries).
+Current templates expose 9 shipped base model families and 36 shipped presets overall (36 modern variants or 36 legacy explicit entries).
 
 On OpenCode `v1.0.210+`, the modern template intentionally shows 9 base model entries because the additional presets are selected through `--variant` instead of separate model keys.
 
-`gpt-5.5-pro` ships in the templates but can still be entitlement-gated by your workspace. Add entitlement-gated Spark variants manually only when your workspace supports them.
+`gpt-5.5-pro` is not shipped in the Codex templates because it is ChatGPT-only, not Codex-routable. Add entitlement-gated Spark variants manually only when your workspace supports them.
 
 ## Verify the Setup
 
@@ -128,6 +128,7 @@ Run one of these commands:
 ```bash
 # Recommended current GPT-5.5 path
 opencode run "Create a short TODO list for this repo" --model=openai/gpt-5.5-medium
+opencode run "Create a short TODO list for this repo" --model=openai/gpt-5.5-fast-medium
 opencode run "Inspect the retry logic and summarize it" --model=openai/gpt-5-codex --variant=high
 
 # Compact modern template, only if your OpenCode release exposes bare base entries

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -368,7 +368,6 @@ resolvedConfig: { reasoningEffort: 'low', ... }  ← Should show your options
    ```
 4. Default fallback chain (when policy is `fallback` and not overridden):
    - `gpt-5.5 -> gpt-5.4`
-   - `gpt-5.5-pro -> gpt-5.5`
    - `gpt-5.4-pro -> gpt-5.4` (if `gpt-5.4-pro` is selected manually)
    - `gpt-5.3-codex -> gpt-5-codex -> gpt-5.2-codex`
    - `gpt-5.3-codex-spark -> gpt-5-codex -> gpt-5.3-codex -> gpt-5.2-codex` (if Spark IDs are selected manually)
@@ -381,7 +380,6 @@ resolvedConfig: { reasoningEffort: 'low', ... }  ← Should show your options
    "fallbackOnUnsupportedCodexModel": true,
    "unsupportedCodexFallbackChain": {
       "gpt-5.5": ["gpt-5.4"],
-      "gpt-5.5-pro": ["gpt-5.5"],
       "gpt-5.4-pro": ["gpt-5.4"],
       "gpt-5-codex": ["gpt-5.2-codex"],
       "gpt-5.3-codex": ["gpt-5-codex", "gpt-5.2-codex"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oc-codex-multi-auth",
-  "version": "6.1.3",
+  "version": "6.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oc-codex-multi-auth",
-      "version": "6.1.3",
+      "version": "6.1.4",
       "license": "MIT",
       "dependencies": {
         "@napi-rs/keyring": "~1.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oc-codex-multi-auth",
-  "version": "6.1.3",
+  "version": "6.1.4",
   "description": "OpenCode plugin for Codex-first GPT-5 workflows with ChatGPT Plus/Pro OAuth, multi-account rotation, and guided setup",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/scripts/install-oc-codex-multi-auth-core.js
+++ b/scripts/install-oc-codex-multi-auth-core.js
@@ -17,7 +17,7 @@ function printHelp() {
 	console.log(`Usage: ${PACKAGE_NAME} [--modern|--legacy] [--dry-run] [--no-cache-clear]\n\n` +
 		"Default behavior:\n" +
 		"  - Installs/updates global config at ~/.config/opencode/opencode.json\n" +
-		"  - Uses full catalog config by default (9 base models + 34 explicit presets)\n" +
+		"  - Uses full catalog config by default (9 base models + 36 explicit presets)\n" +
 		"  - Ensures plugin is unpinned (latest)\n" +
 		"  - Clears OpenCode plugin cache\n\n" +
 		"Options:\n" +
@@ -65,6 +65,7 @@ function buildPaths(homeDir) {
 		configPath: join(configDir, "opencode.json"),
 		cacheDir,
 		cacheNodeModulesPaths: getManagedPackageNames().map((name) => join(cacheDir, "node_modules", name)),
+		cachePackagePaths: getManagedPackageNames().map((name) => join(cacheDir, "packages", `${name}@latest`)),
 		cacheBunLock: join(cacheDir, "bun.lock"),
 		cachePackageJson: join(cacheDir, "package.json"),
 		modernTemplatePath,
@@ -95,13 +96,37 @@ function parseCliArgs(argv = process.argv.slice(2)) {
 	};
 }
 
+function normalizePluginEntryForMatch(entry) {
+	const trimmed = entry.trim();
+	let normalized = trimmed.toLowerCase();
+	try {
+		normalized = decodeURIComponent(normalized);
+	} catch {
+		// Keep the raw lowercased value when a malformed URI escape is present.
+	}
+	normalized = normalized.replace(/\\/g, "/").replace(/\/+$/g, "");
+	if (normalized.endsWith("/dist")) {
+		normalized = normalized.slice(0, -"/dist".length);
+	}
+	return normalized;
+}
+
+function isManagedPluginEntry(entry) {
+	if (typeof entry !== "string") return false;
+	const trimmed = entry.trim().toLowerCase();
+	const normalized = normalizePluginEntryForMatch(entry);
+	return getManagedPackageNames().some((name) => {
+		const lowerName = name.toLowerCase();
+		return trimmed === lowerName ||
+			trimmed.startsWith(`${lowerName}@`) ||
+			normalized.endsWith(`/${lowerName}`) ||
+			normalized.endsWith(`/node_modules/${lowerName}`);
+	});
+}
+
 function normalizePluginList(list) {
 	const entries = Array.isArray(list) ? list.filter(Boolean) : [];
-	const managedNames = getManagedPackageNames();
-	const filtered = entries.filter((entry) => {
-		if (typeof entry !== "string") return true;
-		return !managedNames.some((name) => entry === name || entry.startsWith(`${name}@`));
-	});
+	const filtered = entries.filter((entry) => !isManagedPluginEntry(entry));
 	return [...filtered, PACKAGE_NAME];
 }
 
@@ -351,10 +376,16 @@ async function clearCache(paths, dryRun, skipCacheClear) {
 		for (const cacheNodeModulesPath of paths.cacheNodeModulesPaths) {
 			log(`[dry-run] Would remove ${cacheNodeModulesPath}`);
 		}
+		for (const cachePackagePath of paths.cachePackagePaths) {
+			log(`[dry-run] Would remove ${cachePackagePath}`);
+		}
 		log(`[dry-run] Would remove ${paths.cacheBunLock}`);
 	} else {
 		for (const cacheNodeModulesPath of paths.cacheNodeModulesPaths) {
 			await rm(cacheNodeModulesPath, { recursive: true, force: true });
+		}
+		for (const cachePackagePath of paths.cachePackagePaths) {
+			await rm(cachePackagePath, { recursive: true, force: true });
 		}
 		await rm(paths.cacheBunLock, { force: true });
 	}
@@ -429,10 +460,10 @@ export async function runInstaller(argv = process.argv.slice(2), options = {}) {
 	log("\nDone. Restart OpenCode to (re)install the plugin.");
 	log("Example: opencode");
 	if (configMode === "modern") {
-		log("Note: Modern config intentionally shows 9 base model entries; use --variant to access all 34 shipped presets.");
+		log("Note: Modern config intentionally shows 9 base model entries; use --variant to access all 36 shipped presets.");
 	}
 	if (configMode === "legacy") {
-		log("Note: Legacy config writes 34 explicit preset entries and is also safe for older OpenCode versions.");
+		log("Note: Legacy config writes 36 explicit preset entries and is also safe for older OpenCode versions.");
 	}
 	if (configMode === "full") {
 		log("Note: Full config installs both modern base models and explicit preset entries so the full shipped catalog is visible by default.");

--- a/test/gpt55-release.test.ts
+++ b/test/gpt55-release.test.ts
@@ -39,6 +39,7 @@ describe("GPT-5.5 activation", () => {
 		expect(normalizeModel("openai/gpt-5.5")).toBe("gpt-5.5");
 		expect(normalizeModel("openai/gpt-5.5-high")).toBe("gpt-5.5");
 		expect(normalizeModel("openai/gpt-5.5-fast")).toBe("gpt-5.5");
+		expect(normalizeModel("openai/gpt-5.5-fast-medium")).toBe("gpt-5.5");
 		// User-typed Pro still collapses to the Codex-supported gpt-5.5 so the
 		// fallback chain can rescue it rather than failing 46 accounts.
 		expect(normalizeModel("openai/gpt-5.5-pro-high")).toBe("gpt-5.5");

--- a/test/install-oc-codex-multi-auth.test.ts
+++ b/test/install-oc-codex-multi-auth.test.ts
@@ -53,7 +53,12 @@ describe("install-oc-codex-multi-auth script", () => {
 		await writeFile(
 			configPath,
 			JSON.stringify({
-				plugin: ["existing-plugin", "oc-chatgpt-multi-auth@old"],
+				plugin: [
+					"existing-plugin",
+					"oc-chatgpt-multi-auth@old",
+					"file:///C:/Users/neil/DevTools/pkg/npm-global/node_modules/oc-codex-multi-auth",
+					"C:\\Users\\neil\\DevTools\\pkg\\npm-global\\node_modules\\oc-chatgpt-multi-auth\\dist",
+				],
 				provider: {
 					anthropic: { baseURL: "https://example.invalid" },
 					openai: {
@@ -106,6 +111,8 @@ describe("install-oc-codex-multi-auth script", () => {
 		expect(Object.keys(saved.provider.openai.models)).toHaveLength(expectedCount);
 		expect(saved.provider.openai.models["gpt-5.5"]).toBeDefined();
 		expect(saved.provider.openai.models["gpt-5.5-high"]).toBeDefined();
+		expect(saved.provider.openai.models["gpt-5.5-fast"]).toBeDefined();
+		expect(saved.provider.openai.models["gpt-5.5-fast-medium"]).toBeDefined();
 		// User-added model survives deep-merge without overriding template ids.
 		expect(saved.provider.openai.models["old"]).toEqual({ name: "old" });
 		const configEntries = await readdir(configDir);
@@ -436,6 +443,75 @@ describe("install-oc-codex-multi-auth script", () => {
 		expect(cachePackage.dependencies["oc-chatgpt-multi-auth"]).toBeUndefined();
 		expect(cachePackage.dependencies["oc-codex-multi-auth"]).toBeUndefined();
 		expect(cachePackage.dependencies.other).toBe("^1.0.0");
+	});
+
+	it("clears OpenCode node_modules and package cache layouts", async () => {
+		vi.resetModules();
+		tempHome = await createTempHome();
+		const { runInstaller } = await import("../scripts/install-oc-codex-multi-auth-core.js");
+		const configDir = join(tempHome, ".config", "opencode");
+		const configPath = join(configDir, "opencode.json");
+		const cacheDir = join(tempHome, ".cache", "opencode");
+		const legacyCacheNodeModules = join(cacheDir, "node_modules", "oc-chatgpt-multi-auth");
+		const cacheNodeModules = join(cacheDir, "node_modules", "oc-codex-multi-auth");
+		const legacyCachePackage = join(cacheDir, "packages", "oc-chatgpt-multi-auth@latest");
+		const cachePackage = join(cacheDir, "packages", "oc-codex-multi-auth@latest");
+		const cacheBunLock = join(cacheDir, "bun.lock");
+		const cachePackageJson = join(cacheDir, "package.json");
+
+		await mkdir(configDir, { recursive: true });
+		await mkdir(cacheNodeModules, { recursive: true });
+		await mkdir(legacyCacheNodeModules, { recursive: true });
+		await mkdir(cachePackage, { recursive: true });
+		await mkdir(legacyCachePackage, { recursive: true });
+		await writeFile(configPath, JSON.stringify({ plugin: [] }, null, 2), "utf-8");
+		await writeFile(join(cacheNodeModules, "package.json"), "{}", "utf-8");
+		await writeFile(join(legacyCacheNodeModules, "package.json"), "{}", "utf-8");
+		await writeFile(join(cachePackage, "package.json"), "{}", "utf-8");
+		await writeFile(join(legacyCachePackage, "package.json"), "{}", "utf-8");
+		await writeFile(cacheBunLock, "lockfile", "utf-8");
+		await writeFile(
+			cachePackageJson,
+			JSON.stringify(
+				{
+					dependencies: {
+						"oc-chatgpt-multi-auth": "file:../pinned-plugin.tgz",
+						"oc-codex-multi-auth": "file:../new-plugin.tgz",
+						other: "^1.0.0",
+					},
+				},
+				null,
+				2,
+			),
+			"utf-8",
+		);
+
+		await expect(
+			runInstaller([], {
+				env: {
+					...process.env,
+					HOME: tempHome,
+					USERPROFILE: tempHome,
+				},
+			}),
+		).resolves.toMatchObject({
+			action: "install",
+			configMode: "full",
+			exitCode: 0,
+		});
+
+		await expect(readdir(cacheNodeModules)).rejects.toMatchObject({ code: "ENOENT" });
+		await expect(readdir(legacyCacheNodeModules)).rejects.toMatchObject({ code: "ENOENT" });
+		await expect(readdir(cachePackage)).rejects.toMatchObject({ code: "ENOENT" });
+		await expect(readdir(legacyCachePackage)).rejects.toMatchObject({ code: "ENOENT" });
+		await expect(readFile(cacheBunLock, "utf-8")).rejects.toMatchObject({ code: "ENOENT" });
+
+		const cachedPackageJson = JSON.parse(await readFile(cachePackageJson, "utf-8")) as {
+			dependencies: Record<string, string>;
+		};
+		expect(cachedPackageJson.dependencies["oc-chatgpt-multi-auth"]).toBeUndefined();
+		expect(cachedPackageJson.dependencies["oc-codex-multi-auth"]).toBeUndefined();
+		expect(cachedPackageJson.dependencies.other).toBe("^1.0.0");
 	});
 
 	it("rejects full-mode merges when modern and legacy templates overlap", async () => {

--- a/test/model-map.test.ts
+++ b/test/model-map.test.ts
@@ -43,6 +43,9 @@ describe("Model Map Module", () => {
 	      expect(MODEL_MAP["gpt-5.5-high"]).toBe("gpt-5.5");
 	      expect(MODEL_MAP["gpt-5.5-xhigh"]).toBe("gpt-5.5");
 	      expect(MODEL_MAP["gpt-5.5-fast"]).toBe("gpt-5.5");
+	      expect(MODEL_MAP["gpt-5.5-fast-none"]).toBe("gpt-5.5");
+	      expect(MODEL_MAP["gpt-5.5-fast-low"]).toBe("gpt-5.5");
+	      expect(MODEL_MAP["gpt-5.5-fast-medium"]).toBe("gpt-5.5");
 	      expect(MODEL_MAP["gpt-5.5-fast-high"]).toBe("gpt-5.5");
 	      expect(MODEL_MAP["gpt-5.5-fast-xhigh"]).toBe("gpt-5.5");
 	    });


### PR DESCRIPTION
## Summary
- add shipped OpenCode config entries for gpt-5.5-fast variants, including explicit gpt-5.5-fast-medium
- clear OpenCode's newer packages/<plugin>@latest cache folders during installer refresh
- normalize stale managed file-path plugin entries back to the official npm package name
- bump package to 6.1.4

## Verification
- npm run typecheck
- npm test
- npm run lint
- npm run build
- npm pack --dry-run

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

ships `gpt-5.5-fast` model entries (5 variants each in modern and legacy configs), clears the newer `packages/<name>@latest` opencode cache layout during installer refresh, and normalizes stale file-path plugin entries (including windows absolute paths and `file:///` URIs) back to the canonical npm package name. docs and preset count (34 → 36) are updated consistently across all relevant files.

all three changes are independently motivated, well-scoped, and the test additions cover the happy paths for each. the only concerns are p2: the `/dist` suffix strip in `normalizePluginEntryForMatch` does not handle paths pointing at a file inside `dist/` (e.g. `\\dist\\index.js`), and the malformed-uri `try/catch` branch has no direct vitest unit coverage.

<h3>Confidence Score: 5/5</h3>

safe to merge — all remaining findings are p2 style/coverage suggestions with no correctness impact on the primary install path

the config entries are structurally correct and match the existing model shapes; the cache-clearing and plugin-normalization logic is covered by new tests; the /dist suffix gap and redundant check are edge cases that don't affect the test-verified scenarios

scripts/install-oc-codex-multi-auth-core.js — specifically normalizePluginEntryForMatch for the narrow /dist-only suffix handling

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| scripts/install-oc-codex-multi-auth-core.js | adds normalizePluginEntryForMatch/isManagedPluginEntry helpers and cachePackagePaths for the newer opencode packages layout; /dist suffix stripping is too narrow for file-path-to-main-entry cases and the /node_modules/ check is redundant |
| config/opencode-legacy.json | adds 5 explicit gpt-5.5-fast-{none,low,medium,high,xhigh} entries with correct context/output limits and matching reasoningEffort/reasoningSummary values; consistent with the existing gpt-5.5 entry shape |
| config/opencode-modern.json | adds gpt-5.5-fast base model with all 5 variant levels; limit metadata and options match the legacy explicit entries exactly |
| test/install-oc-codex-multi-auth.test.ts | adds windows file-path entries to the plugin-normalization test and a new cache-layout clearing test; missing direct unit coverage for the try/catch malformed-URI branch and dist/index.js path variant |
| test/gpt55-release.test.ts | adds gpt-5.5-fast-medium → gpt-5.5 normalization assertion; straightforward and correct |
| test/model-map.test.ts | fills in the three previously missing gpt-5.5-fast-{none,low,medium} model-map assertions; complete coverage of all 5 fast variants now |
| CHANGELOG.md | 6.1.4 entry accurately describes the three changes: fast selectors, packages cache clearing, and plugin-entry normalization |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["installer reads existing opencode.json plugin list"] --> B["normalizePluginList()"]
    B --> C{"isManagedPluginEntry(entry)?"}
    C -- "exact name / name@ver" --> D["drop entry"]
    C -- "normalized path ends with /name" --> D
    C -- "normalized path ends with /node_modules/name" --> D
    C -- "not managed" --> E["keep entry"]
    D --> F["append oc-codex-multi-auth"]
    E --> F
    F --> G["write merged config"]
    G --> H["clearCache()"]
    H --> I["rm node_modules/name cache"]
    H --> J["rm packages/name@latest cache  NEW"]
    H --> K["rm bun.lock"]
    I & J & K --> L["Done — restart OpenCode"]
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Foc-codex-multi-auth%22%20on%20the%20existing%20branch%20%22fix%2Fgpt55-fast-config-cache%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fgpt55-fast-config-cache%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Ascripts%2Finstall-oc-codex-multi-auth-core.js%3A108-110%0A**%60%2Fdist%60%20suffix%20strip%20is%20too%20narrow%20for%20windows%20file-path%20entries**%0A%0A%60normalizePluginEntryForMatch%60%20only%20strips%20a%20trailing%20%60%2Fdist%60%20directory.%20any%20plugin%20entry%20pointing%20at%20a%20file%20inside%20%60dist%60%20%E2%80%94%20e.g.%20%60C%3A%5C...%5Coc-codex-multi-auth%5Cdist%5Cindex.js%60%20%E2%80%94%20will%20survive%20the%20strip%20with%20the%20file%20suffix%20still%20attached%2C%20so%20%60isManagedPluginEntry%60%20returns%20%60false%60%20and%20the%20stale%20entry%20is%20never%20replaced.%20on%20windows%2C%20npm%20sometimes%20writes%20the%20resolved%20main-file%20path%20into%20the%20plugin%20list%20rather%20than%20the%20package%20directory.%0A%0Aconsider%20also%20stripping%20common%20build-output%20file%20suffixes%2C%20or%20doing%20a%20path-segment%20%60includes%60%20check%20rather%20than%20an%20exact%20suffix%20match.%0A%0A%23%23%23%20Issue%202%20of%203%0Ascripts%2Finstall-oc-codex-multi-auth-core.js%3A114-124%0A**redundant%20%60%2Fnode_modules%2F%3Cname%3E%60%20check**%0A%0A%60normalized.endsWith%28'%2Fnode_modules%2Foc-codex-multi-auth'%29%60%20is%20already%20covered%20by%20%60normalized.endsWith%28'%2Foc-codex-multi-auth'%29%60%20%E2%80%94%20the%20fourth%20arm%20never%20fires.%20consider%20removing%20it%20to%20keep%20the%20predicate%20minimal%2C%20or%20flip%20the%20order%20and%20drop%20the%20broader%20check%20if%20you%20want%20the%20%60%2Fnode_modules%2F%60%20path%20to%20be%20the%20only%20accepted%20suffix.%0A%0A%23%23%23%20Issue%203%20of%203%0Atest%2Finstall-oc-codex-multi-auth.test.ts%3A628-695%0A**missing%20vitest%20coverage%20for%20%60normalizePluginEntryForMatch%60%20edge%20paths**%0A%0Athe%20%60try%2Fcatch%60%20branch%20%28malformed%20percent-escape%20like%20%60%25GG%60%29%20has%20no%20test%20exercising%20it.%20likewise%2C%20%60isManagedPluginEntry%60%20with%20a%20%60dist%2Findex.js%60%20file%20path%20is%20not%20covered.%20the%20new%20cache-clearing%20test%20is%20solid%2C%20but%20those%20two%20helpers%20only%20have%20indirect%20integration-level%20coverage.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: scripts/install-oc-codex-multi-auth-core.js
Line: 108-110

Comment:
**`/dist` suffix strip is too narrow for windows file-path entries**

`normalizePluginEntryForMatch` only strips a trailing `/dist` directory. any plugin entry pointing at a file inside `dist` — e.g. `C:\...\oc-codex-multi-auth\dist\index.js` — will survive the strip with the file suffix still attached, so `isManagedPluginEntry` returns `false` and the stale entry is never replaced. on windows, npm sometimes writes the resolved main-file path into the plugin list rather than the package directory.

consider also stripping common build-output file suffixes, or doing a path-segment `includes` check rather than an exact suffix match.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: scripts/install-oc-codex-multi-auth-core.js
Line: 114-124

Comment:
**redundant `/node_modules/<name>` check**

`normalized.endsWith('/node_modules/oc-codex-multi-auth')` is already covered by `normalized.endsWith('/oc-codex-multi-auth')` — the fourth arm never fires. consider removing it to keep the predicate minimal, or flip the order and drop the broader check if you want the `/node_modules/` path to be the only accepted suffix.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: test/install-oc-codex-multi-auth.test.ts
Line: 628-695

Comment:
**missing vitest coverage for `normalizePluginEntryForMatch` edge paths**

the `try/catch` branch (malformed percent-escape like `%GG`) has no test exercising it. likewise, `isManagedPluginEntry` with a `dist/index.js` file path is not covered. the new cache-clearing test is solid, but those two helpers only have indirect integration-level coverage.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(config): expose gpt-5.5-fast selecto..."](https://github.com/ndycode/oc-codex-multi-auth/commit/d2df9ee939d79f2dfb91dad2b875ca231c4d5445) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29604065)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->