### PR TITLE
[codex] fix(installer): default to compact model picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - (placeholder for next release)
 
+## [6.1.5] - 2026-04-24
+
+### Changed
+- Default installer mode now writes the compact OAuth model catalog so OpenCode's model picker shows base models only; reasoning depth is selected through the variant picker.
+- Added `--full` installer mode for users who still want explicit selector IDs such as `gpt-5.5-medium` and `gpt-5.5-fast-medium` installed into the model picker.
+- Compact/default installs now prune explicit preset IDs and stale base model IDs from earlier catalogs so rerunning the installer actually cleans up the model picker.
+
 ## [6.1.4] - 2026-04-24
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Use your ChatGPT Plus/Pro subscription inside OpenCode with OAuth login, GPT-5/C
 ## What This Project Does
 
 - Adds an OpenCode plugin that authenticates with ChatGPT Plus/Pro through official OAuth
-- Ships ready-to-use GPT-5.5 templates, explicit `gpt-5.5-medium` / `gpt-5.5-fast-medium` / `gpt-5.5-high` selectors, `gpt-5-codex`, and related GPT-5 families
+- Ships ready-to-use GPT-5.5 OAuth model templates, variant picker presets, optional explicit selector IDs, `gpt-5-codex`, and related GPT-5 families
 - Routes requests through a stateless Codex-compatible request pipeline with automatic token refresh
 - Supports multi-account rotation, per-project account storage, and guided onboarding commands
 
@@ -31,7 +31,7 @@ npx -y oc-codex-multi-auth@latest
 opencode auth login
 
 # 3. Run a prompt in OpenCode
-opencode run "Explain this repository" --model=openai/gpt-5.5-medium
+opencode run "Explain this repository" --model=openai/gpt-5.5 --variant=medium
 ```
 
 What the installer does:
@@ -41,18 +41,19 @@ What the installer does:
 - normalizes the plugin entry to `"oc-codex-multi-auth"`
 - clears the cached plugin copy so OpenCode reinstalls the latest package
 
-By default, the installer now writes a full catalog config that includes both:
-- modern base model entries such as `gpt-5.5` for `--variant` workflows
-- explicit preset entries such as `gpt-5.5-medium` / `gpt-5.5-fast-medium` / `gpt-5.5-high` so the shipped catalog is visible directly in model pickers
+By default, the installer writes the compact UI config:
+- model picker entries stay on actual OAuth model families such as `gpt-5.5` and `gpt-5.5-fast`
+- reasoning presets are selected through OpenCode's model variant picker (`none`, `low`, `medium`, `high`, `xhigh`)
+- rerunning the default installer removes explicit preset entries and stale base models from earlier plugin catalogs
 
-Tested live on OpenCode `1.14.22`: explicit GPT-5.5 model IDs like `openai/gpt-5.5-medium`, `openai/gpt-5.5-fast-medium`, and `openai/gpt-5.5-high` work directly. Some OpenCode releases still reject bare `openai/gpt-5.5` on the CLI even when the base config entry exists in the effective config.
+If you prefer direct model IDs such as `openai/gpt-5.5-medium` or `openai/gpt-5.5-fast-medium`, install with `--full`.
 
 ## Example Usage
 
 ```bash
 # General GPT-5 workflow
-opencode run "Summarize the failing test and suggest a fix" --model=openai/gpt-5.5-medium
-opencode run "Summarize the failing test and suggest a fix" --model=openai/gpt-5.5-fast-medium
+opencode run "Summarize the failing test and suggest a fix" --model=openai/gpt-5.5 --variant=medium
+opencode run "Summarize the failing test and suggest a fix" --model=openai/gpt-5.5-fast --variant=medium
 
 # Codex-focused workflow
 opencode run "Refactor the retry logic and update the tests" --model=openai/gpt-5-codex --variant=high
@@ -89,7 +90,7 @@ OpenCode users often want the same GPT-5 and Codex model experience they use in 
 
 ## Common Workflows
 
-- Personal coding sessions in OpenCode using `gpt-5.5-medium`, `gpt-5.5-high`, or `gpt-5-codex`
+- Personal coding sessions in OpenCode using `gpt-5.5` / `gpt-5.5-fast` with variants, or `gpt-5-codex`
 - Switching between personal and workspace-linked ChatGPT accounts
 - Keeping separate account pools per project or monorepo
 - Recovering from unsupported-model, auth, or rate-limit issues with guided commands
@@ -109,10 +110,10 @@ See [Architecture](docs/development/ARCHITECTURE.md) for implementation details.
 
 Use the quick-start path above for the fastest setup. For full setup, local development installs, legacy OpenCode support, and verification steps, see [Getting Started](docs/getting-started.md).
 
-If you prefer the compact variant-only config on OpenCode `v1.0.210+`, use:
+For direct selector IDs in scripts or older habits, use the full catalog:
 
 ```bash
-npx -y oc-codex-multi-auth@latest --modern
+npx -y oc-codex-multi-auth@latest --full
 ```
 
 ## Configuration

--- a/config/README.md
+++ b/config/README.md
@@ -9,7 +9,7 @@ This directory contains the official OpenCode config templates for `oc-codex-mul
 | [`opencode-modern.json`](./opencode-modern.json) | **v1.0.210+** | Variant-based config: 9 base models with 36 total presets |
 | [`opencode-legacy.json`](./opencode-legacy.json) | **v1.0.209 and below** | Legacy explicit entries: 36 individual model definitions |
 
-The installer currently uses a merged full-catalog mode by default so users get both the modern base entries and the explicit preset entries without having to hand-edit `opencode.json`.
+The installer uses the compact modern template by default so the model picker shows only base OAuth model families. Rerun the default installer to remove explicit preset IDs and stale base models left by earlier plugin catalogs. Use `--full` when you want the explicit preset IDs installed too.
 
 ## Quick pick
 
@@ -41,7 +41,7 @@ Both templates include:
 - `store: false` and `include: ["reasoning.encrypted_content"]`
 - Context metadata (`gpt-5.5`/`gpt-5.5-fast`: 1,050,000; `gpt-5.4-mini`/`gpt-5.4-nano`/Codex models: 400,000; `gpt-5.1`: 272,000; all output: 128,000)
 
-Use `opencode debug config` to verify that these template entries were merged into your effective config. On tested OpenCode `1.14.22`, `opencode models openai` exposes explicit GPT-5.5 entries such as `gpt-5.5-medium` / `gpt-5.5-high`, while bare `gpt-5.5` may still be omitted or rejected by provider lookup even when it exists in the effective config.
+Use `opencode debug config` to verify that these template entries were merged into your effective config. The default compact install shows base OAuth entries such as `gpt-5.5` / `gpt-5.5-fast`; the separate OpenCode variant picker exposes the reasoning presets.
 
 If your OpenCode runtime supports global compaction tuning, you can also set:
 - `model_context_window = 1050000`
@@ -55,18 +55,18 @@ If your workspace is entitled, you can add Spark model IDs manually.
 
 ## Usage examples
 
-Recommended real-session selectors (tested on OpenCode `1.14.22`):
-
-```bash
-opencode run "task" --model=openai/gpt-5.5-medium
-opencode run "task" --model=openai/gpt-5.5-fast-medium
-opencode run "task" --model=openai/gpt-5-codex --variant=high
-```
-
-If your OpenCode release already exposes bare GPT-5.5 base entries, the compact modern template also supports:
+Recommended compact UI selectors:
 
 ```bash
 opencode run "task" --model=openai/gpt-5.5 --variant=medium
+opencode run "task" --model=openai/gpt-5.5-fast --variant=medium
+opencode run "task" --model=openai/gpt-5-codex --variant=high
+```
+
+If you need direct explicit selector IDs for scripts, install with:
+
+```bash
+npx -y oc-codex-multi-auth@latest --full
 ```
 
 ## Minimal config (advanced)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -48,7 +48,7 @@ controls how much thinking the model does.
 | `gpt-5.1-codex-mini` | medium, high |
 | `gpt-5.1` | none, low, medium, high |
 
-The shipped config templates include 9 base model families and 36 shipped presets overall (36 modern variants or 36 legacy explicit entries). On OpenCode `v1.0.210+`, those 36 presets intentionally appear as 9 base model entries plus `--variant` values. `gpt-5.5-pro` is ChatGPT-only (not routed by this plugin), while `gpt-5.3-codex-spark` remains a manual add-on for entitled workspaces only.
+The shipped config templates include 9 base model families and 36 shipped presets overall (36 modern variants or 36 legacy explicit entries). The default installer uses the compact modern template so the TUI model picker shows base OAuth model families and the separate variant picker selects the reasoning preset. Use `--full` to install explicit selector IDs too. `gpt-5.5-pro` is ChatGPT-only (not routed by this plugin), while `gpt-5.3-codex-spark` remains a manual add-on for entitled workspaces only.
 For context sizing, shipped templates use:
 - `gpt-5.5` and `gpt-5.5-fast`: `context=1050000`, `output=128000`
 - `gpt-5.4-mini`, `gpt-5.4-nano`, `gpt-5-codex`, `gpt-5.1-codex`, `gpt-5.1-codex-max`, and `gpt-5.1-codex-mini`: `context=400000`, `output=128000`
@@ -58,16 +58,15 @@ model normalization aliases:
 - `gpt-5.5*`, `gpt-5.5-fast*`, and user-typed `gpt-5.5-pro*` normalize to the public Codex model id `gpt-5.5`
 - legacy `gpt-5` maps to `gpt-5.5`; legacy `gpt-5-mini` / `gpt-5-nano` map to `gpt-5.4-mini` / `gpt-5.4-nano`
 - snapshot ids `gpt-5.4-2026-03-05*`, `gpt-5.4-mini-2026-03-05*`, and `gpt-5.4-pro-2026-03-05*` map to stable `gpt-5.4` / `gpt-5.4-mini` / `gpt-5.4-pro`
-- `opencode debug config` is the reliable way to confirm merged custom/template model entries; on tested OpenCode `1.14.22`, `opencode models openai` exposes explicit GPT-5.5 entries like `gpt-5.5-medium`, `gpt-5.5-fast-medium`, and `gpt-5.5-high`, while bare `gpt-5.5` can still be omitted or rejected by provider lookup
+- `opencode debug config` is the reliable way to confirm merged custom/template model entries; default installs expose compact entries like `gpt-5.5` and `gpt-5.5-fast`, while `--full` also exposes explicit entries like `gpt-5.5-medium`, `gpt-5.5-fast-medium`, and `gpt-5.5-high`
 
 if your OpenCode runtime supports global compaction tuning, you can set:
 - `model_context_window = 1000000`
 - `model_auto_compact_token_limit = 900000`
 
-tested live selector note:
-- OpenCode `1.14.22` accepted `openai/gpt-5.5-medium`, `openai/gpt-5.5-fast-medium`, and `openai/gpt-5.5-high` in real sessions
-- the same runtime rejected bare `openai/gpt-5.5` with `ProviderModelNotFoundError`
-- use explicit shipped GPT-5.5 preset IDs for reliable CLI verification today
+selector note:
+- the default installer is optimized for the TUI model picker: choose a base `(OAuth)` model, then choose a variant
+- install with `--full` when you need direct selector IDs such as `openai/gpt-5.5-medium` or `openai/gpt-5.5-fast-medium`
 
 what they mean:
 - `none` - no reasoning phase (base general-purpose families only; pro families such as `gpt-5.4-pro` ultimately coerce it to `medium`)
@@ -367,12 +366,12 @@ opencode
 ### Verify Model Resolution
 
 ```bash
-DEBUG_CODEX_PLUGIN=1 opencode run "test" --model=openai/gpt-5.5-medium
+DEBUG_CODEX_PLUGIN=1 opencode run "test" --model=openai/gpt-5.5 --variant=medium
 ```
 
 look for:
 ```text
-[openai-codex-plugin] Model config lookup: "gpt-5.5-medium" → normalized to "gpt-5.5" for API {
+[openai-codex-plugin] Model config lookup: "gpt-5.5" -> normalized to "gpt-5.5" for API {
   hasModelSpecificConfig: true,
   resolvedConfig: { ... }
 }
@@ -381,12 +380,12 @@ look for:
 ### Test Per-Model Options
 
 ```bash
-# tested current selectors
-ENABLE_PLUGIN_REQUEST_LOGGING=1 opencode run "test" --model=openai/gpt-5.5-medium
-ENABLE_PLUGIN_REQUEST_LOGGING=1 opencode run "test" --model=openai/gpt-5.5-high
-
-# if your OpenCode release exposes bare base entries, this also works:
+# default compact selectors
+ENABLE_PLUGIN_REQUEST_LOGGING=1 opencode run "test" --model=openai/gpt-5.5 --variant=medium
 ENABLE_PLUGIN_REQUEST_LOGGING=1 opencode run "test" --model=openai/gpt-5.5 --variant=high
+
+# direct selector IDs, only after installing with --full
+ENABLE_PLUGIN_REQUEST_LOGGING=1 opencode run "test" --model=openai/gpt-5.5-medium
 
 # compare reasoning.effort in logs
 cat ~/.opencode/logs/codex-plugin/request-*-after-transform.json | jq '.reasoning.effort'

--- a/docs/development/CONFIG_FLOW.md
+++ b/docs/development/CONFIG_FLOW.md
@@ -30,7 +30,7 @@ OpenCode can also accept override content at process start:
 
 ```bash
 OPENCODE_CONFIG=/path/to/config.json opencode
-OPENCODE_CONFIG_CONTENT='{"model":"openai/gpt-5.5-medium"}' opencode
+OPENCODE_CONFIG_CONTENT='{"model":"openai/gpt-5.5","variant":"medium"}' opencode
 ```
 
 ### Plugin runtime config
@@ -47,7 +47,7 @@ That file controls plugin behavior such as retry policy, beginner safe mode, fal
 
 `scripts/install-oc-codex-multi-auth.js` performs these steps:
 
-1. Load the selected template set (`full` by default, `config/opencode-modern.json` with `--modern`, `config/opencode-legacy.json` with `--legacy`).
+1. Load the selected template set (`config/opencode-modern.json` by default, merged modern+legacy templates with `--full`, or `config/opencode-legacy.json` with `--legacy`).
 2. Back up an existing `~/.config/opencode/opencode.json`.
 3. Normalize the plugin list so it ends with plain `oc-codex-multi-auth`.
 4. Replace `provider.openai` with the selected shipped template block.
@@ -56,7 +56,8 @@ That file controls plugin behavior such as retry policy, beginner safe mode, fal
 Important detail:
 
 - The installer intentionally writes the plugin entry as `oc-codex-multi-auth`, not `oc-codex-multi-auth@latest`.
-- The default `full` install mode merges the modern base-model template with the explicit legacy preset entries so users can access `--variant` workflows and still see the full shipped preset catalog directly.
+- The default install mode uses the compact modern base-model template so the TUI model picker shows real OAuth model families and leaves reasoning depth to the variant picker.
+- `--full` merges the modern base-model template with the explicit legacy preset entries for scripts that require direct selector IDs.
 
 ## Shipped Template Structure
 
@@ -73,14 +74,13 @@ It currently ships:
 - `gpt-5.1` at 272,000 context / 128,000 output
 - `store: false` plus `include: ["reasoning.encrypted_content"]`
 
-### Full installer mode
+### Default installer mode
 
-The default installer mode combines:
+The default installer mode writes:
 
 - the 9 modern base model entries from `config/opencode-modern.json`
-- the 36 explicit preset entries from `config/opencode-legacy.json`
 
-That hybrid install mode is what fixes the "only 9 models" complaint without removing `--variant` support.
+That compact install mode keeps the OpenCode TUI model picker focused on actual OAuth model families. Reasoning presets are selected through the separate variant picker.
 
 Example shape:
 
@@ -110,17 +110,26 @@ Example shape:
 }
 ```
 
-Full/default install, tested live on OpenCode `1.14.22`, uses:
+Default install uses base model IDs plus variants:
 
 ```bash
-opencode run "task" --model=openai/gpt-5.5-medium
-opencode run "task" --model=openai/gpt-5.5-fast-medium
+opencode run "task" --model=openai/gpt-5.5 --variant=medium
+opencode run "task" --model=openai/gpt-5.5-fast --variant=medium
 ```
 
-If your OpenCode release exposes bare base entries, the compact modern template also supports:
+### Full installer mode
+
+`--full` combines:
+
+- the 9 modern base model entries from `config/opencode-modern.json`
+- the 36 explicit preset entries from `config/opencode-legacy.json`
+
+Use it when scripts require direct selector IDs:
 
 ```bash
-opencode run "task" --model=openai/gpt-5.5 --variant=high
+npx -y oc-codex-multi-auth@latest --full
+opencode run "task" --model=openai/gpt-5.5-medium
+opencode run "task" --model=openai/gpt-5.5-fast-medium
 ```
 
 ### Legacy template
@@ -150,7 +159,7 @@ At runtime, OpenCode passes `provider.openai.options` and `provider.openai.model
 
 Examples:
 
-- `openai/gpt-5.5-medium` normalizes to `gpt-5.5`
+- `openai/gpt-5.5` with variant `medium` normalizes to `gpt-5.5`
 - `openai/gpt-5.4-mini-xhigh` normalizes to `gpt-5.4-mini`
 - legacy aliases such as `gpt-5-mini` normalize to `gpt-5.4-mini`
 
@@ -160,14 +169,14 @@ Use these commands when checking the effective config:
 
 ```bash
 opencode debug config
-ENABLE_PLUGIN_REQUEST_LOGGING=1 opencode run "ping" --model=openai/gpt-5.5-medium
+ENABLE_PLUGIN_REQUEST_LOGGING=1 opencode run "ping" --model=openai/gpt-5.5 --variant=medium
 ```
 
 Important runtime behavior:
 
 - `opencode debug config` shows merged provider models from your config.
-- On tested OpenCode `1.14.22`, `opencode models openai` shows explicit GPT-5.5 entries such as `gpt-5.5-medium` / `gpt-5.5-high`.
-- The same runtime can still reject bare `openai/gpt-5.5`, so explicit GPT-5.5 preset IDs are the reliable current CLI path.
+- The default install shows compact GPT-5.5 OAuth base entries such as `gpt-5.5` / `gpt-5.5-fast`.
+- `--full` additionally shows explicit GPT-5.5 entries such as `gpt-5.5-medium` / `gpt-5.5-fast-medium` / `gpt-5.5-high`.
 
 ## File Locations
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -24,21 +24,17 @@ This guide covers the full installation and first-run flow for `oc-codex-multi-a
 ```bash
 npx -y oc-codex-multi-auth@latest
 opencode auth login
-opencode run "Explain this repository" --model=openai/gpt-5.5-medium
+opencode run "Explain this repository" --model=openai/gpt-5.5 --variant=medium
 ```
 
 The installer updates `~/.config/opencode/opencode.json`, backs up the previous config, normalizes the plugin entry to `oc-codex-multi-auth`, and clears the cached plugin copy so OpenCode reinstalls the latest package.
 
-By default, the installer writes a full catalog config so you get both:
-- modern base model entries such as `gpt-5.5` and `gpt-5.5-fast` for `--variant` workflows
-- explicit preset entries such as `gpt-5.5-medium` / `gpt-5.5-fast-medium` / `gpt-5.5-high` so the full shipped catalog is visible directly in pickers
+By default, the installer writes the compact UI config so the model picker shows base OAuth model families such as `gpt-5.5` and `gpt-5.5-fast`, then the separate model variant picker handles `none`, `low`, `medium`, `high`, and `xhigh`. Rerunning the default installer also removes explicit preset entries and stale base models left by earlier plugin catalogs.
 
-Tested live on OpenCode `1.14.22`: use explicit GPT-5.5 selectors like `openai/gpt-5.5-medium`, `openai/gpt-5.5-fast-medium`, or `openai/gpt-5.5-high` for real-session verification. Bare `openai/gpt-5.5 --variant=...` may or may not work depending on your OpenCode release.
-
-If you prefer the compact variant-only config on OpenCode `v1.0.210+`, use:
+If you want direct explicit selector IDs such as `openai/gpt-5.5-medium`, use the full catalog:
 
 ```bash
-npx -y oc-codex-multi-auth@latest --modern
+npx -y oc-codex-multi-auth@latest --full
 ```
 
 If you explicitly want the older explicit-only layout, use:
@@ -127,23 +123,23 @@ Run one of these commands:
 
 ```bash
 # Recommended current GPT-5.5 path
-opencode run "Create a short TODO list for this repo" --model=openai/gpt-5.5-medium
-opencode run "Create a short TODO list for this repo" --model=openai/gpt-5.5-fast-medium
+opencode run "Create a short TODO list for this repo" --model=openai/gpt-5.5 --variant=medium
+opencode run "Create a short TODO list for this repo" --model=openai/gpt-5.5-fast --variant=medium
 opencode run "Inspect the retry logic and summarize it" --model=openai/gpt-5-codex --variant=high
 
-# Compact modern template, only if your OpenCode release exposes bare base entries
-opencode run "Create a short TODO list for this repo" --model=openai/gpt-5.5 --variant=medium
+# Direct selector IDs, only after installing with --full
+opencode run "Create a short TODO list for this repo" --model=openai/gpt-5.5-medium
 ```
 
 If you want to verify request routing, run a request with logging enabled:
 
 ```bash
-ENABLE_PLUGIN_REQUEST_LOGGING=1 opencode run "test" --model=openai/gpt-5.5-medium
+ENABLE_PLUGIN_REQUEST_LOGGING=1 opencode run "test" --model=openai/gpt-5.5 --variant=medium
 ```
 
 The first request should create logs under `~/.opencode/logs/codex-plugin/`.
 
-Use `opencode debug config` when you want to verify that template-defined or custom models were merged into your effective config. On tested OpenCode `1.14.22`, `opencode models openai` exposes explicit GPT-5.5 entries such as `gpt-5.5-medium` / `gpt-5.5-high`; bare `gpt-5.5` may still not be selectable even when present in config.
+Use `opencode debug config` when you want to verify that template-defined or custom models were merged into your effective config. The default install exposes compact OAuth model entries such as `gpt-5.5` and `gpt-5.5-fast`; `--full` additionally exposes explicit entries such as `gpt-5.5-medium` / `gpt-5.5-fast-medium` / `gpt-5.5-high`.
 
 ## Multi-Account Setup
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oc-codex-multi-auth",
-  "version": "6.1.4",
+  "version": "6.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oc-codex-multi-auth",
-      "version": "6.1.4",
+      "version": "6.1.5",
       "license": "MIT",
       "dependencies": {
         "@napi-rs/keyring": "~1.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oc-codex-multi-auth",
-  "version": "6.1.4",
+  "version": "6.1.5",
   "description": "OpenCode plugin for Codex-first GPT-5 workflows with ChatGPT Plus/Pro OAuth, multi-account rotation, and guided setup",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/scripts/install-oc-codex-multi-auth-core.js
+++ b/scripts/install-oc-codex-multi-auth-core.js
@@ -8,21 +8,27 @@ const PACKAGE_NAME = "oc-codex-multi-auth";
 const LEGACY_PACKAGE_NAMES = ["oc-chatgpt-multi-auth"];
 const WINDOWS_RENAME_RETRY_ATTEMPTS = 5;
 const WINDOWS_RENAME_RETRY_BASE_DELAY_MS = 10;
+const STALE_MANAGED_MODEL_KEYS = new Set([
+	"gpt-5.2",
+	"gpt-5.3-codex",
+	"gpt-5.4",
+]);
 
 function getManagedPackageNames() {
 	return [PACKAGE_NAME, ...LEGACY_PACKAGE_NAMES];
 }
 
 function printHelp() {
-	console.log(`Usage: ${PACKAGE_NAME} [--modern|--legacy] [--dry-run] [--no-cache-clear]\n\n` +
+	console.log(`Usage: ${PACKAGE_NAME} [--modern|--full|--legacy] [--dry-run] [--no-cache-clear]\n\n` +
 		"Default behavior:\n" +
 		"  - Installs/updates global config at ~/.config/opencode/opencode.json\n" +
-		"  - Uses full catalog config by default (9 base models + 36 explicit presets)\n" +
+		"  - Uses compact UI config by default (9 base OAuth models + variant picker presets)\n" +
 		"  - Ensures plugin is unpinned (latest)\n" +
 		"  - Clears OpenCode plugin cache\n\n" +
 		"Options:\n" +
-		"  --modern           Force compact modern config (9 base models + --variant presets)\n" +
-		"  --legacy           Force explicit legacy config (34 preset model entries)\n" +
+		"  --modern           Force compact modern config (9 base OAuth models + --variant presets)\n" +
+		"  --full             Install compact base models plus 36 explicit selector entries\n" +
+		"  --legacy           Force explicit legacy config (36 preset model entries)\n" +
 		"  --dry-run          Show actions without writing\n" +
 		"  --no-cache-clear   Skip clearing OpenCode cache\n"
 	);
@@ -82,17 +88,20 @@ function parseCliArgs(argv = process.argv.slice(2)) {
 	}
 
 	const requestedModern = args.has("--modern");
+	const requestedFull = args.has("--full");
 	const requestedLegacy = args.has("--legacy");
 
-	if (requestedModern && requestedLegacy) {
-		throw new Error("Choose only one of --modern or --legacy.");
+	const requestedModes = [requestedModern, requestedFull, requestedLegacy]
+		.filter(Boolean).length;
+	if (requestedModes > 1) {
+		throw new Error("Choose only one of --modern, --full, or --legacy.");
 	}
 
 	return {
 		wantsHelp: false,
 		dryRun: args.has("--dry-run"),
 		skipCacheClear: args.has("--no-cache-clear"),
-		configMode: requestedModern ? "modern" : requestedLegacy ? "legacy" : "full",
+		configMode: requestedFull ? "full" : requestedLegacy ? "legacy" : "modern",
 	};
 }
 
@@ -150,9 +159,12 @@ function isPlainObject(value) {
 // installer overwrite the managed shape it ships. This replaces the earlier
 // wholesale overwrite which clobbered custom user-added keys (see audit top-20
 // #6).
-function mergeOpenaiProvider(existingOpenai, templateOpenai) {
+function mergeOpenaiProvider(existingOpenai, templateOpenai, options = {}) {
 	const existingSafe = isPlainObject(existingOpenai) ? existingOpenai : {};
 	const templateSafe = isPlainObject(templateOpenai) ? templateOpenai : {};
+	const modelKeysToRemove = options.modelKeysToRemove instanceof Set
+		? options.modelKeysToRemove
+		: new Set();
 
 	const result = {};
 
@@ -172,7 +184,10 @@ function mergeOpenaiProvider(existingOpenai, templateOpenai) {
 	// 3. Merge `models` by id: template wins on collision, user-added ids survive.
 	const existingModels = isPlainObject(existingSafe.models) ? existingSafe.models : {};
 	const templateModels = isPlainObject(templateSafe.models) ? templateSafe.models : {};
-	const mergedModels = { ...existingModels, ...templateModels };
+	const prunedExistingModels = Object.fromEntries(
+		Object.entries(existingModels).filter(([key]) => !modelKeysToRemove.has(key)),
+	);
+	const mergedModels = { ...prunedExistingModels, ...templateModels };
 	if (Object.keys(mergedModels).length > 0) {
 		result.models = mergedModels;
 	}
@@ -226,6 +241,10 @@ function mergeFullTemplate(modernTemplate, legacyTemplate) {
 			},
 		},
 	};
+}
+
+function getTemplateModelKeys(template) {
+	return new Set(Object.keys(template.provider?.openai?.models ?? {}));
 }
 
 async function readJson(filePath) {
@@ -417,6 +436,17 @@ export async function runInstaller(argv = process.argv.slice(2), options = {}) {
 
 	const template = await loadTemplate(configMode, paths);
 	template.plugin = [PACKAGE_NAME];
+	const modelKeysToRemove = new Set(STALE_MANAGED_MODEL_KEYS);
+	if (configMode === "modern") {
+		for (const key of getTemplateModelKeys(await readJson(paths.legacyTemplatePath))) {
+			modelKeysToRemove.add(key);
+		}
+	}
+	if (configMode === "legacy") {
+		for (const key of getTemplateModelKeys(await readJson(paths.modernTemplatePath))) {
+			modelKeysToRemove.add(key);
+		}
+	}
 
 	let nextConfig = template;
 	let existingConfig;
@@ -432,7 +462,9 @@ export async function runInstaller(argv = process.argv.slice(2), options = {}) {
 			const provider = (existing.provider && typeof existing.provider === "object")
 				? { ...existing.provider }
 				: {};
-			provider.openai = mergeOpenaiProvider(existing.provider?.openai, template.provider?.openai);
+			provider.openai = mergeOpenaiProvider(existing.provider?.openai, template.provider?.openai, {
+				modelKeysToRemove,
+			});
 			merged.provider = provider;
 			nextConfig = merged;
 		} catch (error) {
@@ -460,13 +492,13 @@ export async function runInstaller(argv = process.argv.slice(2), options = {}) {
 	log("\nDone. Restart OpenCode to (re)install the plugin.");
 	log("Example: opencode");
 	if (configMode === "modern") {
-		log("Note: Modern config intentionally shows 9 base model entries; use --variant to access all 36 shipped presets.");
+		log("Note: Modern config intentionally shows 9 base OAuth model entries; use the variant picker for reasoning presets.");
 	}
 	if (configMode === "legacy") {
 		log("Note: Legacy config writes 36 explicit preset entries and is also safe for older OpenCode versions.");
 	}
 	if (configMode === "full") {
-		log("Note: Full config installs both modern base models and explicit preset entries so the full shipped catalog is visible by default.");
+		log("Note: Full config installs both compact base models and explicit preset entries for direct selector IDs.");
 	}
 
 	return {

--- a/test/install-oc-codex-multi-auth.test.ts
+++ b/test/install-oc-codex-multi-auth.test.ts
@@ -33,7 +33,7 @@ describe("install-oc-codex-multi-auth script", () => {
 		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 		const { runInstaller } = await import("../scripts/install-oc-codex-multi-auth-core.js");
 
-		await expect(runInstaller(["--modern", "--legacy", "--help"])).resolves.toMatchObject({
+		await expect(runInstaller(["--modern", "--full", "--legacy", "--help"])).resolves.toMatchObject({
 			action: "help",
 			exitCode: 0,
 		});
@@ -42,7 +42,7 @@ describe("install-oc-codex-multi-auth script", () => {
 		expect(errorSpy).not.toHaveBeenCalled();
 	});
 
-	it("writes the merged full catalog, preserves user model entries, and normalizes plugin entries", async () => {
+	it("writes compact UI catalog by default, preserves user model entries, and normalizes plugin entries", async () => {
 		vi.resetModules();
 		tempHome = await createTempHome();
 		const { runInstaller } = await import("../scripts/install-oc-codex-multi-auth-core.js");
@@ -64,6 +64,9 @@ describe("install-oc-codex-multi-auth script", () => {
 					openai: {
 						models: {
 							old: { name: "old" },
+							"gpt-5.4": { name: "stale base model" },
+							"gpt-5.5-high": { name: "stale explicit preset" },
+							"gpt-5.5-fast-medium": { name: "stale explicit preset" },
 						},
 					},
 				},
@@ -82,7 +85,7 @@ describe("install-oc-codex-multi-auth script", () => {
 			}),
 		).resolves.toMatchObject({
 			action: "install",
-			configMode: "full",
+			configMode: "modern",
 			exitCode: 0,
 		});
 
@@ -101,18 +104,16 @@ describe("install-oc-codex-multi-auth script", () => {
 		const modernTemplate = JSON.parse(
 			await readFile(new URL("../config/opencode-modern.json", import.meta.url), "utf-8"),
 		) as OpenAiTemplate;
-		const legacyTemplate = JSON.parse(
-			await readFile(new URL("../config/opencode-legacy.json", import.meta.url), "utf-8"),
-		) as OpenAiTemplate;
 		// Template catalog ids plus the user's preserved `old` entry (deep-merge).
-		const expectedCount = Object.keys(modernTemplate.provider.openai.models).length
-			+ Object.keys(legacyTemplate.provider.openai.models).length
-			+ 1;
+		// Explicit preset ids from earlier full installs are managed installer
+		// output, so compact mode prunes them instead of treating them as custom.
+		const expectedCount = Object.keys(modernTemplate.provider.openai.models).length + 1;
 		expect(Object.keys(saved.provider.openai.models)).toHaveLength(expectedCount);
 		expect(saved.provider.openai.models["gpt-5.5"]).toBeDefined();
-		expect(saved.provider.openai.models["gpt-5.5-high"]).toBeDefined();
 		expect(saved.provider.openai.models["gpt-5.5-fast"]).toBeDefined();
-		expect(saved.provider.openai.models["gpt-5.5-fast-medium"]).toBeDefined();
+		expect(saved.provider.openai.models["gpt-5.4"]).toBeUndefined();
+		expect(saved.provider.openai.models["gpt-5.5-high"]).toBeUndefined();
+		expect(saved.provider.openai.models["gpt-5.5-fast-medium"]).toBeUndefined();
 		// User-added model survives deep-merge without overriding template ids.
 		expect(saved.provider.openai.models["old"]).toEqual({ name: "old" });
 		const configEntries = await readdir(configDir);
@@ -122,6 +123,47 @@ describe("install-oc-codex-multi-auth script", () => {
 				expect.stringMatching(/^opencode\.json\.bak-/),
 			]),
 		);
+	});
+
+	it("writes the merged full catalog when --full is requested", async () => {
+		vi.resetModules();
+		tempHome = await createTempHome();
+		const { runInstaller } = await import("../scripts/install-oc-codex-multi-auth-core.js");
+		const configDir = join(tempHome, ".config", "opencode");
+		const configPath = join(configDir, "opencode.json");
+
+		await mkdir(configDir, { recursive: true });
+		await writeFile(configPath, JSON.stringify({ plugin: [] }, null, 2), "utf-8");
+
+		await expect(
+			runInstaller(["--full", "--no-cache-clear"], {
+				env: {
+					...process.env,
+					HOME: tempHome,
+					USERPROFILE: tempHome,
+				},
+			}),
+		).resolves.toMatchObject({
+			action: "install",
+			configMode: "full",
+			exitCode: 0,
+		});
+
+		const saved = JSON.parse(await readFile(configPath, "utf-8")) as OpenAiTemplate;
+		const modernTemplate = JSON.parse(
+			await readFile(new URL("../config/opencode-modern.json", import.meta.url), "utf-8"),
+		) as OpenAiTemplate;
+		const legacyTemplate = JSON.parse(
+			await readFile(new URL("../config/opencode-legacy.json", import.meta.url), "utf-8"),
+		) as OpenAiTemplate;
+		const expectedCount = Object.keys(modernTemplate.provider.openai.models).length
+			+ Object.keys(legacyTemplate.provider.openai.models).length;
+
+		expect(Object.keys(saved.provider.openai.models)).toHaveLength(expectedCount);
+		expect(saved.provider.openai.models["gpt-5.5"]).toBeDefined();
+		expect(saved.provider.openai.models["gpt-5.5-high"]).toBeDefined();
+		expect(saved.provider.openai.models["gpt-5.5-fast"]).toBeDefined();
+		expect(saved.provider.openai.models["gpt-5.5-fast-medium"]).toBeDefined();
 	});
 
 	it("parses BOM-prefixed existing config and preserves custom keys on merge", async () => {
@@ -387,6 +429,32 @@ describe("install-oc-codex-multi-auth script", () => {
 		});
 	});
 
+	it("mergeOpenaiProvider unit: prunes known managed model keys while preserving custom models", async () => {
+		vi.resetModules();
+		const { __test } = await import("../scripts/install-oc-codex-multi-auth-core.js");
+		const merged = __test.mergeOpenaiProvider(
+			{
+				models: {
+					"gpt-5.5-high": { name: "stale explicit preset" },
+					"userOnly": { name: "custom user model" },
+				},
+			},
+			{
+				models: {
+					"gpt-5.5": { name: "compact base model" },
+				},
+			},
+			{
+				modelKeysToRemove: new Set(["gpt-5.5-high"]),
+			},
+		);
+
+		expect(merged.models).toEqual({
+			userOnly: { name: "custom user model" },
+			"gpt-5.5": { name: "compact base model" },
+		});
+	});
+
 	it("keeps cache files when --no-cache-clear is set but still unpins the cached package entry", async () => {
 		vi.resetModules();
 		tempHome = await createTempHome();
@@ -430,7 +498,7 @@ describe("install-oc-codex-multi-auth script", () => {
 			}),
 		).resolves.toMatchObject({
 			action: "install",
-			configMode: "full",
+			configMode: "modern",
 			exitCode: 0,
 		});
 
@@ -496,7 +564,7 @@ describe("install-oc-codex-multi-auth script", () => {
 			}),
 		).resolves.toMatchObject({
 			action: "install",
-			configMode: "full",
+			configMode: "modern",
 			exitCode: 0,
 		});
 


### PR DESCRIPTION
## Summary
- Change the default installer mode from the merged full catalog to the compact modern OAuth catalog.
- Keep explicit preset selector IDs available behind `--full` for scripts and users who still want direct IDs.
- Prune previously shipped explicit preset IDs and stale base IDs during compact/default installs so existing users actually get a clean picker after rerunning the installer.
- Update docs, changelog, and installer tests for the compact model picker behavior.

## Why
The merged full catalog made OpenCode's model picker list every reasoning preset as a separate model, for example `GPT 5.5 Low (OAuth)` and `GPT 5.5 Fast Medium (OAuth)`. Existing installs could also keep those old entries after upgrade because they were already present in `opencode.json`. The default UI should show the actual OAuth model family first, then let OpenCode's variant picker choose the reasoning level.

## User impact
Default installs now show these base plugin OAuth models in the configured catalog: `GPT 5.5 (OAuth)`, `GPT 5.5 Fast (OAuth)`, `GPT 5.4 Mini (OAuth)`, `GPT 5.4 Nano (OAuth)`, `GPT 5.1 Codex Max (OAuth)`, `GPT 5.1 Codex (OAuth)`, `GPT 5.1 Codex Mini (OAuth)`, `GPT 5.1 (OAuth)`, and `GPT 5 Codex (OAuth)`. Reasoning presets stay available through each model's variant picker.

## Validation
- `git diff --check`
- `npx vitest run test/install-oc-codex-multi-auth.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `npm pack --dry-run`
- Local config smoke check with `opencode debug config` against `file:///C:/oc-codex-multi-auth-pr142/dist/index.js`

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

this pr flips the default installer mode from `full` (merged modern+legacy catalog) to `modern` (compact oauth base models only), introduces `--full` as the explicit flag for the previous default behavior, and prunes stale explicit preset ids from existing configs on re-run. the `mergeOpenaiProvider` signature now accepts `modelKeysToRemove` to drive this cleanup, and both a new integration test and a unit test cover the happy path.

<h3>Confidence Score: 5/5</h3>

safe to merge — all remaining findings are p2 style/coverage gaps with no correctness or data-integrity risk

the core installer logic is well-covered by the updated integration tests and new unit test; the pruning set math is sound; mergeFullTemplate guards against key collision with a throw; windows atomic write path is unchanged. the only open items are a missing vitest scenario for --full + stale existing keys, and the --modern alias clarity in help text.

test/install-oc-codex-multi-auth.test.ts — the --full integration test should add a stale-key scenario

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| scripts/install-oc-codex-multi-auth-core.js | core logic change: default mode flipped from "full" to "modern"; --full flag added; pruning via modelKeysToRemove added to mergeOpenaiProvider. no token or windows path safety regressions introduced. |
| test/install-oc-codex-multi-auth.test.ts | new --full integration test and mergeOpenaiProvider unit test added; default-mode test updated for compact catalog. --full mode stale key pruning path is not exercised (coverage gap). |
| CHANGELOG.md | v6.1.5 changelog entry added; accurately describes compact default, --full option, and pruning behavior. |
| README.md | quick-start examples updated to --variant syntax; --full flag documented; --modern reference removed from main path. |
| docs/getting-started.md | all example selectors updated to compact --variant form; full/legacy options documented consistently. |
| docs/development/CONFIG_FLOW.md | installer step 1 description updated; default vs --full mode sections reorganized; debug commands updated to variant syntax. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[npx oc-codex-multi-auth at latest] --> B{CLI flags?}
    B -->|no flags or --modern| C[configMode = modern]
    B -->|--full| D[configMode = full]
    B -->|--legacy| E[configMode = legacy]

    C --> F[loadTemplate: opencode-modern.json]
    D --> G[loadTemplate: merge modern + legacy]
    E --> H[loadTemplate: opencode-legacy.json]

    F --> I[modelKeysToRemove = STALE_MANAGED + all legacy template keys]
    G --> J[modelKeysToRemove = STALE_MANAGED only]
    H --> K[modelKeysToRemove = STALE_MANAGED + all modern template keys]

    I --> L[mergeOpenaiProvider: prune existing config, template wins]
    J --> L
    K --> L

    L --> M[writeFileAtomic to opencode.json]
    M --> N[clearCache]
    N --> O[Done - restart OpenCode]
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Foc-codex-multi-auth%22%20on%20the%20existing%20branch%20%22fix%2Fui-compact-model-picker%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fui-compact-model-picker%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Atest%2Finstall-oc-codex-multi-auth.test.ts%3A615-654%0A**missing%20vitest%20coverage%3A%20%60--full%60%20%2B%20stale%20keys%20in%20existing%20config**%0A%0Athe%20%60--full%60%20integration%20test%20starts%20from%20%60%7B%20plugin%3A%20%5B%5D%20%7D%60%2C%20so%20%60STALE_MANAGED_MODEL_KEYS%60%20pruning%20%28%60gpt-5.2%60%2C%20%60gpt-5.3-codex%60%2C%20%60gpt-5.4%60%29%20is%20never%20exercised%20for%20that%20mode.%20a%20user%20re-running%20with%20%60--full%60%20after%20an%20older%20install%20that%20added%20one%20of%20those%20stale%20entries%20would%20silently%20see%20them%20pruned%20%E2%80%94%20correct%20behavior%2C%20but%20completely%20untested.%20add%20a%20scenario%20that%20pre-populates%20the%20config%20with%20a%20%60gpt-5.2%60%20entry%20and%20asserts%20it's%20absent%20after%20%60--full%60.%0A%0A%23%23%23%20Issue%202%20of%202%0Ascripts%2Finstall-oc-codex-multi-auth-core.js%3A422-434%0A**%60--modern%60%20is%20an%20undocumented%20alias%20for%20the%20new%20default**%0A%0Athe%20help%20text%20still%20lists%20%60--modern%60%20as%20a%20named%20option%2C%20but%20%60parseCliArgs%60%20now%20resolves%20it%20to%20the%20same%20%60%22modern%22%60%20configMode%20as%20the%20no-flag%20default.%20users%20can't%20distinguish%20what%20%60--modern%60%20adds%20vs.%20running%20with%20no%20flags.%20either%20drop%20%60--modern%60%20from%20the%20help%20text%20with%20a%20deprecation%20note%2C%20or%20add%20%60%28alias%20for%20default%29%60%20so%20the%20intent%20is%20clear.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: test/install-oc-codex-multi-auth.test.ts
Line: 615-654

Comment:
**missing vitest coverage: `--full` + stale keys in existing config**

the `--full` integration test starts from `{ plugin: [] }`, so `STALE_MANAGED_MODEL_KEYS` pruning (`gpt-5.2`, `gpt-5.3-codex`, `gpt-5.4`) is never exercised for that mode. a user re-running with `--full` after an older install that added one of those stale entries would silently see them pruned — correct behavior, but completely untested. add a scenario that pre-populates the config with a `gpt-5.2` entry and asserts it's absent after `--full`.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: scripts/install-oc-codex-multi-auth-core.js
Line: 422-434

Comment:
**`--modern` is an undocumented alias for the new default**

the help text still lists `--modern` as a named option, but `parseCliArgs` now resolves it to the same `"modern"` configMode as the no-flag default. users can't distinguish what `--modern` adds vs. running with no flags. either drop `--modern` from the help text with a deprecation note, or add `(alias for default)` so the intent is clear.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(installer): default to compact model..."](https://github.com/ndycode/oc-codex-multi-auth/commit/fb826178ee60b1ec2238e78cba38d66d5d1008bb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29607607)</sub>

<!-- /greptile_comment -->