### PR TITLE
[codex] add OpenCode TUI prompt status

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,7 +6,7 @@ export default [
     ignores: ["dist/**", "node_modules/**", "winston/**", "*.cjs", "*.mjs"],
   },
   {
-    files: ["index.ts", "lib/**/*.ts"],
+    files: ["index.ts", "tui.ts", "lib/**/*.ts"],
     languageOptions: {
       parser: tsparser,
       parserOptions: {

--- a/index.ts
+++ b/index.ts
@@ -212,6 +212,12 @@ import {
 	createToolRegistry,
 	type ToolContext,
 } from "./lib/tools/index.js";
+import { createUsageAccountFingerprint } from "./lib/codex-usage.js";
+import {
+	clearTuiQuotaSnapshot,
+	parseTuiQuotaSnapshotFromHeaders,
+	writeTuiQuotaSnapshot,
+} from "./lib/tui-quota-cache.js";
 
 /**
  * OpenAI Codex OAuth authentication plugin for opencode
@@ -586,6 +592,43 @@ export const OpenAIOAuthPlugin: Plugin = async ({ client }: PluginInput) => {
                         // Ignore when TUI is not available.
                 }
         };
+
+		type TuiQuotaAccount = Parameters<typeof createUsageAccountFingerprint>[0] & {
+			index: number;
+			email?: string;
+			accountLabel?: string;
+		};
+
+		const clearPromptQuotaCache = async (): Promise<void> => {
+			try {
+				await clearTuiQuotaSnapshot();
+			} catch (error) {
+				logDebug(
+					`[${PLUGIN_NAME}] Failed to clear TUI quota cache: ${error instanceof Error ? error.message : String(error)}`,
+				);
+			}
+		};
+
+		const recordPromptQuotaHeaders = async (
+			response: Response,
+			account: TuiQuotaAccount,
+			accountCount: number,
+		): Promise<void> => {
+			try {
+				const snapshot = parseTuiQuotaSnapshotFromHeaders(response.headers, {
+					fingerprint: createUsageAccountFingerprint(account),
+					accountIndex: account.index + 1,
+					accountCount,
+					accountLabel: formatAccountLabel(account, account.index),
+				});
+				if (!snapshot) return;
+				await writeTuiQuotaSnapshot(snapshot);
+			} catch (error) {
+				logDebug(
+					`[${PLUGIN_NAME}] Failed to record TUI quota headers: ${error instanceof Error ? error.message : String(error)}`,
+				);
+			}
+		};
 
 		const resolveActiveIndex = (
 				storage: {
@@ -1290,6 +1333,7 @@ export const OpenAIOAuthPlugin: Plugin = async ({ client }: PluginInput) => {
                                 }
 
                                 await saveAccounts(storage);
+								await clearPromptQuotaCache();
 
                                 // Reload manager from disk so we don't overwrite newer rotated
                                 // refresh tokens with stale in-memory state.
@@ -2100,6 +2144,7 @@ while (attempted.size < Math.max(1, accountCount)) {
 								latencyMs: fetchLatencyMs,
 								headers: Object.fromEntries(response.headers.entries()),
 							});
+							await recordPromptQuotaHeaders(response, account, accountCount);
 
 								if (!response.ok) {
 									const contextOverflowResult = await handleContextOverflow(response, model);

--- a/index.ts
+++ b/index.ts
@@ -2145,7 +2145,7 @@ while (attempted.size < Math.max(1, accountCount)) {
 								latencyMs: fetchLatencyMs,
 								headers: Object.fromEntries(response.headers.entries()),
 							});
-							await recordPromptQuotaHeaders(response, account, accountCount);
+							void recordPromptQuotaHeaders(response, account, accountCount);
 
 								if (!response.ok) {
 									const contextOverflowResult = await handleContextOverflow(response, model);

--- a/index.ts
+++ b/index.ts
@@ -619,6 +619,7 @@ export const OpenAIOAuthPlugin: Plugin = async ({ client }: PluginInput) => {
 					fingerprint: createUsageAccountFingerprint(account),
 					accountIndex: account.index + 1,
 					accountCount,
+					accountEmail: account.email?.trim() || undefined,
 					accountLabel: formatAccountLabel(account, account.index),
 				});
 				if (!snapshot) return;

--- a/lib/codex-usage.ts
+++ b/lib/codex-usage.ts
@@ -1,0 +1,541 @@
+import { createHash } from "node:crypto";
+
+import { extractAccountId } from "./accounts.js";
+import { getFetchTimeoutMs, loadPluginConfig } from "./config.js";
+import { CODEX_BASE_URL, PLUGIN_NAME } from "./constants.js";
+import { createUsageRequestTimeoutError } from "./error-sentinels.js";
+import { logWarn } from "./logger.js";
+import { queuedRefresh } from "./refresh-queue.js";
+import { createCodexHeaders } from "./request/fetch-helpers.js";
+import {
+	withAccountStorageTransaction,
+	type AccountMetadataV3,
+	type AccountStorageV3,
+} from "./storage.js";
+
+export type UsageWindow = {
+	used_percent?: number;
+	limit_window_seconds?: number;
+	reset_at?: number;
+	reset_after_seconds?: number;
+} | null;
+
+export type LimitWindow = {
+	usedPercent?: number;
+	windowMinutes?: number;
+	resetAtMs?: number;
+};
+
+export type UsageRateLimit = {
+	primary_window?: UsageWindow;
+	secondary_window?: UsageWindow;
+} | null;
+
+export type UsageCredits = {
+	has_credits?: boolean;
+	unlimited?: boolean;
+	balance?: string | null;
+} | null;
+
+export type UsagePayload = {
+	plan_type?: string;
+	rate_limit?: UsageRateLimit;
+	code_review_rate_limit?: UsageRateLimit;
+	additional_rate_limits?: Array<{
+		limit_name?: string;
+		metered_feature?: string;
+		rate_limit?: UsageRateLimit;
+	}> | null;
+	credits?: UsageCredits;
+};
+
+export type UsageLimitPayload = {
+	name: string;
+	windowMinutes: number | null;
+	usedPercent: number | null;
+	leftPercent: number | null;
+	resetAtMs: number | null;
+	summary: string;
+};
+
+export type AdditionalUsageLimit = {
+	name: string;
+	window: LimitWindow;
+};
+
+export type CodexUsageSummary = {
+	planType: string | null;
+	credits: string | null;
+	primary: LimitWindow;
+	secondary: LimitWindow;
+	codeReview: LimitWindow;
+	additionalLimits: AdditionalUsageLimit[];
+	limits: UsageLimitPayload[];
+};
+
+export type EnsureCodexUsageAccessTokenResult = {
+	accessToken: string;
+	refreshed: boolean;
+	persisted: boolean;
+};
+
+export type UsageAccountSelection = {
+	index: number;
+	account: AccountMetadataV3;
+};
+
+const usageErrorBodyMaxChars = 4096;
+
+export function getUsageLeftPercent(
+	usedPercent: number | undefined,
+): number | undefined {
+	return typeof usedPercent === "number" && Number.isFinite(usedPercent)
+		? Math.max(0, Math.min(100, Math.round(100 - usedPercent)))
+		: undefined;
+}
+
+export function formatUsageWindowLabel(
+	windowMinutes: number | undefined,
+): string {
+	if (
+		!windowMinutes ||
+		!Number.isFinite(windowMinutes) ||
+		windowMinutes <= 0
+	) {
+		return "quota";
+	}
+	if (windowMinutes % 1440 === 0) return `${windowMinutes / 1440}d`;
+	if (windowMinutes % 60 === 0) return `${windowMinutes / 60}h`;
+	return `${windowMinutes}m`;
+}
+
+export function formatUsageReset(
+	resetAtMs: number | undefined,
+): string | undefined {
+	if (!resetAtMs || !Number.isFinite(resetAtMs) || resetAtMs <= 0) {
+		return undefined;
+	}
+	const date = new Date(resetAtMs);
+	if (!Number.isFinite(date.getTime())) return undefined;
+
+	const now = new Date();
+	const sameDay =
+		now.getFullYear() === date.getFullYear() &&
+		now.getMonth() === date.getMonth() &&
+		now.getDate() === date.getDate();
+	const time = date.toLocaleTimeString(undefined, {
+		hour: "2-digit",
+		minute: "2-digit",
+		hour12: false,
+	});
+	if (sameDay) return time;
+	const day = date.toLocaleDateString(undefined, {
+		month: "short",
+		day: "2-digit",
+	});
+	return `${time} on ${day}`;
+}
+
+export function mapUsageWindow(window: UsageWindow): LimitWindow {
+	if (!window) return {};
+	return {
+		usedPercent:
+			typeof window.used_percent === "number" &&
+			Number.isFinite(window.used_percent)
+				? window.used_percent
+				: undefined,
+		windowMinutes:
+			typeof window.limit_window_seconds === "number" &&
+			Number.isFinite(window.limit_window_seconds)
+				? Math.max(1, Math.ceil(window.limit_window_seconds / 60))
+				: undefined,
+		resetAtMs:
+			typeof window.reset_at === "number" && window.reset_at > 0
+				? window.reset_at * 1000
+				: typeof window.reset_after_seconds === "number" &&
+						window.reset_after_seconds > 0
+					? Date.now() + window.reset_after_seconds * 1000
+					: undefined,
+	};
+}
+
+export function formatUsageLimitTitle(
+	windowMinutes: number | undefined,
+	fallback = "quota",
+): string {
+	if (windowMinutes === 300) return "5h limit";
+	if (windowMinutes === 10080) return "Weekly limit";
+	if (fallback !== "quota") return fallback;
+	return `${formatUsageWindowLabel(windowMinutes)} limit`;
+}
+
+export function formatUsageLimitSummary(window: LimitWindow): string {
+	const left = getUsageLeftPercent(window.usedPercent);
+	const reset = formatUsageReset(window.resetAtMs);
+	if (left !== undefined && reset) return `${left}% left (resets ${reset})`;
+	if (left !== undefined) return `${left}% left`;
+	if (reset) return `resets ${reset}`;
+	return "unavailable";
+}
+
+export function toUsageLimitPayload(
+	name: string,
+	window: LimitWindow,
+): UsageLimitPayload {
+	return {
+		name,
+		windowMinutes: window.windowMinutes ?? null,
+		usedPercent:
+			typeof window.usedPercent === "number" ? window.usedPercent : null,
+		leftPercent: getUsageLeftPercent(window.usedPercent) ?? null,
+		resetAtMs: window.resetAtMs ?? null,
+		summary: formatUsageLimitSummary(window),
+	};
+}
+
+export function formatUsageCredits(
+	credits: UsageCredits,
+): string | undefined {
+	if (!credits) return undefined;
+	if (credits.unlimited) return "unlimited";
+	if (typeof credits.balance === "string" && credits.balance.trim()) {
+		return credits.balance.trim();
+	}
+	if (credits.has_credits) return "available";
+	return undefined;
+}
+
+export function formatAdditionalUsageLimitName(
+	name: string | undefined,
+): string {
+	if (!name) return "Additional limit";
+	if (name === "code_review_rate_limit") return "Code review";
+	return name
+		.replace(/[_-]+/g, " ")
+		.replace(/\b\w/g, (match) => match.toUpperCase());
+}
+
+export function hasUsageWindow(window: LimitWindow): boolean {
+	return Boolean(
+		window.windowMinutes ||
+			typeof window.usedPercent === "number" ||
+			window.resetAtMs,
+	);
+}
+
+export function parseCodexUsagePayload(
+	payload: UsagePayload,
+): CodexUsageSummary {
+	const primary = mapUsageWindow(payload.rate_limit?.primary_window ?? null);
+	const secondary = mapUsageWindow(payload.rate_limit?.secondary_window ?? null);
+	const codeReviewRateLimit =
+		payload.code_review_rate_limit ??
+		payload.additional_rate_limits?.find(
+			(entry) => entry.limit_name === "code_review_rate_limit",
+		)?.rate_limit ??
+		null;
+	const codeReview = mapUsageWindow(codeReviewRateLimit?.primary_window ?? null);
+	const credits = formatUsageCredits(payload.credits ?? null);
+	const additionalLimits = (payload.additional_rate_limits ?? [])
+		.filter((entry) => entry.limit_name !== "code_review_rate_limit")
+		.map((entry) => ({
+			name: formatAdditionalUsageLimitName(
+				entry.limit_name ?? entry.metered_feature,
+			),
+			window: mapUsageWindow(entry.rate_limit?.primary_window ?? null),
+		}));
+	const limits = [
+		toUsageLimitPayload(formatUsageLimitTitle(primary.windowMinutes), primary),
+		toUsageLimitPayload(formatUsageLimitTitle(secondary.windowMinutes), secondary),
+	];
+	if (hasUsageWindow(codeReview)) {
+		limits.push(toUsageLimitPayload("Code review", codeReview));
+	}
+	for (const limit of additionalLimits) {
+		limits.push(toUsageLimitPayload(limit.name, limit.window));
+	}
+
+	return {
+		planType: payload.plan_type ?? null,
+		credits: credits ?? null,
+		primary,
+		secondary,
+		codeReview,
+		additionalLimits,
+		limits,
+	};
+}
+
+function sanitizeUsageErrorMessage(status: number, bodyText: string): string {
+	const normalized = bodyText.replace(/\s+/g, " ").trim();
+	const redacted = normalized
+		.replace(/Bearer\s+\S+/gi, "Bearer [redacted]")
+		.replace(
+			/eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/g,
+			"[redacted-token]",
+		)
+		.replace(/\bsk-[A-Za-z0-9][A-Za-z0-9._:-]{19,}\b/gi, "[redacted-token]")
+		.replace(/\b[a-f0-9]{40,}\b/gi, "[redacted-token]");
+	return redacted ? `HTTP ${status}: ${redacted.slice(0, 200)}` : `HTTP ${status}`;
+}
+
+function isAbortError(error: unknown): boolean {
+	return (
+		(error instanceof Error && error.name === "AbortError") ||
+		(typeof DOMException !== "undefined" &&
+			error instanceof DOMException &&
+			error.name === "AbortError")
+	);
+}
+
+export async function fetchCodexUsage(params: {
+	accountId: string;
+	accessToken: string;
+	organizationId: string | undefined;
+	timeoutMs?: number;
+}): Promise<UsagePayload> {
+	const headers = createCodexHeaders(
+		undefined,
+		params.accountId,
+		params.accessToken,
+		{
+			organizationId: params.organizationId,
+		},
+	);
+	headers.set("accept", "application/json");
+	const controller = new AbortController();
+	const timeout = setTimeout(
+		() => controller.abort(),
+		params.timeoutMs ?? getFetchTimeoutMs(loadPluginConfig()),
+	);
+
+	try {
+		const response = await fetch(`${CODEX_BASE_URL}/wham/usage`, {
+			method: "GET",
+			headers,
+			signal: controller.signal,
+		});
+		if (!response.ok) {
+			let bodyText = "";
+			try {
+				bodyText = (await response.text()).slice(0, usageErrorBodyMaxChars);
+			} catch (error) {
+				if (isAbortError(error) || controller.signal.aborted) {
+					throw createUsageRequestTimeoutError();
+				}
+				throw error;
+			}
+			if (controller.signal.aborted) {
+				throw createUsageRequestTimeoutError();
+			}
+			throw new Error(sanitizeUsageErrorMessage(response.status, bodyText));
+		}
+		return (await response.json()) as UsagePayload;
+	} catch (error) {
+		if (isAbortError(error)) {
+			throw createUsageRequestTimeoutError();
+		}
+		throw error;
+	} finally {
+		clearTimeout(timeout);
+	}
+}
+
+function applyRefreshedCredentials(
+	target: {
+		refreshToken: string;
+		accessToken?: string;
+		expiresAt?: number;
+	},
+	result: {
+		refresh: string;
+		access: string;
+		expires: number;
+	},
+): void {
+	target.refreshToken = result.refresh;
+	target.accessToken = result.access;
+	target.expiresAt = result.expires;
+}
+
+async function persistRefreshedCredentials(params: {
+	previousRefreshToken: string;
+	accountId?: string;
+	organizationId?: string;
+	email?: string;
+	refreshResult: {
+		refresh: string;
+		access: string;
+		expires: number;
+	};
+}): Promise<boolean> {
+	return await withAccountStorageTransaction(async (current, persist) => {
+		const latestStorage: AccountStorageV3 =
+			current ??
+			({
+				version: 3,
+				accounts: [],
+				activeIndex: 0,
+				activeIndexByFamily: {},
+			} satisfies AccountStorageV3);
+
+		const uniqueMatch = <Value>(matches: Value[]): Value | undefined =>
+			matches.length === 1 ? matches[0] : undefined;
+
+		let updated = false;
+		if (params.previousRefreshToken) {
+			for (const storedAccount of latestStorage.accounts) {
+				if (storedAccount.refreshToken === params.previousRefreshToken) {
+					applyRefreshedCredentials(storedAccount, params.refreshResult);
+					updated = true;
+				}
+			}
+		}
+
+		if (!updated) {
+			const normalizedOrganizationId = params.organizationId?.trim() ?? "";
+			const normalizedEmail = params.email?.trim().toLowerCase();
+			const orgScopedMatches = params.accountId
+				? latestStorage.accounts.filter(
+						(storedAccount) =>
+							storedAccount.accountId === params.accountId &&
+							(storedAccount.organizationId?.trim() ?? "") ===
+								normalizedOrganizationId,
+					)
+				: [];
+			const accountIdMatches = params.accountId
+				? latestStorage.accounts.filter(
+						(storedAccount) => storedAccount.accountId === params.accountId,
+					)
+				: [];
+			const emailMatches =
+				normalizedEmail && !params.accountId
+					? latestStorage.accounts.filter(
+							(storedAccount) =>
+								storedAccount.email?.trim().toLowerCase() === normalizedEmail,
+						)
+					: [];
+
+			const fallbackTarget =
+				uniqueMatch(orgScopedMatches) ??
+				uniqueMatch(accountIdMatches) ??
+				uniqueMatch(emailMatches);
+
+			if (fallbackTarget) {
+				applyRefreshedCredentials(fallbackTarget, params.refreshResult);
+				updated = true;
+			}
+		}
+
+		if (updated) {
+			await persist(latestStorage);
+		}
+		if (!updated) {
+			logWarn(
+				`[${PLUGIN_NAME}] persistRefreshedCredentials could not find a matching stored account. Refreshed credentials remain in-memory for this invocation only.`,
+				{
+					accountId: params.accountId,
+					organizationId: params.organizationId,
+				},
+			);
+		}
+
+		return updated;
+	});
+}
+
+export async function ensureCodexUsageAccessToken(params: {
+	storage: AccountStorageV3;
+	account: AccountMetadataV3;
+}): Promise<EnsureCodexUsageAccessTokenResult> {
+	let accessToken = params.account.accessToken;
+	if (
+		typeof accessToken === "string" &&
+		accessToken &&
+		typeof params.account.expiresAt === "number" &&
+		params.account.expiresAt > Date.now() + 30_000
+	) {
+		return { accessToken, refreshed: false, persisted: false };
+	}
+
+	const previousRefreshToken = params.account.refreshToken;
+	if (!previousRefreshToken) {
+		throw new Error("Cannot refresh: account has no refresh token");
+	}
+	const refreshResult = await queuedRefresh(previousRefreshToken);
+	if (refreshResult.type !== "success") {
+		throw new Error(refreshResult.message ?? refreshResult.reason);
+	}
+
+	let refreshedCount = 0;
+	for (const storedAccount of params.storage.accounts) {
+		if (storedAccount.refreshToken === previousRefreshToken) {
+			applyRefreshedCredentials(storedAccount, refreshResult);
+			refreshedCount += 1;
+		}
+	}
+	if (refreshedCount === 0) {
+		applyRefreshedCredentials(params.account, refreshResult);
+	}
+
+	const persisted = await persistRefreshedCredentials({
+		previousRefreshToken,
+		accountId: params.account.accountId,
+		organizationId: params.account.organizationId,
+		email: params.account.email,
+		refreshResult,
+	});
+
+	accessToken = refreshResult.access;
+	return { accessToken, refreshed: true, persisted };
+}
+
+export function deduplicateUsageAccountIndices(storage: AccountStorageV3): number[] {
+	const seenTokens = new Set<string>();
+	const uniqueIndices: number[] = [];
+	for (let i = 0; i < storage.accounts.length; i += 1) {
+		const account = storage.accounts[i];
+		if (!account) continue;
+		const refreshToken =
+			typeof account.refreshToken === "string"
+				? account.refreshToken.trim()
+				: "";
+		if (refreshToken && seenTokens.has(refreshToken)) continue;
+		if (refreshToken) seenTokens.add(refreshToken);
+		uniqueIndices.push(i);
+	}
+	return uniqueIndices;
+}
+
+export function resolveCodexUsageActiveAccount(
+	storage: AccountStorageV3,
+): UsageAccountSelection | null {
+	if (storage.accounts.length === 0) return null;
+	const rawIndex = storage.activeIndexByFamily?.codex ?? storage.activeIndex;
+	const numericIndex =
+		typeof rawIndex === "number" && Number.isFinite(rawIndex) ? rawIndex : 0;
+	const index = Math.max(
+		0,
+		Math.min(storage.accounts.length - 1, Math.trunc(numericIndex)),
+	);
+	const account = storage.accounts[index];
+	return account ? { index, account } : null;
+}
+
+export function resolveCodexUsageAccountId(params: {
+	account: AccountMetadataV3;
+	accessToken: string;
+}): string | undefined {
+	return params.account.accountId ?? extractAccountId(params.accessToken);
+}
+
+export function createUsageAccountFingerprint(
+	account: AccountMetadataV3,
+): string {
+	const fingerprintSource = [
+		account.accountId ?? "",
+		account.organizationId ?? "",
+		account.refreshToken ?? "",
+	].join("\0");
+	return createHash("sha256").update(fingerprintSource).digest("hex").slice(0, 16);
+}

--- a/lib/tools/codex-limits.ts
+++ b/lib/tools/codex-limits.ts
@@ -4,17 +4,18 @@
  */
 
 import { tool, type ToolDefinition } from "@opencode-ai/plugin/tool";
+import { loadAccounts } from "../storage.js";
 import {
-	loadAccounts,
-	withAccountStorageTransaction,
-	type AccountStorageV3,
-} from "../storage.js";
-import { extractAccountId } from "../accounts.js";
-import { queuedRefresh } from "../refresh-queue.js";
-import { createCodexHeaders } from "../request/fetch-helpers.js";
-import { createUsageRequestTimeoutError } from "../error-sentinels.js";
-import { CODEX_BASE_URL, PLUGIN_NAME } from "../constants.js";
-import { getFetchTimeoutMs, loadPluginConfig } from "../config.js";
+	deduplicateUsageAccountIndices,
+	ensureCodexUsageAccessToken,
+	fetchCodexUsage,
+	formatUsageLimitSummary,
+	formatUsageLimitTitle,
+	hasUsageWindow,
+	parseCodexUsagePayload,
+	resolveCodexUsageAccountId,
+} from "../codex-usage.js";
+import { PLUGIN_NAME } from "../constants.js";
 import { logWarn } from "../logger.js";
 import {
 	formatUiBadge,
@@ -81,374 +82,7 @@ export function createCodexLimitsTool(ctx: ToolContext): ToolDefinition {
 				return "No Codex accounts configured. Run: opencode auth login";
 			}
 
-			type UsageWindow = {
-				used_percent?: number;
-				limit_window_seconds?: number;
-				reset_at?: number;
-				reset_after_seconds?: number;
-			} | null;
-
-			type LimitWindow = {
-				usedPercent?: number;
-				windowMinutes?: number;
-				resetAtMs?: number;
-			};
-
-			type UsageRateLimit = {
-				primary_window?: UsageWindow;
-				secondary_window?: UsageWindow;
-			} | null;
-
-			type UsageCredits = {
-				has_credits?: boolean;
-				unlimited?: boolean;
-				balance?: string | null;
-			} | null;
-
-			type UsagePayload = {
-				plan_type?: string;
-				rate_limit?: UsageRateLimit;
-				code_review_rate_limit?: UsageRateLimit;
-				additional_rate_limits?: Array<{
-					limit_name?: string;
-					metered_feature?: string;
-					rate_limit?: UsageRateLimit;
-				}> | null;
-				credits?: UsageCredits;
-			};
-
-			const formatWindowLabel = (windowMinutes: number | undefined): string => {
-				if (
-					!windowMinutes ||
-					!Number.isFinite(windowMinutes) ||
-					windowMinutes <= 0
-				) {
-					return "quota";
-				}
-				if (windowMinutes % 1440 === 0) return `${windowMinutes / 1440}d`;
-				if (windowMinutes % 60 === 0) return `${windowMinutes / 60}h`;
-				return `${windowMinutes}m`;
-			};
-
-			const formatReset = (
-				resetAtMs: number | undefined,
-			): string | undefined => {
-				if (
-					!resetAtMs ||
-					!Number.isFinite(resetAtMs) ||
-					resetAtMs <= 0
-				)
-					return undefined;
-				const date = new Date(resetAtMs);
-				if (!Number.isFinite(date.getTime())) return undefined;
-
-				const now = new Date();
-				const sameDay =
-					now.getFullYear() === date.getFullYear() &&
-					now.getMonth() === date.getMonth() &&
-					now.getDate() === date.getDate();
-				const time = date.toLocaleTimeString(undefined, {
-					hour: "2-digit",
-					minute: "2-digit",
-					hour12: false,
-				});
-				if (sameDay) return time;
-				const day = date.toLocaleDateString(undefined, {
-					month: "short",
-					day: "2-digit",
-				});
-				return `${time} on ${day}`;
-			};
-
-			const mapWindow = (window: UsageWindow): LimitWindow => {
-				if (!window) return {};
-				return {
-					usedPercent:
-						typeof window.used_percent === "number" &&
-						Number.isFinite(window.used_percent)
-							? window.used_percent
-							: undefined,
-					windowMinutes:
-						typeof window.limit_window_seconds === "number" &&
-						Number.isFinite(window.limit_window_seconds)
-							? Math.max(1, Math.ceil(window.limit_window_seconds / 60))
-							: undefined,
-					resetAtMs:
-						typeof window.reset_at === "number" && window.reset_at > 0
-							? window.reset_at * 1000
-							: typeof window.reset_after_seconds === "number" &&
-									window.reset_after_seconds > 0
-								? Date.now() + window.reset_after_seconds * 1000
-								: undefined,
-				};
-			};
-
-			const formatLimitTitle = (
-				windowMinutes: number | undefined,
-				fallback = "quota",
-			): string => {
-				if (windowMinutes === 300) return "5h limit";
-				if (windowMinutes === 10080) return "Weekly limit";
-				if (fallback !== "quota") return fallback;
-				return `${formatWindowLabel(windowMinutes)} limit`;
-			};
-
-			const formatLimitSummary = (window: LimitWindow): string => {
-				const used = window.usedPercent;
-				const left =
-					typeof used === "number" && Number.isFinite(used)
-						? Math.max(0, Math.min(100, Math.round(100 - used)))
-						: undefined;
-				const reset = formatReset(window.resetAtMs);
-				if (left !== undefined && reset)
-					return `${left}% left (resets ${reset})`;
-				if (left !== undefined) return `${left}% left`;
-				if (reset) return `resets ${reset}`;
-				return "unavailable";
-			};
-
-			const toLimitPayload = (name: string, window: LimitWindow) => ({
-				name,
-				windowMinutes: window.windowMinutes ?? null,
-				usedPercent:
-					typeof window.usedPercent === "number" ? window.usedPercent : null,
-				leftPercent:
-					typeof window.usedPercent === "number"
-						? Math.max(0, Math.min(100, Math.round(100 - window.usedPercent)))
-						: null,
-				resetAtMs: window.resetAtMs ?? null,
-				summary: formatLimitSummary(window),
-			});
-
-			const formatCredits = (
-				credits: UsageCredits,
-			): string | undefined => {
-				if (!credits) return undefined;
-				if (credits.unlimited) return "unlimited";
-				if (
-					typeof credits.balance === "string" &&
-					credits.balance.trim()
-				) {
-					return credits.balance.trim();
-				}
-				if (credits.has_credits) return "available";
-				return undefined;
-			};
-
-			const formatExtraName = (name: string | undefined): string => {
-				if (!name) return "Additional limit";
-				if (name === "code_review_rate_limit") return "Code review";
-				return name
-					.replace(/[_-]+/g, " ")
-					.replace(/\b\w/g, (match) => match.toUpperCase());
-			};
-
-			const sanitizeUsageErrorMessage = (
-				status: number,
-				bodyText: string,
-			): string => {
-				const normalized = bodyText.replace(/\s+/g, " ").trim();
-				const redacted = normalized
-					.replace(/Bearer\s+\S+/gi, "Bearer [redacted]")
-					.replace(
-						/eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/g,
-						"[redacted-token]",
-					)
-					.replace(
-						/\bsk-[A-Za-z0-9][A-Za-z0-9._:-]{19,}\b/gi,
-						"[redacted-token]",
-					)
-					.replace(/\b[a-f0-9]{40,}\b/gi, "[redacted-token]");
-				return redacted
-					? `HTTP ${status}: ${redacted.slice(0, 200)}`
-					: `HTTP ${status}`;
-			};
-
-			const isAbortError = (error: unknown): boolean =>
-				(error instanceof Error && error.name === "AbortError") ||
-				(typeof DOMException !== "undefined" &&
-					error instanceof DOMException &&
-					error.name === "AbortError");
-
-			const applyRefreshedCredentials = (
-				target: {
-					refreshToken: string;
-					accessToken?: string;
-					expiresAt?: number;
-				},
-				result: {
-					refresh: string;
-					access: string;
-					expires: number;
-				},
-			): void => {
-				target.refreshToken = result.refresh;
-				target.accessToken = result.access;
-				target.expiresAt = result.expires;
-			};
-			const usageErrorBodyMaxChars = 4096;
-
-			const persistRefreshedCredentials = async (params: {
-				previousRefreshToken: string;
-				accountId?: string;
-				organizationId?: string;
-				email?: string;
-				refreshResult: {
-					refresh: string;
-					access: string;
-					expires: number;
-				};
-			}): Promise<boolean> => {
-				return await withAccountStorageTransaction(async (current, persist) => {
-					const latestStorage: AccountStorageV3 =
-						current ??
-						({
-							version: 3,
-							accounts: [],
-							activeIndex: 0,
-							activeIndexByFamily: {},
-						} satisfies AccountStorageV3);
-
-					const uniqueMatch = <T>(matches: T[]): T | undefined =>
-						matches.length === 1 ? matches[0] : undefined;
-
-					let updated = false;
-					if (params.previousRefreshToken) {
-						for (const storedAccount of latestStorage.accounts) {
-							if (
-								storedAccount.refreshToken === params.previousRefreshToken
-							) {
-								applyRefreshedCredentials(storedAccount, params.refreshResult);
-								updated = true;
-							}
-						}
-					}
-
-					if (!updated) {
-						const normalizedOrganizationId =
-							params.organizationId?.trim() ?? "";
-						const normalizedEmail = params.email?.trim().toLowerCase();
-						const orgScopedMatches = params.accountId
-							? latestStorage.accounts.filter(
-									(storedAccount) =>
-										storedAccount.accountId === params.accountId &&
-										(storedAccount.organizationId?.trim() ?? "") ===
-											normalizedOrganizationId,
-								)
-							: [];
-						const accountIdMatches = params.accountId
-							? latestStorage.accounts.filter(
-									(storedAccount) =>
-										storedAccount.accountId === params.accountId,
-								)
-							: [];
-						const emailMatches =
-							normalizedEmail && !params.accountId
-								? latestStorage.accounts.filter(
-										(storedAccount) =>
-											storedAccount.email?.trim().toLowerCase() ===
-											normalizedEmail,
-									)
-								: [];
-
-						const fallbackTarget =
-							uniqueMatch(orgScopedMatches) ??
-							uniqueMatch(accountIdMatches) ??
-							uniqueMatch(emailMatches);
-
-						if (fallbackTarget) {
-							applyRefreshedCredentials(fallbackTarget, params.refreshResult);
-							updated = true;
-						}
-					}
-
-					if (updated) {
-						await persist(latestStorage);
-					}
-					if (!updated) {
-						logWarn(
-							`[${PLUGIN_NAME}] persistRefreshedCredentials could not find a matching stored account. Refreshed credentials remain in-memory for this invocation only.`,
-							{
-								accountId: params.accountId,
-								organizationId: params.organizationId,
-							},
-						);
-					}
-
-					return updated;
-				});
-			};
-
-			const usageFetchTimeoutMs = getFetchTimeoutMs(loadPluginConfig());
-
-			const fetchUsage = async (params: {
-				accountId: string;
-				accessToken: string;
-				organizationId: string | undefined;
-			}): Promise<UsagePayload> => {
-				const headers = createCodexHeaders(
-					undefined,
-					params.accountId,
-					params.accessToken,
-					{
-						organizationId: params.organizationId,
-					},
-				);
-				headers.set("accept", "application/json");
-				const controller = new AbortController();
-				const timeout = setTimeout(() => controller.abort(), usageFetchTimeoutMs);
-
-				try {
-					const response = await fetch(`${CODEX_BASE_URL}/wham/usage`, {
-						method: "GET",
-						headers,
-						signal: controller.signal,
-					});
-					if (!response.ok) {
-						let bodyText = "";
-						try {
-							bodyText = (await response.text()).slice(
-								0,
-								usageErrorBodyMaxChars,
-							);
-						} catch (error) {
-							if (isAbortError(error) || controller.signal.aborted) {
-								throw createUsageRequestTimeoutError();
-							}
-							throw error;
-						}
-						if (controller.signal.aborted) {
-							throw createUsageRequestTimeoutError();
-						}
-						throw new Error(
-							sanitizeUsageErrorMessage(response.status, bodyText),
-						);
-					}
-					return (await response.json()) as UsagePayload;
-				} catch (error) {
-					if (isAbortError(error)) {
-						throw createUsageRequestTimeoutError();
-					}
-					throw error;
-				} finally {
-					clearTimeout(timeout);
-				}
-			};
-
-			// Deduplicate accounts by refreshToken (same credential = same limits)
-			const seenTokens = new Set<string>();
-			const uniqueIndices: number[] = [];
-			for (let i = 0; i < storage.accounts.length; i++) {
-				const acct = storage.accounts[i];
-				if (!acct) continue;
-				const refreshToken =
-					typeof acct.refreshToken === "string"
-						? acct.refreshToken.trim()
-						: "";
-				if (refreshToken && seenTokens.has(refreshToken)) continue;
-				if (refreshToken) seenTokens.add(refreshToken);
-				uniqueIndices.push(i);
-			}
+			const uniqueIndices = deduplicateUsageAccountIndices(storage);
 
 			const lines: string[] = ui.v2Enabled
 				? [...formatUiHeader(ui, "Codex limits"), ""]
@@ -494,107 +128,28 @@ export function createCodexLimitsTool(ctx: ToolContext): ToolDefinition {
 					: "";
 
 				try {
-					let accessToken = account.accessToken;
-					if (
-						typeof accessToken !== "string" ||
-						!accessToken ||
-						typeof account.expiresAt !== "number" ||
-						account.expiresAt <= Date.now() + 30_000
-					) {
-						const previousRefreshToken = account.refreshToken;
-						if (!previousRefreshToken) {
-							throw new Error("Cannot refresh: account has no refresh token");
-						}
-						const refreshResult = await queuedRefresh(previousRefreshToken);
-						if (refreshResult.type !== "success") {
-							throw new Error(
-								refreshResult.message ?? refreshResult.reason,
-							);
-						}
-
-						let refreshedCount = 0;
-						for (const storedAccount of storage.accounts) {
-							if (!storedAccount) continue;
-							if (storedAccount.refreshToken === previousRefreshToken) {
-								applyRefreshedCredentials(storedAccount, refreshResult);
-								refreshedCount += 1;
-							}
-						}
-						if (refreshedCount === 0) {
-							applyRefreshedCredentials(account, refreshResult);
-						}
-
-						const persistedRefresh = await persistRefreshedCredentials({
-							previousRefreshToken,
-							accountId: account.accountId,
-							organizationId: account.organizationId,
-							email: account.email,
-							refreshResult,
-						});
-
-						accessToken = refreshResult.access;
-						storageChanged = storageChanged || persistedRefresh;
-					}
-
+					const credentials = await ensureCodexUsageAccessToken({
+						storage,
+						account,
+					});
+					storageChanged = storageChanged || credentials.persisted;
 					const effectiveAccount = sharesActiveCredential
 						? effectiveDisplayAccount
 						: account;
-					const accountId =
-						effectiveAccount.accountId ?? extractAccountId(accessToken);
+					const accountId = resolveCodexUsageAccountId({
+						account: effectiveAccount,
+						accessToken: credentials.accessToken,
+					});
 					if (!accountId) {
 						throw new Error("Missing account id");
 					}
 
-					const payload = await fetchUsage({
+					const payload = await fetchCodexUsage({
 						accountId,
-						accessToken,
+						accessToken: credentials.accessToken,
 						organizationId: effectiveAccount.organizationId,
 					});
-
-					const primary = mapWindow(payload.rate_limit?.primary_window ?? null);
-					const secondary = mapWindow(
-						payload.rate_limit?.secondary_window ?? null,
-					);
-					const codeReviewRateLimit =
-						payload.code_review_rate_limit ??
-						payload.additional_rate_limits?.find(
-							(entry) => entry.limit_name === "code_review_rate_limit",
-						)?.rate_limit ??
-						null;
-					const codeReview = mapWindow(
-						codeReviewRateLimit?.primary_window ?? null,
-					);
-					const credits = formatCredits(payload.credits ?? null);
-					const additionalLimits = (
-						payload.additional_rate_limits ?? []
-					).filter(
-						(entry) => entry.limit_name !== "code_review_rate_limit",
-					);
-					const limits = [
-						toLimitPayload(formatLimitTitle(primary.windowMinutes), primary),
-						toLimitPayload(
-							formatLimitTitle(secondary.windowMinutes),
-							secondary,
-						),
-					];
-					if (
-						codeReview.windowMinutes ||
-						typeof codeReview.usedPercent === "number" ||
-						codeReview.resetAtMs
-					) {
-						limits.push(toLimitPayload("Code review", codeReview));
-					}
-					for (const limit of additionalLimits) {
-						const extraWindow = mapWindow(
-							limit.rate_limit?.primary_window ?? null,
-						);
-						limits.push(
-							toLimitPayload(
-								formatExtraName(limit.limit_name ?? limit.metered_feature),
-								extraWindow,
-							),
-						);
-					}
+					const usage = parseCodexUsagePayload(payload);
 					jsonAccounts.push({
 						...buildJsonAccountIdentity(displayIndex, {
 							includeSensitive: includeSensitiveOutput,
@@ -603,76 +158,62 @@ export function createCodexLimitsTool(ctx: ToolContext): ToolDefinition {
 						}),
 						isActive,
 						sharesActiveCredential,
-						planType: payload.plan_type ?? null,
-						credits: credits ?? null,
-						limits,
+						planType: usage.planType,
+						credits: usage.credits,
+						limits: usage.limits,
 					});
 
 					if (ui.v2Enabled) {
 						lines.push(formatUiItem(ui, `${label}${activeSuffix}`));
 						lines.push(
-							`  ${formatUiKeyValue(ui, formatLimitTitle(primary.windowMinutes), formatLimitSummary(primary), "muted")}`,
+							`  ${formatUiKeyValue(ui, formatUsageLimitTitle(usage.primary.windowMinutes), formatUsageLimitSummary(usage.primary), "muted")}`,
 						);
 						lines.push(
-							`  ${formatUiKeyValue(ui, formatLimitTitle(secondary.windowMinutes), formatLimitSummary(secondary), "muted")}`,
+							`  ${formatUiKeyValue(ui, formatUsageLimitTitle(usage.secondary.windowMinutes), formatUsageLimitSummary(usage.secondary), "muted")}`,
 						);
-						if (
-							codeReview.windowMinutes ||
-							typeof codeReview.usedPercent === "number" ||
-							codeReview.resetAtMs
-						) {
+						if (hasUsageWindow(usage.codeReview)) {
 							lines.push(
-								`  ${formatUiKeyValue(ui, "Code review", formatLimitSummary(codeReview), "muted")}`,
+								`  ${formatUiKeyValue(ui, "Code review", formatUsageLimitSummary(usage.codeReview), "muted")}`,
 							);
 						}
-						for (const limit of additionalLimits) {
-							const extraWindow = mapWindow(
-								limit.rate_limit?.primary_window ?? null,
-							);
+						for (const limit of usage.additionalLimits) {
 							lines.push(
-								`  ${formatUiKeyValue(ui, formatExtraName(limit.limit_name ?? limit.metered_feature), formatLimitSummary(extraWindow), "muted")}`,
+								`  ${formatUiKeyValue(ui, limit.name, formatUsageLimitSummary(limit.window), "muted")}`,
 							);
 						}
-						if (payload.plan_type) {
+						if (usage.planType) {
 							lines.push(
-								`  ${formatUiKeyValue(ui, "Plan", payload.plan_type, "muted")}`,
+								`  ${formatUiKeyValue(ui, "Plan", usage.planType, "muted")}`,
 							);
 						}
-						if (credits) {
+						if (usage.credits) {
 							lines.push(
-								`  ${formatUiKeyValue(ui, "Credits", credits, "muted")}`,
+								`  ${formatUiKeyValue(ui, "Credits", usage.credits, "muted")}`,
 							);
 						}
 					} else {
 						lines.push(`${label}${activeSuffix}:`);
 						lines.push(
-							`  ${formatLimitTitle(primary.windowMinutes)}: ${formatLimitSummary(primary)}`,
+							`  ${formatUsageLimitTitle(usage.primary.windowMinutes)}: ${formatUsageLimitSummary(usage.primary)}`,
 						);
 						lines.push(
-							`  ${formatLimitTitle(secondary.windowMinutes)}: ${formatLimitSummary(secondary)}`,
+							`  ${formatUsageLimitTitle(usage.secondary.windowMinutes)}: ${formatUsageLimitSummary(usage.secondary)}`,
 						);
-						if (
-							codeReview.windowMinutes ||
-							typeof codeReview.usedPercent === "number" ||
-							codeReview.resetAtMs
-						) {
+						if (hasUsageWindow(usage.codeReview)) {
 							lines.push(
-								`  Code review: ${formatLimitSummary(codeReview)}`,
+								`  Code review: ${formatUsageLimitSummary(usage.codeReview)}`,
 							);
 						}
-						for (const limit of additionalLimits) {
-							const extraWindow = mapWindow(
-								limit.rate_limit?.primary_window ?? null,
-							);
+						for (const limit of usage.additionalLimits) {
 							lines.push(
-								`  ${formatExtraName(limit.limit_name ?? limit.metered_feature)}: ${formatLimitSummary(extraWindow)}`,
+								`  ${limit.name}: ${formatUsageLimitSummary(limit.window)}`,
 							);
 						}
-						if (payload.plan_type) {
-							lines.push(`  Plan: ${payload.plan_type}`);
+						if (usage.planType) {
+							lines.push(`  Plan: ${usage.planType}`);
 						}
-						if (credits) {
-							lines.push(`  Credits: ${credits}`);
+						if (usage.credits) {
+							lines.push(`  Credits: ${usage.credits}`);
 						}
 					}
 				} catch (error) {

--- a/lib/tools/codex-switch.ts
+++ b/lib/tools/codex-switch.ts
@@ -8,6 +8,7 @@ import { loadAccounts, saveAccounts } from "../storage.js";
 import { AccountManager } from "../accounts.js";
 import { logWarn } from "../logger.js";
 import { MODEL_FAMILIES } from "../prompts/codex.js";
+import { clearTuiQuotaSnapshot } from "../tui-quota-cache.js";
 import {
 	formatUiHeader,
 	formatUiItem,
@@ -145,6 +146,13 @@ export function createCodexSwitchTool(ctx: ToolContext): ToolDefinition {
 					].join("\n");
 				}
 				return `Switched to ${label} but failed to persist. Changes may be lost on restart.`;
+			}
+			try {
+				await clearTuiQuotaSnapshot();
+			} catch (cacheError) {
+				logWarn("Failed to clear TUI quota cache after account switch", {
+					error: String(cacheError),
+				});
 			}
 
 			if (cachedAccountManagerRef.current) {

--- a/lib/tui-quota-cache.ts
+++ b/lib/tui-quota-cache.ts
@@ -7,6 +7,7 @@ import type { CompactQuotaLimit } from "./tui-status.js";
 
 export const TUI_QUOTA_CACHE_VERSION = 1;
 export const TUI_QUOTA_CACHE_FILE = "oc-codex-multi-auth-tui-quota.json";
+const TUI_QUOTA_CACHE_WRITE_SKIP_MS = 500;
 
 export type TuiQuotaSource = "headers" | "usage";
 
@@ -36,6 +37,14 @@ export type TuiQuotaSnapshotInput = Omit<
 > & {
 	fetchedAt?: number;
 };
+
+type RecentTuiQuotaWrite = {
+	key: string;
+	at: number;
+	promise?: Promise<void>;
+};
+
+const recentTuiQuotaWrites = new Map<string, RecentTuiQuotaWrite>();
 
 function getDefaultOpenCodeStateDir(): string {
 	return join(homedir(), ".local", "state", "opencode");
@@ -162,6 +171,26 @@ export function createTuiQuotaSnapshot(
 	};
 }
 
+function getSnapshotWriteKey(snapshot: TuiQuotaSnapshot): string {
+	return JSON.stringify({
+		fingerprint: snapshot.fingerprint,
+		source: snapshot.source,
+		accountIndex: snapshot.accountIndex,
+		accountCount: snapshot.accountCount,
+		accountEmail: snapshot.accountEmail,
+		accountLabel: snapshot.accountLabel,
+		planType: snapshot.planType,
+		activeLimit: snapshot.activeLimit,
+		limits: snapshot.limits.map((limit) => ({
+			label: limit.label,
+			leftPercent: limit.leftPercent,
+			usedPercent: limit.usedPercent,
+			windowMinutes: limit.windowMinutes,
+			resetAtMs: limit.resetAtMs,
+		})),
+	});
+}
+
 export function parseTuiQuotaSnapshotFromHeaders(
 	headers: Headers,
 	input: Omit<TuiQuotaSnapshotInput, "source" | "limits">,
@@ -255,23 +284,52 @@ export async function writeTuiQuotaSnapshot(
 	cachePath?: string,
 ): Promise<void> {
 	const target = cachePath ?? getTuiQuotaCachePath();
-	await fs.mkdir(dirname(target), { recursive: true });
-	const temporary = `${target}.${process.pid}.${Date.now()}.tmp`;
-	try {
+	const writeKey = getSnapshotWriteKey(snapshot);
+	const now = Date.now();
+	const recentWrite = recentTuiQuotaWrites.get(target);
+	if (
+		recentWrite?.key === writeKey &&
+		now - recentWrite.at < TUI_QUOTA_CACHE_WRITE_SKIP_MS
+	) {
+		await recentWrite.promise;
+		return;
+	}
+
+	const temporary =
+		`${target}.${process.pid}.${now}.${Math.random().toString(36).slice(2)}.tmp`;
+	const writePromise = (async () => {
+		await fs.mkdir(dirname(target), { recursive: true });
 		await fs.writeFile(temporary, `${JSON.stringify(snapshot, null, 2)}\n`, {
 			encoding: "utf-8",
 			mode: 0o600,
 		});
 		await renameWithWindowsRetry(temporary, target);
+	})();
+	recentTuiQuotaWrites.set(target, {
+		key: writeKey,
+		at: now,
+		promise: writePromise,
+	});
+	try {
+		await writePromise;
+		recentTuiQuotaWrites.set(target, {
+			key: writeKey,
+			at: Date.now(),
+		});
 	} catch (error) {
 		await fs.unlink(temporary).catch(() => undefined);
+		if (recentTuiQuotaWrites.get(target)?.promise === writePromise) {
+			recentTuiQuotaWrites.delete(target);
+		}
 		throw error;
 	}
 }
 
 export async function clearTuiQuotaSnapshot(cachePath?: string): Promise<void> {
+	const target = cachePath ?? getTuiQuotaCachePath();
+	recentTuiQuotaWrites.delete(target);
 	try {
-		await fs.unlink(cachePath ?? getTuiQuotaCachePath());
+		await fs.unlink(target);
 	} catch (error) {
 		if ((error as NodeJS.ErrnoException)?.code === "ENOENT") return;
 		throw error;

--- a/lib/tui-quota-cache.ts
+++ b/lib/tui-quota-cache.ts
@@ -1,0 +1,276 @@
+import { promises as fs } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+
+import { renameWithWindowsRetry } from "./storage/atomic-write.js";
+import type { CompactQuotaLimit } from "./tui-status.js";
+
+export const TUI_QUOTA_CACHE_VERSION = 1;
+export const TUI_QUOTA_CACHE_FILE = "oc-codex-multi-auth-tui-quota.json";
+
+export type TuiQuotaSource = "headers" | "usage";
+
+export type TuiQuotaLimit = CompactQuotaLimit & {
+	usedPercent?: number;
+	windowMinutes?: number;
+	resetAtMs?: number;
+};
+
+export type TuiQuotaSnapshot = {
+	version: typeof TUI_QUOTA_CACHE_VERSION;
+	fingerprint: string;
+	fetchedAt: number;
+	source: TuiQuotaSource;
+	accountIndex?: number;
+	accountCount?: number;
+	accountLabel?: string;
+	planType?: string;
+	activeLimit?: number;
+	limits: TuiQuotaLimit[];
+};
+
+export type TuiQuotaSnapshotInput = Omit<
+	TuiQuotaSnapshot,
+	"version" | "fetchedAt"
+> & {
+	fetchedAt?: number;
+};
+
+function getDefaultOpenCodeStateDir(): string {
+	return join(homedir(), ".local", "state", "opencode");
+}
+
+export function getTuiQuotaCachePath(stateDir?: string): string {
+	const envStateDir = process.env.OPENCODE_STATE_DIR?.trim();
+	return join(stateDir?.trim() || envStateDir || getDefaultOpenCodeStateDir(), TUI_QUOTA_CACHE_FILE);
+}
+
+function parseFiniteNumberHeader(
+	headers: Headers,
+	name: string,
+): number | undefined {
+	const raw = headers.get(name);
+	if (!raw) return undefined;
+	const parsed = Number(raw);
+	return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function parseFiniteIntHeader(
+	headers: Headers,
+	name: string,
+): number | undefined {
+	const raw = headers.get(name);
+	if (!raw) return undefined;
+	const parsed = Number.parseInt(raw, 10);
+	return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function parseResetAtMs(headers: Headers, prefix: string): number | undefined {
+	const resetAfterSeconds = parseFiniteIntHeader(
+		headers,
+		`${prefix}-reset-after-seconds`,
+	);
+	if (
+		typeof resetAfterSeconds === "number" &&
+		Number.isFinite(resetAfterSeconds) &&
+		resetAfterSeconds > 0
+	) {
+		return Date.now() + resetAfterSeconds * 1000;
+	}
+
+	const resetAtRaw = headers.get(`${prefix}-reset-at`);
+	if (!resetAtRaw) return undefined;
+	const trimmed = resetAtRaw.trim();
+	if (/^\d+$/.test(trimmed)) {
+		const parsedNumber = Number.parseInt(trimmed, 10);
+		if (Number.isFinite(parsedNumber) && parsedNumber > 0) {
+			return parsedNumber < 10_000_000_000
+				? parsedNumber * 1000
+				: parsedNumber;
+		}
+	}
+
+	const parsedDate = Date.parse(trimmed);
+	return Number.isFinite(parsedDate) ? parsedDate : undefined;
+}
+
+function formatWindowLabel(windowMinutes: number | undefined): string {
+	if (
+		!windowMinutes ||
+		!Number.isFinite(windowMinutes) ||
+		windowMinutes <= 0
+	) {
+		return "quota";
+	}
+	if (windowMinutes % 1440 === 0) return `${windowMinutes / 1440}d`;
+	if (windowMinutes % 60 === 0) return `${windowMinutes / 60}h`;
+	return `${windowMinutes}m`;
+}
+
+function getLeftPercent(usedPercent: number | undefined): number | null {
+	return typeof usedPercent === "number" && Number.isFinite(usedPercent)
+		? Math.max(0, Math.min(100, Math.round(100 - usedPercent)))
+		: null;
+}
+
+function hasCodexQuotaHeaders(headers: Headers): boolean {
+	const keys = [
+		"x-codex-primary-used-percent",
+		"x-codex-primary-window-minutes",
+		"x-codex-primary-reset-at",
+		"x-codex-primary-reset-after-seconds",
+		"x-codex-secondary-used-percent",
+		"x-codex-secondary-window-minutes",
+		"x-codex-secondary-reset-at",
+		"x-codex-secondary-reset-after-seconds",
+	];
+	return keys.some((key) => headers.get(key) !== null);
+}
+
+function parseLimit(headers: Headers, prefix: string): TuiQuotaLimit {
+	const usedPercent = parseFiniteNumberHeader(headers, `${prefix}-used-percent`);
+	const windowMinutes = parseFiniteIntHeader(
+		headers,
+		`${prefix}-window-minutes`,
+	);
+	const resetAtMs = parseResetAtMs(headers, prefix);
+	return {
+		label: formatWindowLabel(windowMinutes),
+		leftPercent: getLeftPercent(usedPercent),
+		usedPercent,
+		windowMinutes,
+		resetAtMs,
+	};
+}
+
+function hasUsefulLimit(limit: TuiQuotaLimit): boolean {
+	return Boolean(
+		limit.windowMinutes ||
+			typeof limit.usedPercent === "number" ||
+			typeof limit.resetAtMs === "number",
+	);
+}
+
+export function createTuiQuotaSnapshot(
+	input: TuiQuotaSnapshotInput,
+): TuiQuotaSnapshot {
+	return {
+		version: TUI_QUOTA_CACHE_VERSION,
+		...input,
+		fetchedAt: input.fetchedAt ?? Date.now(),
+	};
+}
+
+export function parseTuiQuotaSnapshotFromHeaders(
+	headers: Headers,
+	input: Omit<TuiQuotaSnapshotInput, "source" | "limits">,
+): TuiQuotaSnapshot | undefined {
+	if (!hasCodexQuotaHeaders(headers)) return undefined;
+	const limits = [
+		parseLimit(headers, "x-codex-primary"),
+		parseLimit(headers, "x-codex-secondary"),
+	].filter(hasUsefulLimit);
+	if (limits.length === 0) return undefined;
+
+	const planTypeRaw = headers.get("x-codex-plan-type");
+	const planType = planTypeRaw?.trim() || undefined;
+	const activeLimit = parseFiniteIntHeader(headers, "x-codex-active-limit");
+
+	return createTuiQuotaSnapshot({
+		...input,
+		source: "headers",
+		planType,
+		activeLimit,
+		limits,
+	});
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function isOptionalFiniteNumber(value: unknown): value is number | undefined {
+	return value === undefined || (typeof value === "number" && Number.isFinite(value));
+}
+
+function isNullablePercent(value: unknown): value is number | null {
+	return (
+		value === null ||
+		(typeof value === "number" &&
+			Number.isFinite(value) &&
+			value >= 0 &&
+			value <= 100)
+	);
+}
+
+function isTuiQuotaLimit(value: unknown): value is TuiQuotaLimit {
+	return (
+		isRecord(value) &&
+		typeof value.label === "string" &&
+		value.label.trim().length > 0 &&
+		isNullablePercent(value.leftPercent) &&
+		isOptionalFiniteNumber(value.usedPercent) &&
+		isOptionalFiniteNumber(value.windowMinutes) &&
+		isOptionalFiniteNumber(value.resetAtMs)
+	);
+}
+
+export function isTuiQuotaSnapshot(value: unknown): value is TuiQuotaSnapshot {
+	return (
+		isRecord(value) &&
+		value.version === TUI_QUOTA_CACHE_VERSION &&
+		typeof value.fingerprint === "string" &&
+		value.fingerprint.trim().length > 0 &&
+		typeof value.fetchedAt === "number" &&
+		Number.isFinite(value.fetchedAt) &&
+		(value.source === "headers" || value.source === "usage") &&
+		isOptionalFiniteNumber(value.accountIndex) &&
+		isOptionalFiniteNumber(value.accountCount) &&
+		(value.accountLabel === undefined ||
+			typeof value.accountLabel === "string") &&
+		(value.planType === undefined || typeof value.planType === "string") &&
+		isOptionalFiniteNumber(value.activeLimit) &&
+		Array.isArray(value.limits) &&
+		value.limits.every(isTuiQuotaLimit)
+	);
+}
+
+export async function readTuiQuotaSnapshot(
+	cachePath?: string,
+): Promise<TuiQuotaSnapshot | undefined> {
+	try {
+		const raw = await fs.readFile(cachePath ?? getTuiQuotaCachePath(), "utf-8");
+		const parsed = JSON.parse(raw) as unknown;
+		return isTuiQuotaSnapshot(parsed) ? parsed : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+export async function writeTuiQuotaSnapshot(
+	snapshot: TuiQuotaSnapshot,
+	cachePath?: string,
+): Promise<void> {
+	const target = cachePath ?? getTuiQuotaCachePath();
+	await fs.mkdir(dirname(target), { recursive: true });
+	const temporary = `${target}.${process.pid}.${Date.now()}.tmp`;
+	try {
+		await fs.writeFile(temporary, `${JSON.stringify(snapshot, null, 2)}\n`, {
+			encoding: "utf-8",
+			mode: 0o600,
+		});
+		await renameWithWindowsRetry(temporary, target);
+	} catch (error) {
+		await fs.unlink(temporary).catch(() => undefined);
+		throw error;
+	}
+}
+
+export async function clearTuiQuotaSnapshot(cachePath?: string): Promise<void> {
+	try {
+		await fs.unlink(cachePath ?? getTuiQuotaCachePath());
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException)?.code === "ENOENT") return;
+		throw error;
+	}
+}

--- a/lib/tui-quota-cache.ts
+++ b/lib/tui-quota-cache.ts
@@ -23,6 +23,7 @@ export type TuiQuotaSnapshot = {
 	source: TuiQuotaSource;
 	accountIndex?: number;
 	accountCount?: number;
+	accountEmail?: string;
 	accountLabel?: string;
 	planType?: string;
 	activeLimit?: number;
@@ -226,6 +227,8 @@ export function isTuiQuotaSnapshot(value: unknown): value is TuiQuotaSnapshot {
 		(value.source === "headers" || value.source === "usage") &&
 		isOptionalFiniteNumber(value.accountIndex) &&
 		isOptionalFiniteNumber(value.accountCount) &&
+		(value.accountEmail === undefined ||
+			typeof value.accountEmail === "string") &&
 		(value.accountLabel === undefined ||
 			typeof value.accountLabel === "string") &&
 		(value.planType === undefined || typeof value.planType === "string") &&

--- a/lib/tui-status.ts
+++ b/lib/tui-status.ts
@@ -5,7 +5,12 @@ export type ReasoningVariant = "none" | "low" | "medium" | "high" | "xhigh";
 export type CompactQuotaLimit = {
 	label: string;
 	leftPercent: number | null;
+	usedPercent?: number;
+	windowMinutes?: number;
+	resetAtMs?: number;
 };
+
+export type CompactQuotaSource = "headers" | "usage";
 
 export type CompactQuotaStatus =
 	| { type: "loading" }
@@ -15,6 +20,14 @@ export type CompactQuotaStatus =
 			type: "ready";
 			limits: readonly CompactQuotaLimit[];
 			stale: boolean;
+			source?: CompactQuotaSource;
+			fetchedAt?: number;
+			fingerprint?: string;
+			accountIndex?: number;
+			accountCount?: number;
+			accountLabel?: string;
+			planType?: string;
+			activeLimit?: number;
 	  };
 
 export type PromptStatusMessage = {
@@ -39,6 +52,7 @@ const variantSuffixes: ReasoningVariant[] = [
 	"low",
 	"none",
 ];
+const STATUS_SEPARATOR = ` ${String.fromCharCode(183)} `;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return value !== null && typeof value === "object" && !Array.isArray(value);
@@ -178,16 +192,33 @@ function formatQuotaLimit(limit: CompactQuotaLimit): string | undefined {
 	return `${label} ${limit.leftPercent}%`;
 }
 
+function formatAccountHint(quota: CompactQuotaStatus): string | undefined {
+	if (quota.type !== "ready") return undefined;
+	if (
+		typeof quota.accountIndex !== "number" ||
+		!Number.isFinite(quota.accountIndex)
+	) {
+		return undefined;
+	}
+	if (
+		typeof quota.accountCount === "number" &&
+		Number.isFinite(quota.accountCount) &&
+		quota.accountCount <= 1
+	) {
+		return undefined;
+	}
+	return `A${quota.accountIndex}`;
+}
+
 function formatQuota(quota: CompactQuotaStatus): string | undefined {
 	if (quota.type === "ready") {
 		const parts = quota.limits
 			.map(formatQuotaLimit)
 			.filter((part): part is string => Boolean(part));
-		return parts.length > 0 ? parts.join(" · ") : undefined;
+		return parts.length > 0 ? parts.join(STATUS_SEPARATOR) : undefined;
 	}
 	if (quota.type === "missing") return "no auth";
 	if (quota.type === "unavailable") return "limits ?";
-	if (quota.type === "loading") return "limits ...";
 	return undefined;
 }
 
@@ -206,12 +237,121 @@ export function formatPromptStatusText(params: {
 	width?: number;
 }): string {
 	const variant = params.variant;
+	const account = formatAccountHint(params.quota);
 	const quota = formatQuota(params.quota);
 	const candidates = [
-		[variant, quota].filter(Boolean).join(" · "),
+		[variant, account, quota].filter(Boolean).join(STATUS_SEPARATOR),
+		[account, quota].filter(Boolean).join(STATUS_SEPARATOR),
+		[variant, quota].filter(Boolean).join(STATUS_SEPARATOR),
 		variant,
 		quota,
+		account,
 	].filter((candidate): candidate is string => Boolean(candidate));
 	const maxChars = maxStatusChars(params.width);
 	return candidates.find((candidate) => candidate.length <= maxChars) ?? "";
+}
+
+export type QuotaPromptTone =
+	| "normal"
+	| "warning"
+	| "danger"
+	| "stale"
+	| "unknown";
+
+export function resolveQuotaPromptTone(
+	quota: CompactQuotaStatus,
+): QuotaPromptTone {
+	if (quota.type === "ready") {
+		if (quota.stale) return "stale";
+		const percents = quota.limits
+			.map((limit) => limit.leftPercent)
+			.filter(isPercent);
+		if (percents.length === 0) return "unknown";
+		const lowest = Math.min(...percents);
+		if (lowest <= 10) return "danger";
+		if (lowest <= 25) return "warning";
+		return "normal";
+	}
+	if (quota.type === "loading") return "unknown";
+	return "warning";
+}
+
+function formatReset(resetAtMs: number | undefined): string | undefined {
+	if (!resetAtMs || !Number.isFinite(resetAtMs) || resetAtMs <= 0) {
+		return undefined;
+	}
+	const date = new Date(resetAtMs);
+	if (!Number.isFinite(date.getTime())) return undefined;
+	const now = new Date();
+	const sameDay =
+		now.getFullYear() === date.getFullYear() &&
+		now.getMonth() === date.getMonth() &&
+		now.getDate() === date.getDate();
+	const time = date.toLocaleTimeString(undefined, {
+		hour: "2-digit",
+		minute: "2-digit",
+		hour12: false,
+	});
+	if (sameDay) return time;
+	const day = date.toLocaleDateString(undefined, {
+		month: "short",
+		day: "2-digit",
+	});
+	return `${time} on ${day}`;
+}
+
+function formatUpdatedAge(fetchedAt: number | undefined, now: number): string {
+	if (!fetchedAt || !Number.isFinite(fetchedAt)) return "unknown";
+	const ageMs = Math.max(0, now - fetchedAt);
+	if (ageMs < 60_000) return "just now";
+	const minutes = Math.floor(ageMs / 60_000);
+	if (minutes < 60) return `${minutes}m ago`;
+	const hours = Math.floor(minutes / 60);
+	if (hours < 24) return `${hours}h ago`;
+	const days = Math.floor(hours / 24);
+	return `${days}d ago`;
+}
+
+function formatDetailsLimit(limit: CompactQuotaLimit): string {
+	const label = limit.label.trim() || "quota";
+	const left = isPercent(limit.leftPercent)
+		? `${limit.leftPercent}% left`
+		: "unavailable";
+	const reset = formatReset(limit.resetAtMs);
+	return reset ? `${label}: ${left}, resets ${reset}` : `${label}: ${left}`;
+}
+
+export function formatQuotaDetailsText(
+	quota: CompactQuotaStatus,
+	now = Date.now(),
+): string {
+	if (quota.type === "loading") return "Quota is loading.";
+	if (quota.type === "missing") return "No Codex OAuth account is configured.";
+	if (quota.type === "unavailable") return "Quota is unavailable.";
+
+	const lines: string[] = [];
+	const accountHint = formatAccountHint(quota);
+	if (quota.accountLabel && accountHint) {
+		lines.push(`Account: ${accountHint} (${quota.accountLabel})`);
+	} else if (quota.accountLabel) {
+		lines.push(`Account: ${quota.accountLabel}`);
+	} else if (accountHint) {
+		lines.push(`Account: ${accountHint}`);
+	}
+	for (const limit of quota.limits) {
+		lines.push(formatDetailsLimit(limit));
+	}
+	if (quota.planType) lines.push(`Plan: ${quota.planType}`);
+	if (
+		typeof quota.activeLimit === "number" &&
+		Number.isFinite(quota.activeLimit)
+	) {
+		lines.push(`Active limit: ${quota.activeLimit}`);
+	}
+	lines.push(
+		`Source: ${quota.source === "headers" ? "response headers" : "usage endpoint"}`,
+	);
+	lines.push(`Updated: ${formatUpdatedAge(quota.fetchedAt, now)}`);
+	if (quota.stale) lines.push("Status: stale fallback");
+	return lines.join("\n");
 }

--- a/lib/tui-status.ts
+++ b/lib/tui-status.ts
@@ -2,14 +2,18 @@ import type { Config } from "@opencode-ai/sdk/v2";
 
 export type ReasoningVariant = "none" | "low" | "medium" | "high" | "xhigh";
 
+export type CompactQuotaLimit = {
+	label: string;
+	leftPercent: number | null;
+};
+
 export type CompactQuotaStatus =
 	| { type: "loading" }
 	| { type: "missing" }
 	| { type: "unavailable" }
 	| {
 			type: "ready";
-			primaryLeftPercent: number | null;
-			secondaryLeftPercent: number | null;
+			limits: readonly CompactQuotaLimit[];
 			stale: boolean;
 	  };
 
@@ -168,42 +172,22 @@ function isPercent(value: number | null): value is number {
 	return typeof value === "number" && Number.isFinite(value);
 }
 
-function formatQuotaNormal(quota: CompactQuotaStatus): string | undefined {
+function formatQuotaLimit(limit: CompactQuotaLimit): string | undefined {
+	if (!isPercent(limit.leftPercent)) return undefined;
+	const label = limit.label.trim() || "quota";
+	return `${label} ${limit.leftPercent}%`;
+}
+
+function formatQuota(quota: CompactQuotaStatus): string | undefined {
 	if (quota.type === "ready") {
-		if (
-			isPercent(quota.primaryLeftPercent) &&
-			isPercent(quota.secondaryLeftPercent)
-		) {
-			return `5h ${quota.primaryLeftPercent}% · weekly ${quota.secondaryLeftPercent}%`;
-		}
-		if (isPercent(quota.primaryLeftPercent)) {
-			return `5h ${quota.primaryLeftPercent}%`;
-		}
-		if (isPercent(quota.secondaryLeftPercent)) {
-			return `weekly ${quota.secondaryLeftPercent}%`;
-		}
-		return undefined;
+		const parts = quota.limits
+			.map(formatQuotaLimit)
+			.filter((part): part is string => Boolean(part));
+		return parts.length > 0 ? parts.join(" · ") : undefined;
 	}
 	if (quota.type === "missing") return "no auth";
 	if (quota.type === "unavailable") return "limits ?";
 	if (quota.type === "loading") return "limits ...";
-	return undefined;
-}
-
-function formatQuotaCompact(quota: CompactQuotaStatus): string | undefined {
-	if (quota.type !== "ready") return formatQuotaNormal(quota);
-	if (
-		isPercent(quota.primaryLeftPercent) &&
-		isPercent(quota.secondaryLeftPercent)
-	) {
-		return `5h ${quota.primaryLeftPercent} · wk ${quota.secondaryLeftPercent}`;
-	}
-	if (isPercent(quota.primaryLeftPercent)) {
-		return `5h ${quota.primaryLeftPercent}`;
-	}
-	if (isPercent(quota.secondaryLeftPercent)) {
-		return `wk ${quota.secondaryLeftPercent}`;
-	}
 	return undefined;
 }
 
@@ -222,13 +206,11 @@ export function formatPromptStatusText(params: {
 	width?: number;
 }): string {
 	const variant = params.variant;
-	const normalQuota = formatQuotaNormal(params.quota);
-	const compactQuota = formatQuotaCompact(params.quota);
+	const quota = formatQuota(params.quota);
 	const candidates = [
-		[variant, normalQuota].filter(Boolean).join(" · "),
-		[variant, compactQuota].filter(Boolean).join(" · "),
+		[variant, quota].filter(Boolean).join(" · "),
 		variant,
-		compactQuota,
+		quota,
 	].filter((candidate): candidate is string => Boolean(candidate));
 	const maxChars = maxStatusChars(params.width);
 	return candidates.find((candidate) => candidate.length <= maxChars) ?? "";

--- a/lib/tui-status.ts
+++ b/lib/tui-status.ts
@@ -25,6 +25,7 @@ export type CompactQuotaStatus =
 			fingerprint?: string;
 			accountIndex?: number;
 			accountCount?: number;
+			accountEmail?: string;
 			accountLabel?: string;
 			planType?: string;
 			activeLimit?: number;
@@ -53,6 +54,8 @@ const variantSuffixes: ReasoningVariant[] = [
 	"none",
 ];
 const STATUS_SEPARATOR = ` ${String.fromCharCode(183)} `;
+const WARNING_LIMIT_LEFT_PERCENT = 25;
+const DANGER_LIMIT_LEFT_PERCENT = 10;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return value !== null && typeof value === "object" && !Array.isArray(value);
@@ -186,10 +189,27 @@ function isPercent(value: number | null): value is number {
 	return typeof value === "number" && Number.isFinite(value);
 }
 
-function formatQuotaLimit(limit: CompactQuotaLimit): string | undefined {
+function extractEmailFromLabel(label: string | undefined): string | undefined {
+	const match = label?.match(/[^\s(),<>]+@[^\s(),<>]+/);
+	return match?.[0];
+}
+
+function formatAccountEmail(email: string | undefined): string | undefined {
+	const trimmed = email?.trim() || undefined;
+	return trimmed ? `[${trimmed}]` : undefined;
+}
+
+function formatQuotaLimit(
+	limit: CompactQuotaLimit,
+	resetLimit: CompactQuotaLimit | undefined,
+	includeReset: boolean,
+): string | undefined {
 	if (!isPercent(limit.leftPercent)) return undefined;
 	const label = limit.label.trim() || "quota";
-	return `${label} ${limit.leftPercent}%`;
+	const base = `${label} ${limit.leftPercent}%`;
+	const reset =
+		includeReset && limit === resetLimit ? formatResetTime(limit.resetAtMs) : undefined;
+	return reset ? `${base} resets ${reset}` : base;
 }
 
 function formatAccountHint(quota: CompactQuotaStatus): string | undefined {
@@ -207,14 +227,45 @@ function formatAccountHint(quota: CompactQuotaStatus): string | undefined {
 	) {
 		return undefined;
 	}
+	const email =
+		formatAccountEmail(quota.accountEmail) ??
+		formatAccountEmail(extractEmailFromLabel(quota.accountLabel));
+	if (email) return email;
 	return `A${quota.accountIndex}`;
+}
+
+function findResetLimitForStatus(
+	limits: readonly CompactQuotaLimit[],
+): CompactQuotaLimit | undefined {
+	const eligible = limits.filter((limit) => isPercent(limit.leftPercent));
+	if (eligible.length === 0) return undefined;
+	const lowest = eligible.reduce((current, limit) =>
+		(limit.leftPercent ?? 100) < (current.leftPercent ?? 100)
+			? limit
+			: current,
+	);
+	if ((lowest.leftPercent ?? 100) > WARNING_LIMIT_LEFT_PERCENT) {
+		return undefined;
+	}
+	return formatResetTime(lowest.resetAtMs) ? lowest : undefined;
+}
+
+function formatQuotaParts(
+	quota: CompactQuotaStatus,
+	includeReset: boolean,
+): string[] {
+	if (quota.type !== "ready") return [];
+	const resetLimit = includeReset
+		? findResetLimitForStatus(quota.limits)
+		: undefined;
+	return quota.limits
+		.map((limit) => formatQuotaLimit(limit, resetLimit, includeReset))
+		.filter((part): part is string => Boolean(part));
 }
 
 function formatQuota(quota: CompactQuotaStatus): string | undefined {
 	if (quota.type === "ready") {
-		const parts = quota.limits
-			.map(formatQuotaLimit)
-			.filter((part): part is string => Boolean(part));
+		const parts = formatQuotaParts(quota, true);
 		return parts.length > 0 ? parts.join(STATUS_SEPARATOR) : undefined;
 	}
 	if (quota.type === "missing") return "no auth";
@@ -224,11 +275,11 @@ function formatQuota(quota: CompactQuotaStatus): string | undefined {
 
 function maxStatusChars(width: number | undefined): number {
 	if (!width || !Number.isFinite(width)) return 32;
-	if (width >= 120) return 34;
-	if (width >= 96) return 30;
-	if (width >= 78) return 24;
-	if (width >= 60) return 18;
-	return 10;
+	if (width >= 120) return 48;
+	if (width >= 96) return 40;
+	if (width >= 78) return 32;
+	if (width >= 60) return 22;
+	return 12;
 }
 
 export function formatPromptStatusText(params: {
@@ -238,13 +289,28 @@ export function formatPromptStatusText(params: {
 }): string {
 	const variant = params.variant;
 	const account = formatAccountHint(params.quota);
-	const quota = formatQuota(params.quota);
+	const quotaParts = formatQuotaParts(params.quota, true);
+	const quotaPartsWithoutReset = formatQuotaParts(params.quota, false);
+	const quota = quotaParts.length > 0
+		? quotaParts.join(STATUS_SEPARATOR)
+		: formatQuota(params.quota);
+	const primaryQuota = quotaParts[0] ?? quota;
+	const quotaWithoutReset = quotaPartsWithoutReset.length > 0
+		? quotaPartsWithoutReset.join(STATUS_SEPARATOR)
+		: quota;
+	const primaryQuotaWithoutReset = quotaPartsWithoutReset[0] ?? primaryQuota;
 	const candidates = [
-		[variant, account, quota].filter(Boolean).join(STATUS_SEPARATOR),
 		[account, quota].filter(Boolean).join(STATUS_SEPARATOR),
+		[account, primaryQuota].filter(Boolean).join(STATUS_SEPARATOR),
+		quota,
+		primaryQuota,
+		[account, quotaWithoutReset].filter(Boolean).join(STATUS_SEPARATOR),
+		[account, primaryQuotaWithoutReset].filter(Boolean).join(STATUS_SEPARATOR),
+		quotaWithoutReset,
+		primaryQuotaWithoutReset,
+		[variant, account, quota].filter(Boolean).join(STATUS_SEPARATOR),
 		[variant, quota].filter(Boolean).join(STATUS_SEPARATOR),
 		variant,
-		quota,
 		account,
 	].filter((candidate): candidate is string => Boolean(candidate));
 	const maxChars = maxStatusChars(params.width);
@@ -268,8 +334,8 @@ export function resolveQuotaPromptTone(
 			.filter(isPercent);
 		if (percents.length === 0) return "unknown";
 		const lowest = Math.min(...percents);
-		if (lowest <= 10) return "danger";
-		if (lowest <= 25) return "warning";
+		if (lowest <= DANGER_LIMIT_LEFT_PERCENT) return "danger";
+		if (lowest <= WARNING_LIMIT_LEFT_PERCENT) return "warning";
 		return "normal";
 	}
 	if (quota.type === "loading") return "unknown";
@@ -298,6 +364,19 @@ function formatReset(resetAtMs: number | undefined): string | undefined {
 		day: "2-digit",
 	});
 	return `${time} on ${day}`;
+}
+
+function formatResetTime(resetAtMs: number | undefined): string | undefined {
+	if (!resetAtMs || !Number.isFinite(resetAtMs) || resetAtMs <= 0) {
+		return undefined;
+	}
+	const date = new Date(resetAtMs);
+	if (!Number.isFinite(date.getTime())) return undefined;
+	return date.toLocaleTimeString(undefined, {
+		hour: "2-digit",
+		minute: "2-digit",
+		hour12: false,
+	});
 }
 
 function formatUpdatedAge(fetchedAt: number | undefined, now: number): string {

--- a/lib/tui-status.ts
+++ b/lib/tui-status.ts
@@ -117,6 +117,18 @@ function resolveProviderReasoningVariant(
 	);
 }
 
+function resolveAgentReasoningVariant(
+	agent: Record<string, unknown> | undefined,
+): ReasoningVariant | undefined {
+	if (!agent) return undefined;
+	const options = isRecord(agent.options) ? agent.options : undefined;
+	return (
+		normalizeReasoningVariant(getString(agent.variant)) ??
+		normalizeReasoningVariant(getString(agent.reasoningEffort)) ??
+		normalizeReasoningVariant(getString(options?.reasoningEffort))
+	);
+}
+
 export function resolvePromptReasoningVariant(params: {
 	messages?: readonly PromptStatusMessage[];
 	config?: PromptStatusConfig;
@@ -141,7 +153,7 @@ export function resolvePromptReasoningVariant(params: {
 	const config = params.config;
 	if (!config) return undefined;
 	const agent = resolveAgentConfig(config);
-	const agentVariant = normalizeReasoningVariant(getString(agent?.variant));
+	const agentVariant = resolveAgentReasoningVariant(agent);
 	if (agentVariant) return agentVariant;
 
 	const agentModel = getString(agent?.model);

--- a/lib/tui-status.ts
+++ b/lib/tui-status.ts
@@ -1,0 +1,223 @@
+import type { Config } from "@opencode-ai/sdk/v2";
+
+export type ReasoningVariant = "none" | "low" | "medium" | "high" | "xhigh";
+
+export type CompactQuotaStatus =
+	| { type: "loading" }
+	| { type: "missing" }
+	| { type: "unavailable" }
+	| {
+			type: "ready";
+			primaryLeftPercent: number | null;
+			secondaryLeftPercent: number | null;
+			stale: boolean;
+	  };
+
+export type PromptStatusMessage = {
+	role: "user" | "assistant";
+	modelID?: string;
+	variant?: string;
+	userModel?: {
+		modelID?: string;
+		variant?: string;
+	};
+};
+
+export type PromptStatusConfig = Pick<
+	Config,
+	"model" | "default_agent" | "agent" | "mode" | "provider"
+>;
+
+const variantSuffixes: ReasoningVariant[] = [
+	"xhigh",
+	"high",
+	"medium",
+	"low",
+	"none",
+];
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function getString(value: unknown): string | undefined {
+	return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+export function normalizeReasoningVariant(
+	value: string | undefined,
+): ReasoningVariant | undefined {
+	const normalized = value?.trim().toLowerCase();
+	if (!normalized) return undefined;
+	if (normalized === "extra-high" || normalized === "extra_high") {
+		return "xhigh";
+	}
+	return variantSuffixes.find((variant) => variant === normalized);
+}
+
+export function inferReasoningVariantFromModelId(
+	modelID: string | undefined,
+): ReasoningVariant | undefined {
+	const modelPart = modelID?.split("/").pop()?.toLowerCase();
+	if (!modelPart) return undefined;
+	for (const variant of variantSuffixes) {
+		if (modelPart.endsWith(`-${variant}`)) return variant;
+	}
+	return undefined;
+}
+
+function splitProviderModel(model: string | undefined): {
+	providerID: string;
+	modelID: string;
+} | undefined {
+	const trimmed = model?.trim();
+	if (!trimmed) return undefined;
+	const slashIndex = trimmed.indexOf("/");
+	if (slashIndex <= 0 || slashIndex === trimmed.length - 1) {
+		return { providerID: "openai", modelID: trimmed };
+	}
+	return {
+		providerID: trimmed.slice(0, slashIndex),
+		modelID: trimmed.slice(slashIndex + 1),
+	};
+}
+
+function resolveAgentConfig(
+	config: PromptStatusConfig,
+): Record<string, unknown> | undefined {
+	const agentName = config.default_agent ?? "build";
+	const agents = config.agent;
+	const selectedAgent = agents?.[agentName];
+	if (isRecord(selectedAgent)) return selectedAgent;
+	if (isRecord(agents?.build)) return agents.build;
+	if (isRecord(agents?.general)) return agents.general;
+	const legacyMode = config.mode;
+	if (isRecord(legacyMode?.build)) return legacyMode.build;
+	return undefined;
+}
+
+function resolveProviderReasoningVariant(
+	config: PromptStatusConfig,
+	model: string | undefined,
+): ReasoningVariant | undefined {
+	const resolved = splitProviderModel(model);
+	if (!resolved) return undefined;
+	const provider = config.provider?.[resolved.providerID];
+	const modelConfig = provider?.models?.[resolved.modelID];
+	const modelOptions = isRecord(modelConfig?.options)
+		? modelConfig.options
+		: undefined;
+	const providerOptions = isRecord(provider?.options)
+		? provider.options
+		: undefined;
+
+	return (
+		normalizeReasoningVariant(getString(modelOptions?.reasoningEffort)) ??
+		normalizeReasoningVariant(getString(providerOptions?.reasoningEffort))
+	);
+}
+
+export function resolvePromptReasoningVariant(params: {
+	messages?: readonly PromptStatusMessage[];
+	config?: PromptStatusConfig;
+}): ReasoningVariant | undefined {
+	const messages = params.messages ?? [];
+	for (let i = messages.length - 1; i >= 0; i -= 1) {
+		const message = messages[i];
+		if (!message) continue;
+		if (message.role === "user") {
+			const variant =
+				normalizeReasoningVariant(message.userModel?.variant) ??
+				inferReasoningVariantFromModelId(message.userModel?.modelID);
+			if (variant) return variant;
+			continue;
+		}
+		const variant =
+			normalizeReasoningVariant(message.variant) ??
+			inferReasoningVariantFromModelId(message.modelID);
+		if (variant) return variant;
+	}
+
+	const config = params.config;
+	if (!config) return undefined;
+	const agent = resolveAgentConfig(config);
+	const agentVariant = normalizeReasoningVariant(getString(agent?.variant));
+	if (agentVariant) return agentVariant;
+
+	const agentModel = getString(agent?.model);
+	const model = agentModel ?? config.model;
+	return (
+		inferReasoningVariantFromModelId(model) ??
+		resolveProviderReasoningVariant(config, model)
+	);
+}
+
+function isPercent(value: number | null): value is number {
+	return typeof value === "number" && Number.isFinite(value);
+}
+
+function formatQuotaNormal(quota: CompactQuotaStatus): string | undefined {
+	if (quota.type === "ready") {
+		if (
+			isPercent(quota.primaryLeftPercent) &&
+			isPercent(quota.secondaryLeftPercent)
+		) {
+			return `5h ${quota.primaryLeftPercent}% · weekly ${quota.secondaryLeftPercent}%`;
+		}
+		if (isPercent(quota.primaryLeftPercent)) {
+			return `5h ${quota.primaryLeftPercent}%`;
+		}
+		if (isPercent(quota.secondaryLeftPercent)) {
+			return `weekly ${quota.secondaryLeftPercent}%`;
+		}
+		return undefined;
+	}
+	if (quota.type === "missing") return "no auth";
+	if (quota.type === "unavailable") return "limits ?";
+	if (quota.type === "loading") return "limits ...";
+	return undefined;
+}
+
+function formatQuotaCompact(quota: CompactQuotaStatus): string | undefined {
+	if (quota.type !== "ready") return formatQuotaNormal(quota);
+	if (
+		isPercent(quota.primaryLeftPercent) &&
+		isPercent(quota.secondaryLeftPercent)
+	) {
+		return `5h ${quota.primaryLeftPercent} · wk ${quota.secondaryLeftPercent}`;
+	}
+	if (isPercent(quota.primaryLeftPercent)) {
+		return `5h ${quota.primaryLeftPercent}`;
+	}
+	if (isPercent(quota.secondaryLeftPercent)) {
+		return `wk ${quota.secondaryLeftPercent}`;
+	}
+	return undefined;
+}
+
+function maxStatusChars(width: number | undefined): number {
+	if (!width || !Number.isFinite(width)) return 32;
+	if (width >= 120) return 34;
+	if (width >= 96) return 30;
+	if (width >= 78) return 24;
+	if (width >= 60) return 18;
+	return 10;
+}
+
+export function formatPromptStatusText(params: {
+	variant?: ReasoningVariant;
+	quota: CompactQuotaStatus;
+	width?: number;
+}): string {
+	const variant = params.variant;
+	const normalQuota = formatQuotaNormal(params.quota);
+	const compactQuota = formatQuotaCompact(params.quota);
+	const candidates = [
+		[variant, normalQuota].filter(Boolean).join(" · "),
+		[variant, compactQuota].filter(Boolean).join(" · "),
+		variant,
+		compactQuota,
+	].filter((candidate): candidate is string => Boolean(candidate));
+	const maxChars = maxStatusChars(params.width);
+	return candidates.find((candidate) => candidate.length <= maxChars) ?? "";
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,12 @@
       "dependencies": {
         "@napi-rs/keyring": "~1.2.0",
         "@openauthjs/openauth": "^0.4.3",
-        "@opencode-ai/plugin": "^1.2.9",
+        "@opencode-ai/plugin": "^1.14.22",
+        "@opentui/core": "^0.1.99",
+        "@opentui/solid": "^0.1.99",
         "hono": "4.12.14",
+        "solid-js": "^1.9.11",
+        "web-tree-sitter": "^0.25.10",
         "zod": "^4.3.6"
       },
       "bin": {
@@ -41,11 +45,244 @@
         "typescript": "^5"
       }
     },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
+      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.0.tgz",
+      "integrity": "sha512-UlLAnTPrFdNGoFtbSXwcGFQBtQZJCNjaN6hQNP3UPvuNXT1i82N26KL3dZeIpNalWywr9IuQuncaAfUaS1g6sQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.2.0",
+        "@babel/code-frame": "^7.27.1",
+        "@babel/generator": "^7.28.0",
+        "@babel/helper-compilation-targets": "^7.27.2",
+        "@babel/helper-module-transforms": "^7.27.3",
+        "@babel/helpers": "^7.27.6",
+        "@babel/parser": "^7.28.0",
+        "@babel/template": "^7.27.2",
+        "@babel/traverse": "^7.28.0",
+        "@babel/types": "^7.28.0",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-annotate-as-pure": {
+      "version": "7.27.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.27.3.tgz",
+      "integrity": "sha512-fXSwMQqitTGeHLBC08Eq5yXz2m37E4pJX1qAU1+2cNedz/ifv/bVXft90VeSav5nFO61EcNgwr0aJxbyPaWBPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.27.3"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.28.6",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-create-class-features-plugin": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.28.6.tgz",
+      "integrity": "sha512-dTOdvsjnG3xNT9Y0AUg1wAl38y+4Rl4sf9caSQZOXdNqVn+H+HbbJ4IyyHaIqNR6SW9oJpA/RuRjsjCw2IdIow==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.27.3",
+        "@babel/helper-member-expression-to-functions": "^7.28.5",
+        "@babel/helper-optimise-call-expression": "^7.27.1",
+        "@babel/helper-replace-supers": "^7.28.6",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
+        "@babel/traverse": "^7.28.6",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-member-expression-to-functions": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.28.5.tgz",
+      "integrity": "sha512-cwM7SBRZcPCLgl8a7cY0soT1SptSzAlMH39vwiRpOQkJlh53r5hdHwLSCZpQdVLT39sZt+CRpNwYG4Y2v77atg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.28.5",
+        "@babel/types": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-optimise-call-expression": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.27.1.tgz",
+      "integrity": "sha512-URMGH08NzYFhubNSGJrpUEphGKQwMQYBySzat5cAByY1/YgIRkULnIy3tAMeszlL/so2HbeilYloUmSpd7GdVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-replace-supers": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.28.6.tgz",
+      "integrity": "sha512-mq8e+laIk94/yFec3DxSjCRD2Z0TAjhVbEJY3UQrlwVo15Lmt7C2wAUbK4bjnTs4APkwsYLTahXRraQXhb1WCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-member-expression-to-functions": "^7.28.5",
+        "@babel/helper-optimise-call-expression": "^7.27.1",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-skip-transparent-expression-wrappers": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.27.1.tgz",
+      "integrity": "sha512-Tub4ZKEXqbPjXgWLl2+3JpQAYBJ8+ikpQ2Ocj/q/r0LwE3UhENh7EUabyHjz2kCEsrRY83ew2DQdHluuiDQFzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.27.1",
+        "@babel/types": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
       "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -55,20 +292,40 @@
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
       "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/parser": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.6.tgz",
-      "integrity": "sha512-TeR9zWR18BvbfPmGbLampPMW+uW1NZnJlRuuHso8i87QZNq2JRF9i6RgxRqtEq+wQGsS19NNTWr2duhnE49mfQ==",
-      "dev": true,
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.28.6"
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -77,11 +334,126 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/@babel/types": {
+    "node_modules/@babel/plugin-syntax-jsx": {
       "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.6.tgz",
-      "integrity": "sha512-0ZrskXVEHSWIqZM/sQZ4EV3jZJXRkio/WCxaqKZP1g//CEWEPSfeZFcms4XeKBCHU0ZKnIkdJeU/kF+eRp5lBg==",
-      "dev": true,
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.28.6.tgz",
+      "integrity": "sha512-wgEmr06G6sIpqr8YDwA2dSRTE3bJ+V0IfpzfSY3Lfgd7YWOaAdlykvJi13ZKBt8cZHfgH1IXN+CL656W3uUa4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-typescript": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.28.6.tgz",
+      "integrity": "sha512-+nDNmQye7nlnuuHDboPbGm00Vqg3oO8niRRL27/4LYHUsHYh0zJ1xWOz0uRwNFmM1Avzk8wZbc6rdiYhomzv/A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-modules-commonjs": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.28.6.tgz",
+      "integrity": "sha512-jppVbf8IV9iWWwWTQIxJMAJCWBuuKx71475wHwYytrRGQ2CWiDvYlADQno3tcYpS/T2UUWFQp3nVtYfK/YBQrA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-typescript": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.28.6.tgz",
+      "integrity": "sha512-0YWL2RFxOqEm9Efk5PvreamxPME8OyY0wM5wh5lHjF+VtVhdneCWGzZeSqzOfiobVqQaNCd2z0tQvnI9DaPWPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.27.3",
+        "@babel/helper-create-class-features-plugin": "^7.28.6",
+        "@babel/helper-plugin-utils": "^7.28.6",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
+        "@babel/plugin-syntax-typescript": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/preset-typescript": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.27.1.tgz",
+      "integrity": "sha512-l7WfQfX0WK4M0v2RudjuQK4u99BS6yLHYEmdtVPP7lKV013zr9DygFuWNlnbvQ9LR+LS0Egz/XAvGx5U9MX0fQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/plugin-syntax-jsx": "^7.27.1",
+        "@babel/plugin-transform-modules-commonjs": "^7.27.1",
+        "@babel/plugin-transform-typescript": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
@@ -101,10 +473,17 @@
         "node": ">=18"
       }
     },
+    "node_modules/@dimforge/rapier2d-simd-compat": {
+      "version": "0.17.3",
+      "resolved": "https://registry.npmjs.org/@dimforge/rapier2d-simd-compat/-/rapier2d-simd-compat-0.17.3.tgz",
+      "integrity": "sha512-bijvwWz6NHsNj5e5i1vtd3dU2pDhthSaTUZSh14DUGGKJfw8eMnlWZsxwHBxB/a3AXVNDjL9abuHw1k9FGR+jg==",
+      "license": "Apache-2.0",
+      "optional": true
+    },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.2.tgz",
-      "integrity": "sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
       "cpu": [
         "ppc64"
       ],
@@ -119,9 +498,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.2.tgz",
-      "integrity": "sha512-DVNI8jlPa7Ujbr1yjU2PfUSRtAUZPG9I1RwW4F4xFB1Imiu2on0ADiI/c3td+KmDtVKNbi+nffGDQMfcIMkwIA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
       "cpu": [
         "arm"
       ],
@@ -136,9 +515,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.2.tgz",
-      "integrity": "sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
       "cpu": [
         "arm64"
       ],
@@ -153,9 +532,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.2.tgz",
-      "integrity": "sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
       "cpu": [
         "x64"
       ],
@@ -170,9 +549,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.2.tgz",
-      "integrity": "sha512-davCD2Zc80nzDVRwXTcQP/28fiJbcOwvdolL0sOiOsbwBa72kegmVU0Wrh1MYrbuCL98Omp5dVhQFWRKR2ZAlg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
       "cpu": [
         "arm64"
       ],
@@ -187,9 +566,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.2.tgz",
-      "integrity": "sha512-ZxtijOmlQCBWGwbVmwOF/UCzuGIbUkqB1faQRf5akQmxRJ1ujusWsb3CVfk/9iZKr2L5SMU5wPBi1UWbvL+VQA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
       "cpu": [
         "x64"
       ],
@@ -204,9 +583,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.2.tgz",
-      "integrity": "sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
       "cpu": [
         "arm64"
       ],
@@ -221,9 +600,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.2.tgz",
-      "integrity": "sha512-tAfqtNYb4YgPnJlEFu4c212HYjQWSO/w/h/lQaBK7RbwGIkBOuNKQI9tqWzx7Wtp7bTPaGC6MJvWI608P3wXYA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
       "cpu": [
         "x64"
       ],
@@ -238,9 +617,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.2.tgz",
-      "integrity": "sha512-vWfq4GaIMP9AIe4yj1ZUW18RDhx6EPQKjwe7n8BbIecFtCQG4CfHGaHuh7fdfq+y3LIA2vGS/o9ZBGVxIDi9hw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
       "cpu": [
         "arm"
       ],
@@ -255,9 +634,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.2.tgz",
-      "integrity": "sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
       "cpu": [
         "arm64"
       ],
@@ -272,9 +651,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.2.tgz",
-      "integrity": "sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
       "cpu": [
         "ia32"
       ],
@@ -289,9 +668,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.2.tgz",
-      "integrity": "sha512-lugyF1atnAT463aO6KPshVCJK5NgRnU4yb3FUumyVz+cGvZbontBgzeGFO1nF+dPueHD367a2ZXe1NtUkAjOtg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
       "cpu": [
         "loong64"
       ],
@@ -306,9 +685,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.2.tgz",
-      "integrity": "sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
       "cpu": [
         "mips64el"
       ],
@@ -323,9 +702,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.2.tgz",
-      "integrity": "sha512-C92gnpey7tUQONqg1n6dKVbx3vphKtTHJaNG2Ok9lGwbZil6DrfyecMsp9CrmXGQJmZ7iiVXvvZH6Ml5hL6XdQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
       "cpu": [
         "ppc64"
       ],
@@ -340,9 +719,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.2.tgz",
-      "integrity": "sha512-B5BOmojNtUyN8AXlK0QJyvjEZkWwy/FKvakkTDCziX95AowLZKR6aCDhG7LeF7uMCXEJqwa8Bejz5LTPYm8AvA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
       "cpu": [
         "riscv64"
       ],
@@ -357,9 +736,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.2.tgz",
-      "integrity": "sha512-p4bm9+wsPwup5Z8f4EpfN63qNagQ47Ua2znaqGH6bqLlmJ4bx97Y9JdqxgGZ6Y8xVTixUnEkoKSHcpRlDnNr5w==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
       "cpu": [
         "s390x"
       ],
@@ -374,9 +753,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.2.tgz",
-      "integrity": "sha512-uwp2Tip5aPmH+NRUwTcfLb+W32WXjpFejTIOWZFw/v7/KnpCDKG66u4DLcurQpiYTiYwQ9B7KOeMJvLCu/OvbA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
       "cpu": [
         "x64"
       ],
@@ -391,9 +770,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.2.tgz",
-      "integrity": "sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
       "cpu": [
         "arm64"
       ],
@@ -408,9 +787,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.2.tgz",
-      "integrity": "sha512-HwGDZ0VLVBY3Y+Nw0JexZy9o/nUAWq9MlV7cahpaXKW6TOzfVno3y3/M8Ga8u8Yr7GldLOov27xiCnqRZf0tCA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
       "cpu": [
         "x64"
       ],
@@ -425,9 +804,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.2.tgz",
-      "integrity": "sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
       "cpu": [
         "arm64"
       ],
@@ -442,9 +821,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.2.tgz",
-      "integrity": "sha512-/it7w9Nb7+0KFIzjalNJVR5bOzA9Vay+yIPLVHfIQYG/j+j9VTH84aNB8ExGKPU4AzfaEvN9/V4HV+F+vo8OEg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
       "cpu": [
         "x64"
       ],
@@ -459,9 +838,9 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.2.tgz",
-      "integrity": "sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
       "cpu": [
         "arm64"
       ],
@@ -476,9 +855,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.2.tgz",
-      "integrity": "sha512-kMtx1yqJHTmqaqHPAzKCAkDaKsffmXkPHThSfRwZGyuqyIeBvf08KSsYXl+abf5HDAPMJIPnbBfXvP2ZC2TfHg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
       "cpu": [
         "x64"
       ],
@@ -493,9 +872,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.2.tgz",
-      "integrity": "sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
       "cpu": [
         "arm64"
       ],
@@ -510,9 +889,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.2.tgz",
-      "integrity": "sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
       "cpu": [
         "ia32"
       ],
@@ -527,9 +906,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.2.tgz",
-      "integrity": "sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
       "cpu": [
         "x64"
       ],
@@ -541,6 +920,5525 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.23.5",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
+      "integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^3.0.5",
+        "debug": "^4.3.1",
+        "minimatch": "^10.2.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.5.tgz",
+      "integrity": "sha512-eIJYKTCECbP/nsKaaruF6LW967mtbQbsw4JTtSVkUQc9MneSkbrgPJAbKl9nWr0ZeowV8BfsarBmPpBzGelA2w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.2.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
+      "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
+      "integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.1.tgz",
+      "integrity": "sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.2.1",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@fast-check/vitest": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@fast-check/vitest/-/vitest-0.2.4.tgz",
+      "integrity": "sha512-Ilcr+JAIPhb1s6FRm4qoglQYSGXXrS+zAupZeNuWAA3qHVGDA1d1Gb84Hb/+otL3GzVZjFJESg5/1SfIvrgssA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "fast-check": "^3.0.0 || ^4.0.0"
+      },
+      "peerDependencies": {
+        "vitest": "^1 || ^2 || ^3 || ^4"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@jimp/core": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/core/-/core-1.6.0.tgz",
+      "integrity": "sha512-EQQlKU3s9QfdJqiSrZWNTxBs3rKXgO2W+GxNXDtwchF3a4IqxDheFX1ti+Env9hdJXDiYLp2jTRjlxhPthsk8w==",
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/file-ops": "1.6.0",
+        "@jimp/types": "1.6.0",
+        "@jimp/utils": "1.6.0",
+        "await-to-js": "^3.0.0",
+        "exif-parser": "^0.1.12",
+        "file-type": "^16.0.0",
+        "mime": "3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/diff": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/diff/-/diff-1.6.0.tgz",
+      "integrity": "sha512-+yUAQ5gvRC5D1WHYxjBHZI7JBRusGGSLf8AmPRPCenTzh4PA+wZ1xv2+cYqQwTfQHU5tXYOhA0xDytfHUf1Zyw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/plugin-resize": "1.6.0",
+        "@jimp/types": "1.6.0",
+        "@jimp/utils": "1.6.0",
+        "pixelmatch": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/file-ops": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/file-ops/-/file-ops-1.6.0.tgz",
+      "integrity": "sha512-Dx/bVDmgnRe1AlniRpCKrGRm5YvGmUwbDzt+MAkgmLGf+jvBT75hmMEZ003n9HQI/aPnm/YKnXjg/hOpzNCpHQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/js-bmp": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/js-bmp/-/js-bmp-1.6.0.tgz",
+      "integrity": "sha512-FU6Q5PC/e3yzLyBDXupR3SnL3htU7S3KEs4e6rjDP6gNEOXRFsWs6YD3hXuXd50jd8ummy+q2WSwuGkr8wi+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/core": "1.6.0",
+        "@jimp/types": "1.6.0",
+        "@jimp/utils": "1.6.0",
+        "bmp-ts": "^1.0.9"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/js-gif": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/js-gif/-/js-gif-1.6.0.tgz",
+      "integrity": "sha512-N9CZPHOrJTsAUoWkWZstLPpwT5AwJ0wge+47+ix3++SdSL/H2QzyMqxbcDYNFe4MoI5MIhATfb0/dl/wmX221g==",
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/core": "1.6.0",
+        "@jimp/types": "1.6.0",
+        "gifwrap": "^0.10.1",
+        "omggif": "^1.0.10"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/js-jpeg": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/js-jpeg/-/js-jpeg-1.6.0.tgz",
+      "integrity": "sha512-6vgFDqeusblf5Pok6B2DUiMXplH8RhIKAryj1yn+007SIAQ0khM1Uptxmpku/0MfbClx2r7pnJv9gWpAEJdMVA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/core": "1.6.0",
+        "@jimp/types": "1.6.0",
+        "jpeg-js": "^0.4.4"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/js-png": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/js-png/-/js-png-1.6.0.tgz",
+      "integrity": "sha512-AbQHScy3hDDgMRNfG0tPjL88AV6qKAILGReIa3ATpW5QFjBKpisvUaOqhzJ7Reic1oawx3Riyv152gaPfqsBVg==",
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/core": "1.6.0",
+        "@jimp/types": "1.6.0",
+        "pngjs": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/js-tiff": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/js-tiff/-/js-tiff-1.6.0.tgz",
+      "integrity": "sha512-zhReR8/7KO+adijj3h0ZQUOiun3mXUv79zYEAKvE0O+rP7EhgtKvWJOZfRzdZSNv0Pu1rKtgM72qgtwe2tFvyw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/core": "1.6.0",
+        "@jimp/types": "1.6.0",
+        "utif2": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-blit": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-blit/-/plugin-blit-1.6.0.tgz",
+      "integrity": "sha512-M+uRWl1csi7qilnSK8uxK4RJMSuVeBiO1AY0+7APnfUbQNZm6hCe0CCFv1Iyw1D/Dhb8ph8fQgm5mwM0eSxgVA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/types": "1.6.0",
+        "@jimp/utils": "1.6.0",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-blit/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@jimp/plugin-blur": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-blur/-/plugin-blur-1.6.0.tgz",
+      "integrity": "sha512-zrM7iic1OTwUCb0g/rN5y+UnmdEsT3IfuCXCJJNs8SZzP0MkZ1eTvuwK9ZidCuMo4+J3xkzCidRwYXB5CyGZTw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/core": "1.6.0",
+        "@jimp/utils": "1.6.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-circle": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-circle/-/plugin-circle-1.6.0.tgz",
+      "integrity": "sha512-xt1Gp+LtdMKAXfDp3HNaG30SPZW6AQ7dtAtTnoRKorRi+5yCJjKqXRgkewS5bvj8DEh87Ko1ydJfzqS3P2tdWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/types": "1.6.0",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-circle/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@jimp/plugin-color": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-color/-/plugin-color-1.6.0.tgz",
+      "integrity": "sha512-J5q8IVCpkBsxIXM+45XOXTrsyfblyMZg3a9eAo0P7VPH4+CrvyNQwaYatbAIamSIN1YzxmO3DkIZXzRjFSz1SA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/core": "1.6.0",
+        "@jimp/types": "1.6.0",
+        "@jimp/utils": "1.6.0",
+        "tinycolor2": "^1.6.0",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-color/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@jimp/plugin-contain": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-contain/-/plugin-contain-1.6.0.tgz",
+      "integrity": "sha512-oN/n+Vdq/Qg9bB4yOBOxtY9IPAtEfES8J1n9Ddx+XhGBYT1/QTU/JYkGaAkIGoPnyYvmLEDqMz2SGihqlpqfzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/core": "1.6.0",
+        "@jimp/plugin-blit": "1.6.0",
+        "@jimp/plugin-resize": "1.6.0",
+        "@jimp/types": "1.6.0",
+        "@jimp/utils": "1.6.0",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-contain/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@jimp/plugin-cover": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-cover/-/plugin-cover-1.6.0.tgz",
+      "integrity": "sha512-Iow0h6yqSC269YUJ8HC3Q/MpCi2V55sMlbkkTTx4zPvd8mWZlC0ykrNDeAy9IJegrQ7v5E99rJwmQu25lygKLA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/core": "1.6.0",
+        "@jimp/plugin-crop": "1.6.0",
+        "@jimp/plugin-resize": "1.6.0",
+        "@jimp/types": "1.6.0",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-cover/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@jimp/plugin-crop": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-crop/-/plugin-crop-1.6.0.tgz",
+      "integrity": "sha512-KqZkEhvs+21USdySCUDI+GFa393eDIzbi1smBqkUPTE+pRwSWMAf01D5OC3ZWB+xZsNla93BDS9iCkLHA8wang==",
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/core": "1.6.0",
+        "@jimp/types": "1.6.0",
+        "@jimp/utils": "1.6.0",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-crop/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@jimp/plugin-displace": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-displace/-/plugin-displace-1.6.0.tgz",
+      "integrity": "sha512-4Y10X9qwr5F+Bo5ME356XSACEF55485j5nGdiyJ9hYzjQP9nGgxNJaZ4SAOqpd+k5sFaIeD7SQ0Occ26uIng5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/types": "1.6.0",
+        "@jimp/utils": "1.6.0",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-displace/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@jimp/plugin-dither": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-dither/-/plugin-dither-1.6.0.tgz",
+      "integrity": "sha512-600d1RxY0pKwgyU0tgMahLNKsqEcxGdbgXadCiVCoGd6V6glyCvkNrnnwC0n5aJ56Htkj88PToSdF88tNVZEEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/types": "1.6.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-fisheye": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-fisheye/-/plugin-fisheye-1.6.0.tgz",
+      "integrity": "sha512-E5QHKWSCBFtpgZarlmN3Q6+rTQxjirFqo44ohoTjzYVrDI6B6beXNnPIThJgPr0Y9GwfzgyarKvQuQuqCnnfbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/types": "1.6.0",
+        "@jimp/utils": "1.6.0",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-fisheye/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@jimp/plugin-flip": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-flip/-/plugin-flip-1.6.0.tgz",
+      "integrity": "sha512-/+rJVDuBIVOgwoyVkBjUFHtP+wmW0r+r5OQ2GpatQofToPVbJw1DdYWXlwviSx7hvixTWLKVgRWQ5Dw862emDg==",
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/types": "1.6.0",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-flip/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@jimp/plugin-hash": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-hash/-/plugin-hash-1.6.0.tgz",
+      "integrity": "sha512-wWzl0kTpDJgYVbZdajTf+4NBSKvmI3bRI8q6EH9CVeIHps9VWVsUvEyb7rpbcwVLWYuzDtP2R0lTT6WeBNQH9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/core": "1.6.0",
+        "@jimp/js-bmp": "1.6.0",
+        "@jimp/js-jpeg": "1.6.0",
+        "@jimp/js-png": "1.6.0",
+        "@jimp/js-tiff": "1.6.0",
+        "@jimp/plugin-color": "1.6.0",
+        "@jimp/plugin-resize": "1.6.0",
+        "@jimp/types": "1.6.0",
+        "@jimp/utils": "1.6.0",
+        "any-base": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-mask": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-mask/-/plugin-mask-1.6.0.tgz",
+      "integrity": "sha512-Cwy7ExSJMZszvkad8NV8o/Z92X2kFUFM8mcDAhNVxU0Q6tA0op2UKRJY51eoK8r6eds/qak3FQkXakvNabdLnA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/types": "1.6.0",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-mask/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@jimp/plugin-print": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-print/-/plugin-print-1.6.0.tgz",
+      "integrity": "sha512-zarTIJi8fjoGMSI/M3Xh5yY9T65p03XJmPsuNet19K/Q7mwRU6EV2pfj+28++2PV2NJ+htDF5uecAlnGyxFN2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/core": "1.6.0",
+        "@jimp/js-jpeg": "1.6.0",
+        "@jimp/js-png": "1.6.0",
+        "@jimp/plugin-blit": "1.6.0",
+        "@jimp/types": "1.6.0",
+        "parse-bmfont-ascii": "^1.0.6",
+        "parse-bmfont-binary": "^1.0.6",
+        "parse-bmfont-xml": "^1.1.6",
+        "simple-xml-to-json": "^1.2.2",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-print/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@jimp/plugin-quantize": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-quantize/-/plugin-quantize-1.6.0.tgz",
+      "integrity": "sha512-EmzZ/s9StYQwbpG6rUGBCisc3f64JIhSH+ncTJd+iFGtGo0YvSeMdAd+zqgiHpfZoOL54dNavZNjF4otK+mvlg==",
+      "license": "MIT",
+      "dependencies": {
+        "image-q": "^4.0.0",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-quantize/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@jimp/plugin-resize": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-resize/-/plugin-resize-1.6.0.tgz",
+      "integrity": "sha512-uSUD1mqXN9i1SGSz5ov3keRZ7S9L32/mAQG08wUwZiEi5FpbV0K8A8l1zkazAIZi9IJzLlTauRNU41Mi8IF9fA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/core": "1.6.0",
+        "@jimp/types": "1.6.0",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-resize/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@jimp/plugin-rotate": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-rotate/-/plugin-rotate-1.6.0.tgz",
+      "integrity": "sha512-JagdjBLnUZGSG4xjCLkIpQOZZ3Mjbg8aGCCi4G69qR+OjNpOeGI7N2EQlfK/WE8BEHOW5vdjSyglNqcYbQBWRw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/core": "1.6.0",
+        "@jimp/plugin-crop": "1.6.0",
+        "@jimp/plugin-resize": "1.6.0",
+        "@jimp/types": "1.6.0",
+        "@jimp/utils": "1.6.0",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-rotate/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@jimp/plugin-threshold": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-threshold/-/plugin-threshold-1.6.0.tgz",
+      "integrity": "sha512-M59m5dzLoHOVWdM41O8z9SyySzcDn43xHseOH0HavjsfQsT56GGCC4QzU1banJidbUrePhzoEdS42uFE8Fei8w==",
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/core": "1.6.0",
+        "@jimp/plugin-color": "1.6.0",
+        "@jimp/plugin-hash": "1.6.0",
+        "@jimp/types": "1.6.0",
+        "@jimp/utils": "1.6.0",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-threshold/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@jimp/types": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/types/-/types-1.6.0.tgz",
+      "integrity": "sha512-7UfRsiKo5GZTAATxm2qQ7jqmUXP0DxTArztllTcYdyw6Xi5oT4RaoXynVtCD4UyLK5gJgkZJcwonoijrhYFKfg==",
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/types/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@jimp/utils": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jimp/utils/-/utils-1.6.0.tgz",
+      "integrity": "sha512-gqFTGEosKbOkYF/WFj26jMHOI5OH2jeP1MmC/zbK6BF6VJBf8rIC5898dPfSzZEbSA0wbbV5slbntWVc5PKLFA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/types": "1.6.0",
+        "tinycolor2": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.3.tgz",
+      "integrity": "sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-x64": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.3.tgz",
+      "integrity": "sha512-mdzd3AVzYKuUmiWOQ8GNhl64/IoFGol569zNRdkLReh6LRLHOXxU4U8eq0JwaD8iFHdVGqSy4IjFL4reoWCDFw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.3.tgz",
+      "integrity": "sha512-fg0uy/dG/nZEXfYilKoRe7yALaNmHoYeIoJuJ7KJ+YyU2bvY8vPv27f7UKhGRpY6euFYqEVhxCFZgAUNQBM3nw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm64": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.3.tgz",
+      "integrity": "sha512-YxQL+ax0XqBJDZiKimS2XQaf+2wDGVa1enVRGzEvLLVFeqa5kx2bWbtcSXgsxjQB7nRqqIGFIcLteF/sHeVtQg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-x64": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.3.tgz",
+      "integrity": "sha512-cvwNfbP07pKUfq1uH+S6KJ7dT9K8WOE4ZiAcsrSes+UY55E/0jLYc+vq+DO7jlmqRb5zAggExKm0H7O/CBaesg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-win32-x64": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.3.tgz",
+      "integrity": "sha512-x0fWaQtYp4E6sktbsdAqnehxDgEc/VwM7uLsRCYWaiGu0ykYdZPiS8zCWdnjHwyiumousxfBm4SO31eXqwEZhQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@napi-rs/keyring": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring/-/keyring-1.2.0.tgz",
+      "integrity": "sha512-d0d4Oyxm+v980PEq1ZH2PmS6cvpMIRc17eYpiU47KgW+lzxklMu6+HOEOPmxrpnF/XQZ0+Q78I2mgMhbIIo/dg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "optionalDependencies": {
+        "@napi-rs/keyring-darwin-arm64": "1.2.0",
+        "@napi-rs/keyring-darwin-x64": "1.2.0",
+        "@napi-rs/keyring-freebsd-x64": "1.2.0",
+        "@napi-rs/keyring-linux-arm-gnueabihf": "1.2.0",
+        "@napi-rs/keyring-linux-arm64-gnu": "1.2.0",
+        "@napi-rs/keyring-linux-arm64-musl": "1.2.0",
+        "@napi-rs/keyring-linux-riscv64-gnu": "1.2.0",
+        "@napi-rs/keyring-linux-x64-gnu": "1.2.0",
+        "@napi-rs/keyring-linux-x64-musl": "1.2.0",
+        "@napi-rs/keyring-win32-arm64-msvc": "1.2.0",
+        "@napi-rs/keyring-win32-ia32-msvc": "1.2.0",
+        "@napi-rs/keyring-win32-x64-msvc": "1.2.0"
+      }
+    },
+    "node_modules/@napi-rs/keyring-darwin-arm64": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-darwin-arm64/-/keyring-darwin-arm64-1.2.0.tgz",
+      "integrity": "sha512-CA83rDeyONDADO25JLZsh3eHY8yTEtm/RS6ecPsY+1v+dSawzT9GywBMu2r6uOp1IEhQs/xAfxgybGAFr17lSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-darwin-x64": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-darwin-x64/-/keyring-darwin-x64-1.2.0.tgz",
+      "integrity": "sha512-dBHjtKRCj4ByfnfqIKIJLo3wueQNJhLRyuxtX/rR4K/XtcS7VLlRD01XXizjpre54vpmObj63w+ZpHG+mGM8uA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-freebsd-x64": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-freebsd-x64/-/keyring-freebsd-x64-1.2.0.tgz",
+      "integrity": "sha512-DPZFr11pNJSnaoh0dzSUNF+T6ORhy3CkzUT3uGixbA71cAOPJ24iG8e8QrLOkuC/StWrAku3gBnth2XMWOcR3Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-arm-gnueabihf": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-arm-gnueabihf/-/keyring-linux-arm-gnueabihf-1.2.0.tgz",
+      "integrity": "sha512-8xv6DyEMlvRdqJzp4F39RLUmmTQsLcGYYv/3eIfZNZN1O5257tHxTrFYqAsny659rJJK2EKeSa7PhrSibQqRWQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-arm64-gnu": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-arm64-gnu/-/keyring-linux-arm64-gnu-1.2.0.tgz",
+      "integrity": "sha512-Pu2V6Py+PBt7inryEecirl+t+ti8bhZphjP+W68iVaXHUxLdWmkgL9KI1VkbRHbx5k8K5Tew9OP218YfmVguIA==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-arm64-musl": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-arm64-musl/-/keyring-linux-arm64-musl-1.2.0.tgz",
+      "integrity": "sha512-8TDymrpC4P1a9iDEaegT7RnrkmrJN5eNZh3Im3UEV5PPYGtrb82CRxsuFohthCWQW81O483u1bu+25+XA4nKUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-riscv64-gnu": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-riscv64-gnu/-/keyring-linux-riscv64-gnu-1.2.0.tgz",
+      "integrity": "sha512-awsB5XI1MYL7fwfjMDGmKOWvNgJEO7mM7iVEMS0fO39f0kVJnOSjlu7RHcXAF0LOx+0VfF3oxbWqJmZbvRCRHw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-x64-gnu": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-x64-gnu/-/keyring-linux-x64-gnu-1.2.0.tgz",
+      "integrity": "sha512-8E+7z4tbxSJXxIBqA+vfB1CGajpCDRyTyqXkBig5NtASrv4YXcntSo96Iah2QDR5zD3dSTsmbqJudcj9rKKuHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-x64-musl": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-x64-musl/-/keyring-linux-x64-musl-1.2.0.tgz",
+      "integrity": "sha512-8RZ8yVEnmWr/3BxKgBSzmgntI7lNEsY7xouNfOsQkuVAiCNmxzJwETspzK3PQ2FHtDxgz5vHQDEBVGMyM4hUHA==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-win32-arm64-msvc": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-win32-arm64-msvc/-/keyring-win32-arm64-msvc-1.2.0.tgz",
+      "integrity": "sha512-AoqaDZpQ6KPE19VBLpxyORcp+yWmHI9Xs9Oo0PJ4mfHma4nFSLVdhAubJCxdlNptHe5va7ghGCHj3L9Akiv4cQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-win32-ia32-msvc": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-win32-ia32-msvc/-/keyring-win32-ia32-msvc-1.2.0.tgz",
+      "integrity": "sha512-EYL+EEI6bCsYi3LfwcQdnX3P/R76ENKNn+3PmpGheBsUFLuh0gQuP7aMVHM4rTw6UVe+L3vCLZSptq/oeacz0A==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-win32-x64-msvc": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-win32-x64-msvc/-/keyring-win32-x64-msvc-1.2.0.tgz",
+      "integrity": "sha512-xFlx/TsmqmCwNU9v+AVnEJgoEAlBYgzFF5Ihz1rMpPAt4qQWWkMd4sCyM1gMJ1A/GnRqRegDiQpwaxGUHFtFbA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@openauthjs/openauth": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@openauthjs/openauth/-/openauth-0.4.3.tgz",
+      "integrity": "sha512-RlnjqvHzqcbFVymEwhlUEuac4utA5h4nhSK/i2szZuQmxTIqbGUxZ+nM+avM+VV4Ing+/ZaNLKILoXS3yrkOOw==",
+      "dependencies": {
+        "@standard-schema/spec": "1.0.0-beta.3",
+        "aws4fetch": "1.0.20",
+        "jose": "5.9.6"
+      },
+      "peerDependencies": {
+        "arctic": "^2.2.2",
+        "hono": "^4.0.0"
+      }
+    },
+    "node_modules/@opencode-ai/plugin": {
+      "version": "1.14.23",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.14.23.tgz",
+      "integrity": "sha512-ctRBb3q4EartUf6B9uuXJvoCBlznCmCXETJEElHQQ9JUJOnK3TnQs0B9iHLcowT75/5EBijL9VxlY1inZaz4qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@opencode-ai/sdk": "1.14.23",
+        "effect": "4.0.0-beta.48",
+        "zod": "4.1.8"
+      },
+      "peerDependencies": {
+        "@opentui/core": ">=0.1.99",
+        "@opentui/solid": ">=0.1.99"
+      },
+      "peerDependenciesMeta": {
+        "@opentui/core": {
+          "optional": true
+        },
+        "@opentui/solid": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@opencode-ai/plugin/node_modules/zod": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.8.tgz",
+      "integrity": "sha512-5R1P+WwQqmmMIEACyzSvo4JXHY5WiAFHRMg+zBZKgKS+Q1viRa0C1hmUKtHltoIFKtIdki3pRxkmpP74jnNYHQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@opencode-ai/sdk": {
+      "version": "1.14.23",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.14.23.tgz",
+      "integrity": "sha512-KGyprRx9xkvz3I4bBi7W0cKrdzVQA60PaCLd89749yRZNijGKMeLswns462rJErY/oi8oEMGLFpcy/3KElm65g==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "7.0.6"
+      }
+    },
+    "node_modules/@opentui/core": {
+      "version": "0.1.99",
+      "resolved": "https://registry.npmjs.org/@opentui/core/-/core-0.1.99.tgz",
+      "integrity": "sha512-I3+AEgGzqNWIpWX9g2WOscSPwtQDNOm4KlBjxBWCZjLxkF07u77heWXF7OiAdhKLtNUW6TFiyt6yznqAZPdG3A==",
+      "license": "MIT",
+      "dependencies": {
+        "bun-ffi-structs": "0.1.2",
+        "diff": "8.0.2",
+        "jimp": "1.6.0",
+        "marked": "17.0.1",
+        "yoga-layout": "3.2.1"
+      },
+      "optionalDependencies": {
+        "@dimforge/rapier2d-simd-compat": "^0.17.3",
+        "@opentui/core-darwin-arm64": "0.1.99",
+        "@opentui/core-darwin-x64": "0.1.99",
+        "@opentui/core-linux-arm64": "0.1.99",
+        "@opentui/core-linux-x64": "0.1.99",
+        "@opentui/core-win32-arm64": "0.1.99",
+        "@opentui/core-win32-x64": "0.1.99",
+        "bun-webgpu": "0.1.5",
+        "planck": "^1.4.2",
+        "three": "0.177.0"
+      },
+      "peerDependencies": {
+        "web-tree-sitter": "0.25.10"
+      }
+    },
+    "node_modules/@opentui/core-darwin-arm64": {
+      "version": "0.1.99",
+      "resolved": "https://registry.npmjs.org/@opentui/core-darwin-arm64/-/core-darwin-arm64-0.1.99.tgz",
+      "integrity": "sha512-bzVrqeX2vb5iWrc/ftOUOqeUY8XO+qSgoTwj5TXHuwagavgwD3Hpeyjx8+icnTTeM4pao0som1WR9xfye6/X5Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@opentui/core-darwin-x64": {
+      "version": "0.1.99",
+      "resolved": "https://registry.npmjs.org/@opentui/core-darwin-x64/-/core-darwin-x64-0.1.99.tgz",
+      "integrity": "sha512-VE4FrXBYpkxnvkqcCV1a8aN9jyyMJMihVW+V2NLCtp+4yQsj0AapG5TiUSN76XnmSZRptxDy5rBmEempeoIZbg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@opentui/core-linux-arm64": {
+      "version": "0.1.99",
+      "resolved": "https://registry.npmjs.org/@opentui/core-linux-arm64/-/core-linux-arm64-0.1.99.tgz",
+      "integrity": "sha512-viXQsbpS7yHjYkl7+am32JdvG96QU9lvHh1UiZtpOxcNUUqiYmA2ZwZFPD2Bi54jNyj5l2hjH6YkD3DzE2FEWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@opentui/core-linux-x64": {
+      "version": "0.1.99",
+      "resolved": "https://registry.npmjs.org/@opentui/core-linux-x64/-/core-linux-x64-0.1.99.tgz",
+      "integrity": "sha512-WLoEFINOSp0tZSR9y4LUuGc7n4Y7H1wcpjUPzQ9vChkYDXrfZltEanzoDWbDcQ4kZQW5tHVC7LrZHpAsRLwFZg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@opentui/core-win32-arm64": {
+      "version": "0.1.99",
+      "resolved": "https://registry.npmjs.org/@opentui/core-win32-arm64/-/core-win32-arm64-0.1.99.tgz",
+      "integrity": "sha512-yWMOLWCEO8HdrctU1dMkgZC8qGkiO4Dwr4/e11tTvVpRmYhDsP/IR89ZjEEtOwnKwFOFuB/MxvflqaEWVQ2g5Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@opentui/core-win32-x64": {
+      "version": "0.1.99",
+      "resolved": "https://registry.npmjs.org/@opentui/core-win32-x64/-/core-win32-x64-0.1.99.tgz",
+      "integrity": "sha512-aYRlsL2w8YRL6vPd7/hrqlNVkXU3QowWb01TOvAcHS8UAsXaGFUr47kSDyjxDi1wg1MzmVduCfsC7T3NoThV1w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@opentui/solid": {
+      "version": "0.1.99",
+      "resolved": "https://registry.npmjs.org/@opentui/solid/-/solid-0.1.99.tgz",
+      "integrity": "sha512-DrqqO4h2V88FmeIP2cErYkMU0ZK5MrUsZw3w6IzZpoXyyiL4/9qpWzUq+CXx+r16VP2iGxDJwGKUmtFAzUch2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "7.28.0",
+        "@babel/preset-typescript": "7.27.1",
+        "@opentui/core": "0.1.99",
+        "babel-plugin-module-resolver": "5.0.2",
+        "babel-preset-solid": "1.9.10",
+        "entities": "7.0.1",
+        "s-js": "^0.4.9"
+      },
+      "peerDependencies": {
+        "solid-js": "1.9.11"
+      }
+    },
+    "node_modules/@oslojs/asn1": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@oslojs/asn1/-/asn1-1.0.0.tgz",
+      "integrity": "sha512-zw/wn0sj0j0QKbIXfIlnEcTviaCzYOY3V5rAyjR6YtOByFtJiT574+8p9Wlach0lZH9fddD4yb9laEAIl4vXQA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@oslojs/binary": "1.0.0"
+      }
+    },
+    "node_modules/@oslojs/binary": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@oslojs/binary/-/binary-1.0.0.tgz",
+      "integrity": "sha512-9RCU6OwXU6p67H4NODbuxv2S3eenuQ4/WFLrsq+K/k682xrznH5EVWA7N4VFk9VYVcbFtKqur5YQQZc0ySGhsQ==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@oslojs/crypto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@oslojs/crypto/-/crypto-1.0.1.tgz",
+      "integrity": "sha512-7n08G8nWjAr/Yu3vu9zzrd0L9XnrJfpMioQcvCMxBIiF5orECHe5/3J0jmXRVvgfqMm/+4oxlQ+Sq39COYLcNQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@oslojs/asn1": "1.0.0",
+        "@oslojs/binary": "1.0.0"
+      }
+    },
+    "node_modules/@oslojs/encoding": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@oslojs/encoding/-/encoding-1.1.0.tgz",
+      "integrity": "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@oslojs/jwt": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@oslojs/jwt/-/jwt-0.2.0.tgz",
+      "integrity": "sha512-bLE7BtHrURedCn4Mco3ma9L4Y1GR2SMBuIvjWr7rmQ4/W/4Jy70TIAgZ+0nIlk0xHz1vNP8x8DCns45Sb2XRbg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@oslojs/encoding": "0.4.1"
+      }
+    },
+    "node_modules/@oslojs/jwt/node_modules/@oslojs/encoding": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@oslojs/encoding/-/encoding-0.4.1.tgz",
+      "integrity": "sha512-hkjo6MuIK/kQR5CrGNdAPZhS01ZCXuWDRJ187zh6qqF2+yMHZpD9fAYpX8q2bOO6Ryhl3XpCT6kUX76N8hhm4Q==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@polka/url": {
+      "version": "1.0.0-next.29",
+      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
+      "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.0.tgz",
+      "integrity": "sha512-WOhNW9K8bR3kf4zLxbfg6Pxu2ybOUbB2AjMDHSQx86LIF4rH4Ft7vmMwNt0loO0eonglSNy4cpD3MKXXKQu0/A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.0.tgz",
+      "integrity": "sha512-u6JHLll5QKRvjciE78bQXDmqRqNs5M/3GVqZeMwvmjaNODJih/WIrJlFVEihvV0MiYFmd+ZyPr9wxOVbPAG2Iw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.0.tgz",
+      "integrity": "sha512-qEF7CsKKzSRc20Ciu2Zw1wRrBz4g56F7r/vRwY430UPp/nt1x21Q/fpJ9N5l47WWvJlkNCPJz3QRVw008fi7yA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.0.tgz",
+      "integrity": "sha512-WADYozJ4QCnXCH4wPB+3FuGmDPoFseVCUrANmA5LWwGmC6FL14BWC7pcq+FstOZv3baGX65tZ378uT6WG8ynTw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.0.tgz",
+      "integrity": "sha512-6b8wGHJlDrGeSE3aH5mGNHBjA0TTkxdoNHik5EkvPHCt351XnigA4pS7Wsj/Eo9Y8RBU6f35cjN9SYmCFBtzxw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.0.tgz",
+      "integrity": "sha512-h25Ga0t4jaylMB8M/JKAyrvvfxGRjnPQIR8lnCayyzEjEOx2EJIlIiMbhpWxDRKGKF8jbNH01NnN663dH638mA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.0.tgz",
+      "integrity": "sha512-RzeBwv0B3qtVBWtcuABtSuCzToo2IEAIQrcyB/b2zMvBWVbjo8bZDjACUpnaafaxhTw2W+imQbP2BD1usasK4g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.0.tgz",
+      "integrity": "sha512-Sf7zusNI2CIU1HLzuu9Tc5YGAHEZs5Lu7N1ssJG4Tkw6e0MEsN7NdjUDDfGNHy2IU+ENyWT+L2obgWiguWibWQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.0.tgz",
+      "integrity": "sha512-DX2x7CMcrJzsE91q7/O02IJQ5/aLkVtYFryqCjduJhUfGKG6yJV8hxaw8pZa93lLEpPTP/ohdN4wFz7yp/ry9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.0.tgz",
+      "integrity": "sha512-09EL+yFVbJZlhcQfShpswwRZ0Rg+z/CsSELFCnPt3iK+iqwGsI4zht3secj5vLEs957QvFFXnzAT0FFPIxSrkQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.0.tgz",
+      "integrity": "sha512-i9IcCMPr3EXm8EQg5jnja0Zyc1iFxJjZWlb4wr7U2Wx/GrddOuEafxRdMPRYVaXjgbhvqalp6np07hN1w9kAKw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.0.tgz",
+      "integrity": "sha512-DGzdJK9kyJ+B78MCkWeGnpXJ91tK/iKA6HwHxF4TAlPIY7GXEvMe8hBFRgdrR9Ly4qebR/7gfUs9y2IoaVEyog==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.0.tgz",
+      "integrity": "sha512-RwpnLsqC8qbS8z1H1AxBA1H6qknR4YpPR9w2XX0vo2Sz10miu57PkNcnHVaZkbqyw/kUWfKMI73jhmfi9BRMUQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.0.tgz",
+      "integrity": "sha512-Z8pPf54Ly3aqtdWC3G4rFigZgNvd+qJlOE52fmko3KST9SoGfAdSRCwyoyG05q1HrrAblLbk1/PSIV+80/pxLg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.0.tgz",
+      "integrity": "sha512-3a3qQustp3COCGvnP4SvrMHnPQ9d1vzCakQVRTliaz8cIp/wULGjiGpbcqrkv0WrHTEp8bQD/B3HBjzujVWLOA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.0.tgz",
+      "integrity": "sha512-pjZDsVH/1VsghMJ2/kAaxt6dL0psT6ZexQVrijczOf+PeP2BUqTHYejk3l6TlPRydggINOeNRhvpLa0AYpCWSQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.0.tgz",
+      "integrity": "sha512-3ObQs0BhvPgiUVZrN7gqCSvmFuMWvWvsjG5ayJ3Lraqv+2KhOsp+pUbigqbeWqueGIsnn+09HBw27rJ+gYK4VQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.0.tgz",
+      "integrity": "sha512-EtylprDtQPdS5rXvAayrNDYoJhIz1/vzN2fEubo3yLE7tfAw+948dO0g4M0vkTVFhKojnF+n6C8bDNe+gDRdTg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.0.tgz",
+      "integrity": "sha512-k09oiRCi/bHU9UVFqD17r3eJR9bn03TyKraCrlz5ULFJGdJGi7VOmm9jl44vOJvRJ6P7WuBi/s2A97LxxHGIdw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.0.tgz",
+      "integrity": "sha512-1o/0/pIhozoSaDJoDcec+IVLbnRtQmHwPV730+AOD29lHEEo4F5BEUB24H0OBdhbBBDwIOSuf7vgg0Ywxdfiiw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.0.tgz",
+      "integrity": "sha512-pESDkos/PDzYwtyzB5p/UoNU/8fJo68vcXM9ZW2V0kjYayj1KaaUfi1NmTUTUpMn4UhU4gTuK8gIaFO4UGuMbA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.0.tgz",
+      "integrity": "sha512-hj1wFStD7B1YBeYmvY+lWXZ7ey73YGPcViMShYikqKT1GtstIKQAtfUI6yrzPjAy/O7pO0VLXGmUVWXQMaYgTQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.0.tgz",
+      "integrity": "sha512-SyaIPFoxmUPlNDq5EHkTbiKzmSEmq/gOYFI/3HHJ8iS/v1mbugVa7dXUzcJGQfoytp9DJFLhHH4U3/eTy2Bq4w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.0.tgz",
+      "integrity": "sha512-RdcryEfzZr+lAr5kRm2ucN9aVlCCa2QNq4hXelZxb8GG0NJSazq44Z3PCCc8wISRuCVnGs0lQJVX5Vp6fKA+IA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.0.tgz",
+      "integrity": "sha512-PrsWNQ8BuE00O3Xsx3ALh2Df8fAj9+cvvX9AIA6o4KpATR98c9mud4XtDWVvsEuyia5U4tVSTKygawyJkjm60w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0-beta.3.tgz",
+      "integrity": "sha512-0ifF3BjA1E8SY9C+nUew8RefNOIq0cDlYALPty4rhUm8Rrl6tCM8hBT4bhGhx7I7iXD0uAgt50lgo8dD73ACMw==",
+      "license": "MIT"
+    },
+    "node_modules/@tokenizer/token": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/esrecurse": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.19.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.0.tgz",
+      "integrity": "sha512-HyAZtpdkgZwpq8Sz3FSUvCR4c+ScbuWa9AksK2Jweub7w4M3yTz4O11AqVJzLYjy/B9ZWPyc81I+mOdJU/bDQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.59.0",
+        "@typescript-eslint/type-utils": "8.59.0",
+        "@typescript-eslint/utils": "8.59.0",
+        "@typescript-eslint/visitor-keys": "8.59.0",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.59.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.0.tgz",
+      "integrity": "sha512-TI1XGwKbDpo9tRW8UDIXCOeLk55qe9ZFGs8MTKU6/M08HWTw52DD/IYhfQtOEhEdPhLMT26Ka/x7p70nd3dzDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.59.0",
+        "@typescript-eslint/types": "8.59.0",
+        "@typescript-eslint/typescript-estree": "8.59.0",
+        "@typescript-eslint/visitor-keys": "8.59.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.0.tgz",
+      "integrity": "sha512-Lw5ITrR5s5TbC19YSvlr63ZfLaJoU6vtKTHyB0GQOpX0W7d5/Ir6vUahWi/8Sps/nOukZQ0IB3SmlxZnjaKVnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.59.0",
+        "@typescript-eslint/types": "^8.59.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.0.tgz",
+      "integrity": "sha512-UzR16Ut8IpA3Mc4DbgAShlPPkVm8xXMWafXxB0BocaVRHs8ZGakAxGRskF7FId3sdk9lgGD73GSFaWmWFDE4dg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.59.0",
+        "@typescript-eslint/visitor-keys": "8.59.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.0.tgz",
+      "integrity": "sha512-91Sbl3s4Kb3SybliIY6muFBmHVv+pYXfybC4Oolp3dvk8BvIE3wOPc+403CWIT7mJNkfQRGtdqghzs2+Z91Tqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.0.tgz",
+      "integrity": "sha512-3TRiZaQSltGqGeNrJzzr1+8YcEobKH9rHnqIp/1psfKFmhRQDNMGP5hBufanYTGznwShzVLs3Mz+gDN7HkWfXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.59.0",
+        "@typescript-eslint/typescript-estree": "8.59.0",
+        "@typescript-eslint/utils": "8.59.0",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.0.tgz",
+      "integrity": "sha512-nLzdsT1gdOgFxxxwrlNVUBzSNBEEHJ86bblmk4QAS6stfig7rcJzWKqCyxFy3YRRHXDWEkb2NralA1nOYkkm/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.0.tgz",
+      "integrity": "sha512-O9Re9P1BmBLFJyikRbQpLku/QA3/AueZNO9WePLBwQrvkixTmDe8u76B6CYUAITRl/rHawggEqUGn5QIkVRLMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.59.0",
+        "@typescript-eslint/tsconfig-utils": "8.59.0",
+        "@typescript-eslint/types": "8.59.0",
+        "@typescript-eslint/visitor-keys": "8.59.0",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.0.tgz",
+      "integrity": "sha512-I1R/K7V07XsMJ12Oaxg/O9GfrysGTmCRhvZJBv0RE0NcULMzjqVpR5kRRQjHsz3J/bElU7HwCO7zkqL+MSUz+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.59.0",
+        "@typescript-eslint/types": "8.59.0",
+        "@typescript-eslint/typescript-estree": "8.59.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.0.tgz",
+      "integrity": "sha512-/uejZt4dSere1bx12WLlPfv8GktzcaDtuJ7s42/HEZ5zGj9oxRaD4bj7qwSunXkf+pbAhFt2zjpHYUiT5lHf0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.59.0",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.5.tgz",
+      "integrity": "sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.5",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.5",
+        "vitest": "4.1.5"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
+      "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/expect/node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
+      "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.5",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
+      "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
+      "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.5",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
+      "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
+      "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/ui": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-4.1.5.tgz",
+      "integrity": "sha512-3Z9HNFiV0IF1fk0JPiK+7kE1GcaIPefQQIBYur6PM5yFIq6agys3uqP/0t966e1wXfmjbRCHDe7qW236Xjwnag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.5",
+        "fflate": "^0.8.2",
+        "flatted": "^3.4.2",
+        "pathe": "^2.0.3",
+        "sirv": "^3.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "vitest": "4.1.5"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
+      "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@webgpu/types": {
+      "version": "0.1.69",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.69.tgz",
+      "integrity": "sha512-RPmm6kgRbI8e98zSD3RVACvnuktIja5+yLgDAkTmxLr90BEwdTXRQWNLF3ETTTyH/8mKhznZuN5AveXYFEsMGQ==",
+      "license": "BSD-3-Clause",
+      "optional": true
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-escapes": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
+      "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "environment": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/any-base": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/any-base/-/any-base-1.1.0.tgz",
+      "integrity": "sha512-uMgjozySS8adZZYePpaWs8cxB9/kdzmpX6SgJZ+wbz1K5eYk5QMYDVJaZKhxyIHUdnnJkfR7SVgStgH7LkGUyg==",
+      "license": "MIT"
+    },
+    "node_modules/arctic": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/arctic/-/arctic-2.3.4.tgz",
+      "integrity": "sha512-+p30BOWsctZp+CVYCt7oAean/hWGW42sH5LAcRQX56ttEkFJWbzXBhmSpibbzwSJkRrotmsA+oAoJoVsU0f5xA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@oslojs/crypto": "1.0.1",
+        "@oslojs/encoding": "1.1.0",
+        "@oslojs/jwt": "0.2.0"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.0.tgz",
+      "integrity": "sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/await-to-js": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/await-to-js/-/await-to-js-3.0.0.tgz",
+      "integrity": "sha512-zJAaP9zxTcvTHRlejau3ZOY4V7SRpiByf3/dxx2uyKxxor19tpmpV2QRsTKikckwhaPmr2dVpxxMr7jOCYVp5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/aws4fetch": {
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/aws4fetch/-/aws4fetch-1.0.20.tgz",
+      "integrity": "sha512-/djoAN709iY65ETD6LKCtyyEI04XIBP5xVvfmNxsEP0uJB5tyaGBztSryRr4HqMStr9R06PisQE7m9zDTXKu6g==",
+      "license": "MIT"
+    },
+    "node_modules/babel-plugin-jsx-dom-expressions": {
+      "version": "0.40.6",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jsx-dom-expressions/-/babel-plugin-jsx-dom-expressions-0.40.6.tgz",
+      "integrity": "sha512-v3P1MW46Lm7VMpAkq0QfyzLWWkC8fh+0aE5Km4msIgDx5kjenHU0pF2s+4/NH8CQn/kla6+Hvws+2AF7bfV5qQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "7.18.6",
+        "@babel/plugin-syntax-jsx": "^7.18.6",
+        "@babel/types": "^7.20.7",
+        "html-entities": "2.3.3",
+        "parse5": "^7.1.2"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.20.12"
+      }
+    },
+    "node_modules/babel-plugin-jsx-dom-expressions/node_modules/@babel/helper-module-imports": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.18.6.tgz",
+      "integrity": "sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.18.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/babel-plugin-module-resolver": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/babel-plugin-module-resolver/-/babel-plugin-module-resolver-5.0.2.tgz",
+      "integrity": "sha512-9KtaCazHee2xc0ibfqsDeamwDps6FZNo5S0Q81dUqEuFzVwPhcT4J5jOqIVvgCA3Q/wO9hKYxN/Ds3tIsp5ygg==",
+      "license": "MIT",
+      "dependencies": {
+        "find-babel-config": "^2.1.1",
+        "glob": "^9.3.3",
+        "pkg-up": "^3.1.0",
+        "reselect": "^4.1.7",
+        "resolve": "^1.22.8"
+      }
+    },
+    "node_modules/babel-preset-solid": {
+      "version": "1.9.10",
+      "resolved": "https://registry.npmjs.org/babel-preset-solid/-/babel-preset-solid-1.9.10.tgz",
+      "integrity": "sha512-HCelrgua/Y+kqO8RyL04JBWS/cVdrtUv/h45GntgQY+cJl4eBcKkCDV3TdMjtKx1nXwRaR9QXslM/Npm1dxdZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "babel-plugin-jsx-dom-expressions": "^0.40.3"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0",
+        "solid-js": "^1.9.10"
+      },
+      "peerDependenciesMeta": {
+        "solid-js": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT"
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.21",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.21.tgz",
+      "integrity": "sha512-Q+rUQ7Uz8AHM7DEaNdwvfFCTq7a43lNTzuS94eiWqwyxfV/wJv+oUivef51T91mmRY4d4A1u9rcSvkeufCVXlA==",
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bmp-ts": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/bmp-ts/-/bmp-ts-1.0.9.tgz",
+      "integrity": "sha512-cTEHk2jLrPyi+12M3dhpEbnnPOsaZuq7C45ylbbQIiWgDFZq4UVYPEY5mlqjvsj/6gJv9qX5sa+ebDzLXT28Vw==",
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/bun-ffi-structs": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/bun-ffi-structs/-/bun-ffi-structs-0.1.2.tgz",
+      "integrity": "sha512-Lh1oQAYHDcnesJauieA4UNkWGXY9hYck7OA5IaRwE3Bp6K2F2pJSNYqq+hIy7P3uOvo3km3oxS8304g5gDMl/w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": "^5"
+      }
+    },
+    "node_modules/bun-webgpu": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/bun-webgpu/-/bun-webgpu-0.1.5.tgz",
+      "integrity": "sha512-91/K6S5whZKX7CWAm9AylhyKrLGRz6BUiiPiM/kXadSnD4rffljCD/q9cNFftm5YXhx4MvLqw33yEilxogJvwA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@webgpu/types": "^0.1.60"
+      },
+      "optionalDependencies": {
+        "bun-webgpu-darwin-arm64": "^0.1.5",
+        "bun-webgpu-darwin-x64": "^0.1.5",
+        "bun-webgpu-linux-x64": "^0.1.5",
+        "bun-webgpu-win32-x64": "^0.1.5"
+      }
+    },
+    "node_modules/bun-webgpu-darwin-arm64": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/bun-webgpu-darwin-arm64/-/bun-webgpu-darwin-arm64-0.1.6.tgz",
+      "integrity": "sha512-lIsDkPzJzPl6yrB5CUOINJFPnTRv6fF/Q8J1mAr43ogSp86WZEg9XZKaT6f3EUJ+9ETogGoMnoj1q0AwHUTbAQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/bun-webgpu-darwin-x64": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/bun-webgpu-darwin-x64/-/bun-webgpu-darwin-x64-0.1.6.tgz",
+      "integrity": "sha512-uEddf5U7GvKIkM/BV18rUKtYHL6d0KeqBjNHwfqDH9QgEo9KVSKvJXS5I/sMefk5V5pIYE+8tQhtrREevhocng==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/bun-webgpu-linux-x64": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/bun-webgpu-linux-x64/-/bun-webgpu-linux-x64-0.1.6.tgz",
+      "integrity": "sha512-Y/f15j9r8ba0xUz+3lATtS74OE+PPzQXO7Do/1eCluJcuOlfa77kMjvBK/ShWnem3Y9xqi59pebTPOGRB+CaJA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/bun-webgpu-win32-x64": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/bun-webgpu-win32-x64/-/bun-webgpu-win32-x64-0.1.6.tgz",
+      "integrity": "sha512-MHSFAKqizISb+C5NfDrFe3g0Al5Njnu0j/A+oO2Q+bIWX+fUYjBSowiYE1ZXJx65KuryuB+tiM7Qh6cQbVvkEg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001790",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001790.tgz",
+      "integrity": "sha512-bOoxfJPyYo+ds6W0YfptaCWbFnJYjh2Y1Eow5lRv+vI2u8ganPZqNm1JwNh0t2ELQCqIWg4B3dWEusgAmsoyOw==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cli-cursor": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.2.0.tgz",
+      "integrity": "sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "slice-ansi": "^8.0.0",
+        "string-width": "^8.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/colorette": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/diff": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.2.tgz",
+      "integrity": "sha512-sSuxWU5j5SR9QQji/o2qMvqRNYRDOcBTgsJ/DeCf4iSN4gW+gNMXM7wFIP+fdXZxoNiAnHUTGjCr+TSWXdRDKg==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/effect": {
+      "version": "4.0.0-beta.48",
+      "resolved": "https://registry.npmjs.org/effect/-/effect-4.0.0-beta.48.tgz",
+      "integrity": "sha512-MMAM/ZabuNdNmgXiin+BAanQXK7qM8mlt7nfXDoJ/Gn9V8i89JlCq+2N0AiWmqFLXjGLA0u3FjiOjSOYQk5uMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "fast-check": "^4.6.0",
+        "find-my-way-ts": "^0.1.6",
+        "ini": "^6.0.0",
+        "kubernetes-types": "^1.30.0",
+        "msgpackr": "^1.11.9",
+        "multipasta": "^0.2.7",
+        "toml": "^4.1.1",
+        "uuid": "^13.0.0",
+        "yaml": "^2.8.3"
+      }
+    },
+    "node_modules/effect/node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.344",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.344.tgz",
+      "integrity": "sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg==",
+      "license": "ISC"
+    },
+    "node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/environment": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+      "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.2.1.tgz",
+      "integrity": "sha512-wiyGaKsDgqXvF40P8mDwiUp/KQjE1FdrIEJsM8PZ3XCiniTMXS3OHWWUe5FI5agoCnr8x4xPrTDZuxsBlNHl+Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@eslint/config-array": "^0.23.5",
+        "@eslint/config-helpers": "^0.5.5",
+        "@eslint/core": "^1.2.1",
+        "@eslint/plugin-kit": "^0.7.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^9.1.2",
+        "eslint-visitor-keys": "^5.0.1",
+        "espree": "^11.2.0",
+        "esquery": "^1.7.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "minimatch": "^10.2.4",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+      "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@types/esrecurse": "^4.3.1",
+        "@types/estree": "^1.0.8",
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/eslint/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/eslint/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/eslint/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/espree": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^5.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
+    "node_modules/exif-parser": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/exif-parser/-/exif-parser-0.1.12.tgz",
+      "integrity": "sha512-c2bQfLNbMzLPmzQuOr8fy0csy84WmwnER81W88DzTp9CYNPJ6yzOj2EZAh9pywYpqHnshVLHQJ8WzldAyfY+Iw=="
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fast-check": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.7.0.tgz",
+      "integrity": "sha512-NsZRtqvSSoCP0HbNjUD+r1JH8zqZalyp6gLY9e7OYs7NK9b6AHOs2baBFeBG7bVNsuoukh89x2Yg3rPsul8ziQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/file-type": {
+      "version": "16.5.4",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-16.5.4.tgz",
+      "integrity": "sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw==",
+      "license": "MIT",
+      "dependencies": {
+        "readable-web-to-node-stream": "^3.0.0",
+        "strtok3": "^6.2.4",
+        "token-types": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/file-type?sponsor=1"
+      }
+    },
+    "node_modules/find-babel-config": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/find-babel-config/-/find-babel-config-2.1.2.tgz",
+      "integrity": "sha512-ZfZp1rQyp4gyuxqt1ZqjFGVeVBvmpURMqdIWXbPRfB97Bf6BzdK/xSIbylEINzQ0kB5tlDQfn9HkNXXWsqTqLg==",
+      "license": "MIT",
+      "dependencies": {
+        "json5": "^2.2.3"
+      }
+    },
+    "node_modules/find-my-way-ts": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/find-my-way-ts/-/find-my-way-ts-0.1.6.tgz",
+      "integrity": "sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA==",
+      "license": "MIT"
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
+      "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/gifwrap": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/gifwrap/-/gifwrap-0.10.1.tgz",
+      "integrity": "sha512-2760b1vpJHNmLzZ/ubTtNnEx5WApN/PYWJvXvgS+tL1egTTthayFYIQQNi136FLEDcN/IyEY2EcGpIITD6eYUw==",
+      "license": "MIT",
+      "dependencies": {
+        "image-q": "^4.0.0",
+        "omggif": "^1.0.10"
+      }
+    },
+    "node_modules/glob": {
+      "version": "9.3.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-9.3.5.tgz",
+      "integrity": "sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "minimatch": "^8.0.2",
+        "minipass": "^4.2.4",
+        "path-scurry": "^1.6.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.14",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
+      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/html-entities": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.3.3.tgz",
+      "integrity": "sha512-DV5Ln36z34NNTDgnz0EWGBLZENelNAtkiFA4kyNOG2tDI6Mz1uSWiq1wAKdyjnJwyDiDO7Fa2SO1CTxPXL8VxA==",
+      "license": "MIT"
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/image-q": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/image-q/-/image-q-4.0.0.tgz",
+      "integrity": "sha512-PfJGVgIfKQJuq3s0tTDOKtztksibuUEbJQIYT3by6wctQo+Rdlh7ef4evJ5NCdxY4CfMbvFkocEwbl4BF8RlJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "16.9.1"
+      }
+    },
+    "node_modules/image-q/node_modules/@types/node": {
+      "version": "16.9.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.9.1.tgz",
+      "integrity": "sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g==",
+      "license": "MIT"
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/ini": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-6.0.0.tgz",
+      "integrity": "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jimp": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/jimp/-/jimp-1.6.0.tgz",
+      "integrity": "sha512-YcwCHw1kiqEeI5xRpDlPPBGL2EOpBKLwO4yIBJcXWHPj5PnA5urGq0jbyhM5KoNpypQ6VboSoxc9D8HyfvngSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/core": "1.6.0",
+        "@jimp/diff": "1.6.0",
+        "@jimp/js-bmp": "1.6.0",
+        "@jimp/js-gif": "1.6.0",
+        "@jimp/js-jpeg": "1.6.0",
+        "@jimp/js-png": "1.6.0",
+        "@jimp/js-tiff": "1.6.0",
+        "@jimp/plugin-blit": "1.6.0",
+        "@jimp/plugin-blur": "1.6.0",
+        "@jimp/plugin-circle": "1.6.0",
+        "@jimp/plugin-color": "1.6.0",
+        "@jimp/plugin-contain": "1.6.0",
+        "@jimp/plugin-cover": "1.6.0",
+        "@jimp/plugin-crop": "1.6.0",
+        "@jimp/plugin-displace": "1.6.0",
+        "@jimp/plugin-dither": "1.6.0",
+        "@jimp/plugin-fisheye": "1.6.0",
+        "@jimp/plugin-flip": "1.6.0",
+        "@jimp/plugin-hash": "1.6.0",
+        "@jimp/plugin-mask": "1.6.0",
+        "@jimp/plugin-print": "1.6.0",
+        "@jimp/plugin-quantize": "1.6.0",
+        "@jimp/plugin-resize": "1.6.0",
+        "@jimp/plugin-rotate": "1.6.0",
+        "@jimp/plugin-threshold": "1.6.0",
+        "@jimp/types": "1.6.0",
+        "@jimp/utils": "1.6.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/jose": {
+      "version": "5.9.6",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.9.6.tgz",
+      "integrity": "sha512-AMlnetc9+CV9asI19zHmrgS/WYsWUwCn2R7RzlbJWD7F9eWYUTGyBmU9o6PxngtLGOiDGPRu+Uc4fhKzbpteZQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/jpeg-js": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.4.tgz",
+      "integrity": "sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/kubernetes-types": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/kubernetes-types/-/kubernetes-types-1.30.0.tgz",
+      "integrity": "sha512-Dew1okvhM/SQcIa2rcgujNndZwU8VnSapDgdxlYoB84ZlpAD43U6KLAFqYo17ykSFGHNPrg0qry0bP+GJd9v7Q==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lint-staged": {
+      "version": "16.4.0",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-16.4.0.tgz",
+      "integrity": "sha512-lBWt8hujh/Cjysw5GYVmZpFHXDCgZzhrOm8vbcUdobADZNOK/bRshr2kM3DfgrrtR1DQhfupW9gnIXOfiFi+bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^14.0.3",
+        "listr2": "^9.0.5",
+        "picomatch": "^4.0.3",
+        "string-argv": "^0.3.2",
+        "tinyexec": "^1.0.4",
+        "yaml": "^2.8.2"
+      },
+      "bin": {
+        "lint-staged": "bin/lint-staged.js"
+      },
+      "engines": {
+        "node": ">=20.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/lint-staged"
+      }
+    },
+    "node_modules/listr2": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-9.0.5.tgz",
+      "integrity": "sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cli-truncate": "^5.0.0",
+        "colorette": "^2.0.20",
+        "eventemitter3": "^5.0.1",
+        "log-update": "^6.1.0",
+        "rfdc": "^1.4.1",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz",
+      "integrity": "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^7.0.0",
+        "cli-cursor": "^5.0.0",
+        "slice-ansi": "^7.1.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/slice-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
+      "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
+      "integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/marked": {
+      "version": "17.0.1",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-17.0.1.tgz",
+      "integrity": "sha512-boeBdiS0ghpWcSwoNm/jJBwdpFaMnZWRzjA6SkUMYb40SVaN1x7mmfGKp0jvexGcx+7y2La5zRZsYFZI6Qpypg==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/mime": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.8.tgz",
+      "integrity": "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/mrmime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
+      "integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/msgpackr": {
+      "version": "1.11.10",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.11.10.tgz",
+      "integrity": "sha512-iCZNq+HszvF+fC3anCm4nBmWEnbeIAfpDs6IStAEKhQ2YSgkjzVG2FF9XJqwwQh5bH3N9OUTUt4QwVN6MLMLtA==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "msgpackr-extract": "^3.0.2"
+      }
+    },
+    "node_modules/msgpackr-extract": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-3.0.3.tgz",
+      "integrity": "sha512-P0efT1C9jIdVRefqjzOQ9Xml57zpOXnIuS+csaB4MdZbTdmGDLo8XhzBG1N7aO11gKDDkJvBLULeFTo46wwreA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-gyp-build-optional-packages": "5.2.2"
+      },
+      "bin": {
+        "download-msgpackr-prebuilds": "bin/download-prebuilds.js"
+      },
+      "optionalDependencies": {
+        "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.3"
+      }
+    },
+    "node_modules/multipasta": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/multipasta/-/multipasta-0.2.7.tgz",
+      "integrity": "sha512-KPA58d68KgGil15oDqXjkUBEBYc00XvbPj5/X+dyzeo/lWm9Nc25pQRlf1D+gv4OpK7NM0J1odrbu9JNNGvynA==",
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-gyp-build-optional-packages": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.2.2.tgz",
+      "integrity": "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "detect-libc": "^2.0.1"
+      },
+      "bin": {
+        "node-gyp-build-optional-packages": "bin.js",
+        "node-gyp-build-optional-packages-optional": "optional.js",
+        "node-gyp-build-optional-packages-test": "build-test.js"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.38",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",
+      "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
+      "license": "MIT"
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/omggif": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/omggif/-/omggif-1.0.10.tgz",
+      "integrity": "sha512-LMJTtvgc/nugXj0Vcrrs68Mn2D1r0zf630VNtqtpI1FEO7e+O9FP4gqs9AcnBaSEeoHIPm28u6qgPR0oyEpGSw==",
+      "license": "MIT"
+    },
+    "node_modules/onetime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
+    "node_modules/parse-bmfont-ascii": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/parse-bmfont-ascii/-/parse-bmfont-ascii-1.0.6.tgz",
+      "integrity": "sha512-U4RrVsUFCleIOBsIGYOMKjn9PavsGOXxbvYGtMOEfnId0SVNsgehXh1DxUdVPLoxd5mvcEtvmKs2Mmf0Mpa1ZA==",
+      "license": "MIT"
+    },
+    "node_modules/parse-bmfont-binary": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/parse-bmfont-binary/-/parse-bmfont-binary-1.0.6.tgz",
+      "integrity": "sha512-GxmsRea0wdGdYthjuUeWTMWPqm2+FAd4GI8vCvhgJsFnoGhTrLhXDDupwTo7rXVAgaLIGoVHDZS9p/5XbSqeWA==",
+      "license": "MIT"
+    },
+    "node_modules/parse-bmfont-xml": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/parse-bmfont-xml/-/parse-bmfont-xml-1.1.6.tgz",
+      "integrity": "sha512-0cEliVMZEhrFDwMh4SxIyVJpqYoOWDJ9P895tFuS+XuNzI5UBmBk5U5O4KuJdTnZpSBI4LFA2+ZiJaiwfSwlMA==",
+      "license": "MIT",
+      "dependencies": {
+        "xml-parse-from-string": "^1.0.0",
+        "xml2js": "^0.5.0"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "license": "MIT"
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
+    },
+    "node_modules/path-scurry/node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/peek-readable": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-4.1.0.tgz",
+      "integrity": "sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pixelmatch": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/pixelmatch/-/pixelmatch-5.3.0.tgz",
+      "integrity": "sha512-o8mkY4E/+LNUf6LzX96ht6k6CEDi65k9G2rjMtBe9Oo+VPKSvl+0GKHuH/AlG+GA5LPG/i5hrekkxUc3s2HU+Q==",
+      "license": "ISC",
+      "dependencies": {
+        "pngjs": "^6.0.0"
+      },
+      "bin": {
+        "pixelmatch": "bin/pixelmatch"
+      }
+    },
+    "node_modules/pixelmatch/node_modules/pngjs": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-6.0.0.tgz",
+      "integrity": "sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.13.0"
+      }
+    },
+    "node_modules/pkg-up": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-3.1.0.tgz",
+      "integrity": "sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==",
+      "license": "MIT",
+      "dependencies": {
+        "find-up": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkg-up/node_modules/find-up": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/pkg-up/node_modules/locate-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^3.0.0",
+        "path-exists": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/pkg-up/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pkg-up/node_modules/p-locate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/pkg-up/node_modules/path-exists": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/planck": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/planck/-/planck-1.5.0.tgz",
+      "integrity": "sha512-dlvqJE+FscZgrGUXJ5ybd0o5bvZ5XXyZNbm08xGsXp9WjXeAyWSFT6n9s/1PQcUBo4546fDXA5RMA4wbDyZw6g==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=24.0"
+      },
+      "peerDependencies": {
+        "stage-js": "^1.0.0-alpha.12"
+      }
+    },
+    "node_modules/pngjs": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-7.0.0.tgz",
+      "integrity": "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.19.0"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/pure-rand": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.0.tgz",
+      "integrity": "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/readable-web-to-node-stream": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.4.tgz",
+      "integrity": "sha512-9nX56alTf5bwXQ3ZDipHJhusu9NTQJ/CVPtb/XHAJCXihZeitfJvIRS4GqQ/mfIoOE3IelHMrpayVrosdHBuLw==",
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^4.7.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/reselect": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.8.tgz",
+      "integrity": "sha512-ab9EmR80F/zQTMNeneUr4cv+jSwPJgIlvEmVwLerwrWVbpLlBuls9XHzIeTFy4cegU2NHBp3va0LKOzU5qFEYQ==",
+      "license": "MIT"
+    },
+    "node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/restore-cursor": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^7.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rollup": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.0.tgz",
+      "integrity": "sha512-yqjxruMGBQJ2gG4HtjZtAfXArHomazDHoFwFFmZZl0r7Pdo7qCIXKqKHZc8yeoMgzJJ+pO6pEEHa+V7uzWlrAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.0",
+        "@rollup/rollup-android-arm64": "4.60.0",
+        "@rollup/rollup-darwin-arm64": "4.60.0",
+        "@rollup/rollup-darwin-x64": "4.60.0",
+        "@rollup/rollup-freebsd-arm64": "4.60.0",
+        "@rollup/rollup-freebsd-x64": "4.60.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.0",
+        "@rollup/rollup-linux-arm64-musl": "4.60.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.0",
+        "@rollup/rollup-linux-loong64-musl": "4.60.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.0",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.0",
+        "@rollup/rollup-linux-x64-gnu": "4.60.0",
+        "@rollup/rollup-linux-x64-musl": "4.60.0",
+        "@rollup/rollup-openbsd-x64": "4.60.0",
+        "@rollup/rollup-openharmony-arm64": "4.60.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.0",
+        "@rollup/rollup-win32-x64-gnu": "4.60.0",
+        "@rollup/rollup-win32-x64-msvc": "4.60.0",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/s-js": {
+      "version": "0.4.9",
+      "resolved": "https://registry.npmjs.org/s-js/-/s-js-0.4.9.tgz",
+      "integrity": "sha512-RtpOm+cM6O0sHg6IA70wH+UC3FZcND+rccBZpBAHzlUgNO2Bm5BN+FnM8+OBxzXdwpKWFwX11JGF0MFRkhSoIQ==",
+      "license": "MIT"
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/sax": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/seroval": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/seroval/-/seroval-1.5.2.tgz",
+      "integrity": "sha512-xcRN39BdsnO9Tf+VzsE7b3JyTJASItIV1FVFewJKCFcW4s4haIKS3e6vj8PGB9qBwC7tnuOywQMdv5N4qkzi7Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/seroval-plugins": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/seroval-plugins/-/seroval-plugins-1.5.2.tgz",
+      "integrity": "sha512-qpY0Cl+fKYFn4GOf3cMiq6l72CpuVaawb6ILjubOQ+diJ54LfOWaSSPsaswN8DRPIPW4Yq+tE1k5aKd7ILyaFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "seroval": "^1.0"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/simple-xml-to-json": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/simple-xml-to-json/-/simple-xml-to-json-1.2.7.tgz",
+      "integrity": "sha512-mz9VXphOxQWX3eQ/uXCtm6upltoN0DLx8Zb5T4TFC4FHB7S9FDPGre8CfLWqPWQQH/GrQYd2AXhhVM5LDpYx6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.12.2"
+      }
+    },
+    "node_modules/sirv": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.2.tgz",
+      "integrity": "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@polka/url": "^1.0.0-next.24",
+        "mrmime": "^2.0.0",
+        "totalist": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/slice-ansi": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-8.0.0.tgz",
+      "integrity": "sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.3",
+        "is-fullwidth-code-point": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/solid-js": {
+      "version": "1.9.11",
+      "resolved": "https://registry.npmjs.org/solid-js/-/solid-js-1.9.11.tgz",
+      "integrity": "sha512-WEJtcc5mkh/BnHA6Yrg4whlF8g6QwpmXXRg4P2ztPmcKeHHlH4+djYecBLhSpecZY2RRECXYUwIc/C2r3yzQ4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.1.0",
+        "seroval": "~1.5.0",
+        "seroval-plugins": "~1.5.0"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stage-js": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/stage-js/-/stage-js-1.0.2.tgz",
+      "integrity": "sha512-EWTRBYlg7Qv9wGUao99/PfRe3KaiQqWmgSvTOXvaWnu1Jk/q/vV8yJVu6bi/3EqDZeMVnCPAjheba6OFc5k1GQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=24.0"
+      }
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-argv": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
+      "integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.19"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.0.tgz",
+      "integrity": "sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strtok3": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-6.3.0.tgz",
+      "integrity": "sha512-fZtbhtvI9I48xDSywd/somNqgUHl2L2cstmXCCif0itOf96jeW18MBSyrLuNicYQVkvpOxkZtkzujiTJ9LW5Jw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0",
+        "peek-readable": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/three": {
+      "version": "0.177.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.177.0.tgz",
+      "integrity": "sha512-EiXv5/qWAaGI+Vz2A+JfavwYCMdGjxVsrn3oBwllUoqYeaBO75J63ZfyaQKoiLrqNHoTlUc6PFgMXnS0kI45zg==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinycolor2": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
+      "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==",
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
+      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/token-types": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-4.2.1.tgz",
+      "integrity": "sha512-6udB24Q737UD/SDsKAHI9FCRP7Bqc9D/MQUV02ORQg5iskjtLJlZJNdN4kKtcdtwCeWIwIHDGaUsTsCCAa8sFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0",
+        "ieee754": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/toml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/toml/-/toml-4.1.1.tgz",
+      "integrity": "sha512-EBJnVBr3dTXdA89WVFoAIPUqkBjxPMwRqsfuo1r240tKFHXv3zgca4+NJib/h6TyvGF7vOawz0jGuryJCdNHrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/totalist": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
+      "integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-language-server": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/typescript-language-server/-/typescript-language-server-5.1.3.tgz",
+      "integrity": "sha512-r+pAcYtWdN8tKlYZPwiiHNA2QPjXnI02NrW5Sf2cVM3TRtuQ3V9EKKwOxqwaQ0krsaEXk/CbN90I5erBuf84Vg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "typescript-language-server": "lib/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/utif2": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/utif2/-/utif2-4.1.0.tgz",
+      "integrity": "sha512-+oknB9FHrJ7oW7A2WZYajOcv4FcDR4CfoGB0dPNfxbi4GO05RRnFmt5oa23+9w32EanrYcSJWspUiJkLMs+37w==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^1.0.11"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
+      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
+    },
+    "node_modules/vite": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
+      "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.5",
+        "@vitest/mocker": "4.1.5",
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/runner": "4.1.5",
+        "@vitest/snapshot": "4.1.5",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.5",
+        "@vitest/browser-preview": "4.1.5",
+        "@vitest/browser-webdriverio": "4.1.5",
+        "@vitest/coverage-istanbul": "4.1.5",
+        "@vitest/coverage-v8": "4.1.5",
+        "@vitest/ui": "4.1.5",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/web-tree-sitter": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/web-tree-sitter/-/web-tree-sitter-0.25.10.tgz",
+      "integrity": "sha512-Y09sF44/13XvgVKgO2cNDw5rGk6s26MgoZPXLESvMXeefBf7i6/73eFurre0IsTW6E14Y0ArIzhUMmjoc7xyzA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/emscripten": "^1.40.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/emscripten": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/xml-parse-from-string": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/xml-parse-from-string/-/xml-parse-from-string-1.0.1.tgz",
+      "integrity": "sha512-ErcKwJTF54uRzzNMXq2X5sMIy88zJvfN2DmdoQvy7PAFJ+tPRU6ydWuOKNMyfmOjdyBQTFREi60s0Y0SyI0G0g==",
+      "license": "MIT"
+    },
+    "node_modules/xml2js": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
+      "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
+      "license": "MIT",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yoga-layout": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/yoga-layout/-/yoga-layout-3.2.1.tgz",
+      "integrity": "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==",
+      "license": "MIT"
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,16 @@
   "description": "OpenCode plugin for Codex-first GPT-5 workflows with ChatGPT Plus/Pro OAuth, multi-account rotation, and guided setup",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./tui": {
+      "types": "./dist/tui.d.ts",
+      "import": "./dist/tui.js"
+    }
+  },
   "type": "module",
   "license": "MIT",
   "author": "ndycode",
@@ -98,8 +108,12 @@
   "dependencies": {
     "@napi-rs/keyring": "~1.2.0",
     "@openauthjs/openauth": "^0.4.3",
-    "@opencode-ai/plugin": "^1.2.9",
+    "@opencode-ai/plugin": "^1.14.22",
+    "@opentui/core": "^0.1.99",
+    "@opentui/solid": "^0.1.99",
     "hono": "4.12.14",
+    "solid-js": "^1.9.11",
+    "web-tree-sitter": "^0.25.10",
     "zod": "^4.3.6"
   },
   "overrides": {

--- a/scripts/install-oc-codex-multi-auth-core.js
+++ b/scripts/install-oc-codex-multi-auth-core.js
@@ -22,6 +22,7 @@ function printHelp() {
 	console.log(`Usage: ${PACKAGE_NAME} [--modern|--full|--legacy] [--dry-run] [--no-cache-clear]\n\n` +
 		"Default behavior:\n" +
 		"  - Installs/updates global config at ~/.config/opencode/opencode.json\n" +
+		"  - Enables the prompt status bar TUI plugin at ~/.config/opencode/tui.json\n" +
 		"  - Uses compact UI config by default (9 base OAuth models + variant picker presets)\n" +
 		"  - Ensures plugin is unpinned (latest)\n" +
 		"  - Clears OpenCode plugin cache\n\n" +
@@ -69,6 +70,7 @@ function buildPaths(homeDir) {
 	return {
 		configDir,
 		configPath: join(configDir, "opencode.json"),
+		tuiConfigPath: join(configDir, "tui.json"),
 		cacheDir,
 		cacheNodeModulesPaths: getManagedPackageNames().map((name) => join(cacheDir, "node_modules", name)),
 		cachePackagePaths: getManagedPackageNames().map((name) => join(cacheDir, "packages", `${name}@latest`)),
@@ -137,6 +139,16 @@ function normalizePluginList(list) {
 	const entries = Array.isArray(list) ? list.filter(Boolean) : [];
 	const filtered = entries.filter((entry) => !isManagedPluginEntry(entry));
 	return [...filtered, PACKAGE_NAME];
+}
+
+function mergeTuiConfig(existingConfig) {
+	const existing = isPlainObject(existingConfig) ? { ...existingConfig } : {};
+	const next = { ...existing };
+	if (typeof next.$schema !== "string" || !next.$schema.trim()) {
+		next.$schema = "https://opencode.ai/tui.json";
+	}
+	next.plugin = normalizePluginList(existing.plugin);
+	return next;
 }
 
 function formatJson(obj) {
@@ -476,15 +488,39 @@ export async function runInstaller(argv = process.argv.slice(2), options = {}) {
 		log("No existing config found. Creating new global config.");
 	}
 
+	let nextTuiConfig = mergeTuiConfig(undefined);
+	let existingTuiConfig;
+	if (existsSync(paths.tuiConfigPath)) {
+		const backupPath = await backupConfig(paths.tuiConfigPath, dryRun);
+		log(`${dryRun ? "[dry-run] Would create backup" : "Backup created"}: ${backupPath}`);
+
+		try {
+			const existing = await readJson(paths.tuiConfigPath);
+			existingTuiConfig = existing;
+			nextTuiConfig = mergeTuiConfig(existing);
+		} catch (error) {
+			log(`Warning: Could not parse existing TUI config (${formatErrorForLog(error)}). Replacing with minimal TUI config.`);
+			existingTuiConfig = undefined;
+			nextTuiConfig = mergeTuiConfig(undefined);
+		}
+	} else {
+		log("No existing TUI config found. Creating new global TUI config.");
+	}
+
 	let wrote = false;
 	if (dryRun) {
 		log(`[dry-run] Would write ${paths.configPath} using ${configMode} config`);
 		log(`[dry-run] Diff for ${paths.configPath}:`);
 		log(formatConfigDiff(existingConfig, nextConfig));
+		log(`[dry-run] Would write ${paths.tuiConfigPath} with the TUI status plugin`);
+		log(`[dry-run] Diff for ${paths.tuiConfigPath}:`);
+		log(formatConfigDiff(existingTuiConfig, nextTuiConfig));
 	} else {
 		await writeFileAtomic(paths.configPath, formatJson(nextConfig));
+		await writeFileAtomic(paths.tuiConfigPath, formatJson(nextTuiConfig));
 		wrote = true;
 		log(`Wrote ${paths.configPath} (${configMode} config)`);
+		log(`Wrote ${paths.tuiConfigPath} (TUI status plugin)`);
 	}
 
 	await clearCache(paths, dryRun, skipCacheClear);
@@ -506,6 +542,7 @@ export async function runInstaller(argv = process.argv.slice(2), options = {}) {
 		action: "install",
 		configMode,
 		configPath: paths.configPath,
+		tuiConfigPath: paths.tuiConfigPath,
 		dryRun: Boolean(dryRun),
 		wrote,
 	};
@@ -518,6 +555,7 @@ export const __test = {
 	formatConfigDiff,
 	mergeFullTemplate,
 	mergeOpenaiProvider,
+	mergeTuiConfig,
 	parseCliArgs,
 	writeFileAtomic,
 	renameWithWindowsRetry,

--- a/test/codex-usage.test.ts
+++ b/test/codex-usage.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	deduplicateUsageAccountIndices,
+	getUsageLeftPercent,
+	parseCodexUsagePayload,
+	resolveCodexUsageActiveAccount,
+	type UsagePayload,
+} from "../lib/codex-usage.js";
+import type { AccountStorageV3 } from "../lib/storage.js";
+
+describe("codex usage helpers", () => {
+	it("parses usage payloads using remaining-percent semantics", () => {
+		const payload: UsagePayload = {
+			plan_type: "team",
+			rate_limit: {
+				primary_window: {
+					used_percent: 13,
+					limit_window_seconds: 18000,
+				},
+				secondary_window: {
+					used_percent: 36,
+					limit_window_seconds: 604800,
+				},
+			},
+			code_review_rate_limit: {
+				primary_window: {
+					used_percent: 0,
+					limit_window_seconds: 604800,
+				},
+			},
+			additional_rate_limits: [
+				{
+					limit_name: "batch_jobs",
+					rate_limit: {
+						primary_window: {
+							used_percent: 25,
+							limit_window_seconds: 3600,
+						},
+					},
+				},
+			],
+			credits: { unlimited: true },
+		};
+
+		const usage = parseCodexUsagePayload(payload);
+
+		expect(usage.planType).toBe("team");
+		expect(usage.credits).toBe("unlimited");
+		expect(usage.limits).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					name: "5h limit",
+					leftPercent: 87,
+					summary: "87% left",
+				}),
+				expect.objectContaining({
+					name: "Weekly limit",
+					leftPercent: 64,
+					summary: "64% left",
+				}),
+				expect.objectContaining({
+					name: "Code review",
+					leftPercent: 100,
+				}),
+				expect.objectContaining({
+					name: "Batch Jobs",
+					leftPercent: 75,
+				}),
+			]),
+		);
+	});
+
+	it("clamps remaining percent and preserves active codex account selection", () => {
+		expect(getUsageLeftPercent(-10)).toBe(100);
+		expect(getUsageLeftPercent(110)).toBe(0);
+		expect(getUsageLeftPercent(12.4)).toBe(88);
+
+		const storage: AccountStorageV3 = {
+			version: 3,
+			activeIndex: 0,
+			activeIndexByFamily: { codex: 2 },
+			accounts: [
+				{ refreshToken: "r1", addedAt: 0, lastUsed: 0 },
+				{ refreshToken: "r1", addedAt: 0, lastUsed: 0 },
+				{ refreshToken: "r2", accountId: "acc-2", addedAt: 0, lastUsed: 0 },
+			],
+		};
+
+		expect(deduplicateUsageAccountIndices(storage)).toEqual([0, 2]);
+		expect(resolveCodexUsageActiveAccount(storage)).toMatchObject({
+			index: 2,
+			account: { accountId: "acc-2" },
+		});
+	});
+});

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -2459,7 +2459,11 @@ describe("OpenAIOAuthPlugin fetch handler", () => {
 			const { getTuiQuotaCachePath, readTuiQuotaSnapshot } = await import(
 				"../lib/tui-quota-cache.js"
 			);
-			const snapshot = await readTuiQuotaSnapshot(getTuiQuotaCachePath(stateDir));
+			let snapshot = await readTuiQuotaSnapshot(getTuiQuotaCachePath(stateDir));
+			for (let attempt = 0; !snapshot && attempt < 20; attempt += 1) {
+				await new Promise((resolve) => setTimeout(resolve, 10));
+				snapshot = await readTuiQuotaSnapshot(getTuiQuotaCachePath(stateDir));
+			}
 
 			expect(response.status).toBe(200);
 			expect(snapshot).toEqual(

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,3 +1,7 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 vi.mock("@opencode-ai/plugin/tool", () => {
@@ -2426,6 +2430,71 @@ describe("OpenAIOAuthPlugin fetch handler", () => {
 		});
 
 		expect(response.status).toBe(200);
+	});
+
+	it("records TUI quota cache from successful Codex response headers", async () => {
+		const previousStateDir = process.env.OPENCODE_STATE_DIR;
+		const stateDir = await mkdtemp(join(tmpdir(), "tui-quota-index-"));
+		process.env.OPENCODE_STATE_DIR = stateDir;
+		try {
+			globalThis.fetch = vi.fn().mockResolvedValue(
+				new Response(JSON.stringify({ content: "test" }), {
+					status: 200,
+					headers: {
+						"x-codex-primary-used-percent": "6",
+						"x-codex-primary-window-minutes": "300",
+						"x-codex-secondary-used-percent": "17",
+						"x-codex-secondary-window-minutes": "10080",
+						"x-codex-plan-type": "plus",
+						"x-codex-active-limit": "40",
+					},
+				}),
+			);
+
+			const { sdk } = await setupPlugin();
+			const response = await sdk.fetch!("https://api.openai.com/v1/chat", {
+				method: "POST",
+				body: JSON.stringify({ model: "gpt-5.1" }),
+			});
+			const { getTuiQuotaCachePath, readTuiQuotaSnapshot } = await import(
+				"../lib/tui-quota-cache.js"
+			);
+			const snapshot = await readTuiQuotaSnapshot(getTuiQuotaCachePath(stateDir));
+
+			expect(response.status).toBe(200);
+			expect(snapshot).toEqual(
+				expect.objectContaining({
+					source: "headers",
+					accountIndex: 1,
+					accountCount: 1,
+					accountEmail: "user@example.com",
+					accountLabel: "Account 1",
+					planType: "plus",
+					activeLimit: 40,
+				}),
+			);
+			expect(snapshot?.limits).toEqual([
+				expect.objectContaining({
+					label: "5h",
+					leftPercent: 94,
+					usedPercent: 6,
+					windowMinutes: 300,
+				}),
+				expect.objectContaining({
+					label: "7d",
+					leftPercent: 83,
+					usedPercent: 17,
+					windowMinutes: 10080,
+				}),
+			]);
+		} finally {
+			if (previousStateDir === undefined) {
+				delete process.env.OPENCODE_STATE_DIR;
+			} else {
+				process.env.OPENCODE_STATE_DIR = previousStateDir;
+			}
+			await rm(stateDir, { recursive: true, force: true });
+		}
 	});
 
 	it("handles network errors and rotates to next account", async () => {

--- a/test/install-oc-codex-multi-auth.test.ts
+++ b/test/install-oc-codex-multi-auth.test.ts
@@ -166,6 +166,65 @@ describe("install-oc-codex-multi-auth script", () => {
 		expect(saved.provider.openai.models["gpt-5.5-fast-medium"]).toBeDefined();
 	});
 
+	it("merges tui.json plugin entries without clobbering plugin_enabled", async () => {
+		vi.resetModules();
+		tempHome = await createTempHome();
+		const { runInstaller } = await import("../scripts/install-oc-codex-multi-auth-core.js");
+		const configDir = join(tempHome, ".config", "opencode");
+		const configPath = join(configDir, "opencode.json");
+		const tuiConfigPath = join(configDir, "tui.json");
+
+		await mkdir(configDir, { recursive: true });
+		await writeFile(configPath, JSON.stringify({ plugin: [] }, null, 2), "utf-8");
+		await writeFile(
+			tuiConfigPath,
+			JSON.stringify(
+				{
+					plugin: [
+						"other-tui-plugin",
+						"oc-chatgpt-multi-auth@old",
+						"file:///C:/Users/neil/pkg/node_modules/oc-codex-multi-auth",
+					],
+					plugin_enabled: {
+						"other.id": false,
+					},
+				},
+				null,
+				2,
+			),
+			"utf-8",
+		);
+
+		await expect(
+			runInstaller(["--no-cache-clear"], {
+				env: {
+					...process.env,
+					HOME: tempHome,
+					USERPROFILE: tempHome,
+				},
+			}),
+		).resolves.toMatchObject({
+			action: "install",
+			tuiConfigPath,
+		});
+
+		const saved = JSON.parse(await readFile(tuiConfigPath, "utf-8")) as {
+			$schema: string;
+			plugin: string[];
+			plugin_enabled: Record<string, boolean>;
+		};
+		expect(saved.$schema).toBe("https://opencode.ai/tui.json");
+		expect(saved.plugin).toEqual(["other-tui-plugin", "oc-codex-multi-auth"]);
+		expect(saved.plugin_enabled).toEqual({ "other.id": false });
+		const configEntries = await readdir(configDir);
+		expect(configEntries).toEqual(
+			expect.arrayContaining([
+				"tui.json",
+				expect.stringMatching(/^tui\.json\.bak-/),
+			]),
+		);
+	});
+
 	it("parses BOM-prefixed existing config and preserves custom keys on merge", async () => {
 		vi.resetModules();
 		tempHome = await createTempHome();

--- a/test/tui-quota-cache.test.ts
+++ b/test/tui-quota-cache.test.ts
@@ -1,0 +1,87 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { describe, expect, it } from "vitest";
+
+import {
+	clearTuiQuotaSnapshot,
+	createTuiQuotaSnapshot,
+	getTuiQuotaCachePath,
+	parseTuiQuotaSnapshotFromHeaders,
+	readTuiQuotaSnapshot,
+	writeTuiQuotaSnapshot,
+} from "../lib/tui-quota-cache.js";
+
+describe("TUI quota cache", () => {
+	it("parses Codex quota response headers into a prompt snapshot", () => {
+		const headers = new Headers({
+			"x-codex-primary-used-percent": "20",
+			"x-codex-primary-window-minutes": "300",
+			"x-codex-secondary-used-percent": "16",
+			"x-codex-secondary-window-minutes": "10080",
+			"x-codex-plan-type": "plus",
+			"x-codex-active-limit": "40",
+		});
+
+		const snapshot = parseTuiQuotaSnapshotFromHeaders(headers, {
+			fingerprint: "acct",
+			accountIndex: 2,
+			accountCount: 3,
+			accountLabel: "Account 2",
+			fetchedAt: 1000,
+		});
+
+		expect(snapshot).toEqual(
+			expect.objectContaining({
+				fingerprint: "acct",
+				source: "headers",
+				accountIndex: 2,
+				accountCount: 3,
+				accountLabel: "Account 2",
+				planType: "plus",
+				activeLimit: 40,
+			}),
+		);
+		expect(snapshot?.limits).toEqual([
+			expect.objectContaining({
+				label: "5h",
+				leftPercent: 80,
+				usedPercent: 20,
+				windowMinutes: 300,
+			}),
+			expect.objectContaining({
+				label: "7d",
+				leftPercent: 84,
+				usedPercent: 16,
+				windowMinutes: 10080,
+			}),
+		]);
+	});
+
+	it("returns undefined when response headers do not include quota", () => {
+		expect(
+			parseTuiQuotaSnapshotFromHeaders(new Headers(), {
+				fingerprint: "acct",
+			}),
+		).toBeUndefined();
+	});
+
+	it("round-trips the shared quota cache file", async () => {
+		const dir = await mkdtemp(join(tmpdir(), "tui-quota-cache-"));
+		const path = getTuiQuotaCachePath(dir);
+		try {
+			const snapshot = createTuiQuotaSnapshot({
+				fingerprint: "acct",
+				source: "usage",
+				fetchedAt: 1000,
+				limits: [{ label: "5h", leftPercent: 99 }],
+			});
+			await writeTuiQuotaSnapshot(snapshot, path);
+			await expect(readTuiQuotaSnapshot(path)).resolves.toEqual(snapshot);
+			await clearTuiQuotaSnapshot(path);
+			await expect(readTuiQuotaSnapshot(path)).resolves.toBeUndefined();
+		} finally {
+			await rm(dir, { recursive: true, force: true });
+		}
+	});
+});

--- a/test/tui-quota-cache.test.ts
+++ b/test/tui-quota-cache.test.ts
@@ -86,4 +86,30 @@ describe("TUI quota cache", () => {
 			await rm(dir, { recursive: true, force: true });
 		}
 	});
+
+	it("skips repeated equivalent writes in a short window", async () => {
+		const dir = await mkdtemp(join(tmpdir(), "tui-quota-cache-"));
+		const path = getTuiQuotaCachePath(dir);
+		try {
+			const first = createTuiQuotaSnapshot({
+				fingerprint: "acct",
+				source: "headers",
+				fetchedAt: 1000,
+				limits: [{ label: "5h", leftPercent: 94 }],
+			});
+			const second = createTuiQuotaSnapshot({
+				fingerprint: "acct",
+				source: "headers",
+				fetchedAt: 2000,
+				limits: [{ label: "5h", leftPercent: 94 }],
+			});
+
+			await writeTuiQuotaSnapshot(first, path);
+			await writeTuiQuotaSnapshot(second, path);
+
+			await expect(readTuiQuotaSnapshot(path)).resolves.toEqual(first);
+		} finally {
+			await rm(dir, { recursive: true, force: true });
+		}
+	});
 });

--- a/test/tui-quota-cache.test.ts
+++ b/test/tui-quota-cache.test.ts
@@ -27,6 +27,7 @@ describe("TUI quota cache", () => {
 			fingerprint: "acct",
 			accountIndex: 2,
 			accountCount: 3,
+			accountEmail: "user2@example.com",
 			accountLabel: "Account 2",
 			fetchedAt: 1000,
 		});
@@ -37,6 +38,7 @@ describe("TUI quota cache", () => {
 				source: "headers",
 				accountIndex: 2,
 				accountCount: 3,
+				accountEmail: "user2@example.com",
 				accountLabel: "Account 2",
 				planType: "plus",
 				activeLimit: 40,

--- a/test/tui-refresh-events.test.ts
+++ b/test/tui-refresh-events.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "vitest";
+import type { Event } from "@opencode-ai/sdk/v2";
+
+import { shouldRefreshQuotaForEvent } from "../tui.js";
+
+const tokens = {
+	input: 10,
+	output: 4,
+	reasoning: 2,
+	cache: {
+		read: 0,
+		write: 0,
+	},
+};
+
+describe("TUI quota refresh events", () => {
+	it("refreshes after assistant completion and model step finish", () => {
+		const assistantCompleted = {
+			type: "message.updated",
+			properties: {
+				sessionID: "ses_1",
+				info: {
+					id: "msg_1",
+					sessionID: "ses_1",
+					role: "assistant",
+					time: { created: 1, completed: 2 },
+					parentID: "msg_0",
+					modelID: "gpt-5.5",
+					providerID: "openai",
+					mode: "build",
+					agent: "build",
+					path: { cwd: "C:\\repo", root: "C:\\repo" },
+					cost: 0,
+					tokens,
+				},
+			},
+		} satisfies Extract<Event, { type: "message.updated" }>;
+
+		const stepFinish = {
+			type: "message.part.updated",
+			properties: {
+				sessionID: "ses_1",
+				time: 2,
+				part: {
+					id: "part_1",
+					sessionID: "ses_1",
+					messageID: "msg_1",
+					type: "step-finish",
+					reason: "tool",
+					cost: 0,
+					tokens,
+				},
+			},
+		} satisfies Extract<Event, { type: "message.part.updated" }>;
+
+		expect(shouldRefreshQuotaForEvent(assistantCompleted)).toBe(true);
+		expect(shouldRefreshQuotaForEvent(stepFinish)).toBe(true);
+	});
+
+	it("refreshes after tool completion and session idle", () => {
+		const toolCompleted = {
+			type: "message.part.updated",
+			properties: {
+				sessionID: "ses_1",
+				time: 3,
+				part: {
+					id: "part_2",
+					sessionID: "ses_1",
+					messageID: "msg_1",
+					type: "tool",
+					callID: "call_1",
+					tool: "bash",
+					state: {
+						status: "completed",
+						input: {},
+						output: "ok",
+						title: "bash",
+						metadata: {},
+						time: { start: 2, end: 3 },
+					},
+				},
+			},
+		} satisfies Extract<Event, { type: "message.part.updated" }>;
+
+		const idleStatus = {
+			type: "session.status",
+			properties: {
+				sessionID: "ses_1",
+				status: { type: "idle" },
+			},
+		} satisfies Extract<Event, { type: "session.status" }>;
+
+		expect(shouldRefreshQuotaForEvent(toolCompleted)).toBe(true);
+		expect(shouldRefreshQuotaForEvent(idleStatus)).toBe(true);
+	});
+
+	it("does not refresh for streaming text or busy status", () => {
+		const textPart = {
+			type: "message.part.updated",
+			properties: {
+				sessionID: "ses_1",
+				time: 1,
+				part: {
+					id: "part_3",
+					sessionID: "ses_1",
+					messageID: "msg_1",
+					type: "text",
+					text: "hello",
+				},
+			},
+		} satisfies Extract<Event, { type: "message.part.updated" }>;
+
+		const busyStatus = {
+			type: "session.status",
+			properties: {
+				sessionID: "ses_1",
+				status: { type: "busy" },
+			},
+		} satisfies Extract<Event, { type: "session.status" }>;
+
+		expect(shouldRefreshQuotaForEvent(textPart)).toBe(false);
+		expect(shouldRefreshQuotaForEvent(busyStatus)).toBe(false);
+	});
+});

--- a/test/tui-status.test.ts
+++ b/test/tui-status.test.ts
@@ -2,13 +2,16 @@ import { describe, expect, it } from "vitest";
 
 import {
 	formatPromptStatusText,
+	formatQuotaDetailsText,
 	resolvePromptReasoningVariant,
+	resolveQuotaPromptTone,
 	type CompactQuotaStatus,
 	type PromptStatusConfig,
 	type PromptStatusMessage,
 } from "../lib/tui-status.js";
 
 describe("TUI prompt status helpers", () => {
+	const sep = ` ${String.fromCharCode(183)} `;
 	const quota: CompactQuotaStatus = {
 		type: "ready",
 		limits: [
@@ -25,7 +28,7 @@ describe("TUI prompt status helpers", () => {
 				quota,
 				width: 120,
 			}),
-		).toBe("xhigh · 5h 88% · 7d 83%");
+		).toBe(`xhigh${sep}5h 88%${sep}7d 83%`);
 
 		expect(
 			formatPromptStatusText({
@@ -33,7 +36,7 @@ describe("TUI prompt status helpers", () => {
 				quota,
 				width: 80,
 			}),
-		).toBe("xhigh · 5h 88% · 7d 83%");
+		).toBe(`xhigh${sep}5h 88%${sep}7d 83%`);
 
 		expect(
 			formatPromptStatusText({
@@ -51,13 +54,83 @@ describe("TUI prompt status helpers", () => {
 				quota: { type: "unavailable" },
 				width: 120,
 			}),
-		).toBe("high · limits ?");
+		).toBe(`high${sep}limits ?`);
 		expect(
 			formatPromptStatusText({
 				quota: { type: "missing" },
 				width: 120,
 			}),
 		).toBe("no auth");
+		expect(
+			formatPromptStatusText({
+				quota: { type: "loading" },
+				width: 120,
+			}),
+		).toBe("");
+	});
+
+	it("adds account hint only when multiple accounts are configured", () => {
+		expect(
+			formatPromptStatusText({
+				quota: {
+					...quota,
+					accountIndex: 2,
+					accountCount: 3,
+				},
+				width: 120,
+			}),
+		).toBe(`A2${sep}5h 88%${sep}7d 83%`);
+
+		expect(
+			formatPromptStatusText({
+				quota: {
+					...quota,
+					accountIndex: 1,
+					accountCount: 1,
+				},
+				width: 120,
+			}),
+		).toBe(`5h 88%${sep}7d 83%`);
+	});
+
+	it("resolves prompt tone from quota thresholds", () => {
+		expect(resolveQuotaPromptTone(quota)).toBe("normal");
+		expect(
+			resolveQuotaPromptTone({
+				...quota,
+				limits: [{ label: "5h", leftPercent: 20 }],
+			}),
+		).toBe("warning");
+		expect(
+			resolveQuotaPromptTone({
+				...quota,
+				limits: [{ label: "5h", leftPercent: 8 }],
+			}),
+		).toBe("danger");
+		expect(resolveQuotaPromptTone({ ...quota, stale: true })).toBe("stale");
+	});
+
+	it("formats quota details for the command dialog", () => {
+		const details = formatQuotaDetailsText(
+			{
+				...quota,
+				accountIndex: 2,
+				accountCount: 3,
+				accountLabel: "Account 2 (neil@example.com)",
+				source: "headers",
+				fetchedAt: 1_000,
+				planType: "plus",
+				activeLimit: 40,
+			},
+			31_000,
+		);
+
+		expect(details).toContain("Account: A2 (Account 2");
+		expect(details).toContain("5h: 88% left");
+		expect(details).toContain("Plan: plus");
+		expect(details).toContain("Active limit: 40");
+		expect(details).toContain("Source: response headers");
+		expect(details).toContain("Updated: just now");
 	});
 
 	it("resolves the selected variant from session messages before config defaults", () => {

--- a/test/tui-status.test.ts
+++ b/test/tui-status.test.ts
@@ -11,19 +11,21 @@ import {
 describe("TUI prompt status helpers", () => {
 	const quota: CompactQuotaStatus = {
 		type: "ready",
-		primaryLeftPercent: 88,
-		secondaryLeftPercent: 83,
+		limits: [
+			{ label: "5h", leftPercent: 88 },
+			{ label: "7d", leftPercent: 83 },
+		],
 		stale: false,
 	};
 
-	it("formats full and compact prompt status text", () => {
+	it("formats prompt status text from supplied quota labels", () => {
 		expect(
 			formatPromptStatusText({
 				variant: "xhigh",
 				quota,
 				width: 120,
 			}),
-		).toBe("xhigh · 5h 88% · weekly 83%");
+		).toBe("xhigh · 5h 88% · 7d 83%");
 
 		expect(
 			formatPromptStatusText({
@@ -31,7 +33,7 @@ describe("TUI prompt status helpers", () => {
 				quota,
 				width: 80,
 			}),
-		).toBe("xhigh · 5h 88 · wk 83");
+		).toBe("xhigh · 5h 88% · 7d 83%");
 
 		expect(
 			formatPromptStatusText({

--- a/test/tui-status.test.ts
+++ b/test/tui-status.test.ts
@@ -28,7 +28,7 @@ describe("TUI prompt status helpers", () => {
 				quota,
 				width: 120,
 			}),
-		).toBe(`xhigh${sep}5h 88%${sep}7d 83%`);
+		).toBe(`5h 88%${sep}7d 83%`);
 
 		expect(
 			formatPromptStatusText({
@@ -36,7 +36,7 @@ describe("TUI prompt status helpers", () => {
 				quota,
 				width: 80,
 			}),
-		).toBe(`xhigh${sep}5h 88%${sep}7d 83%`);
+		).toBe(`5h 88%${sep}7d 83%`);
 
 		expect(
 			formatPromptStatusText({
@@ -44,7 +44,7 @@ describe("TUI prompt status helpers", () => {
 				quota,
 				width: 50,
 			}),
-		).toBe("xhigh");
+		).toBe("5h 88%");
 	});
 
 	it("falls back to non-sensitive status when quota is unavailable", () => {
@@ -54,7 +54,7 @@ describe("TUI prompt status helpers", () => {
 				quota: { type: "unavailable" },
 				width: 120,
 			}),
-		).toBe(`high${sep}limits ?`);
+		).toBe("limits ?");
 		expect(
 			formatPromptStatusText({
 				quota: { type: "missing" },
@@ -70,6 +70,18 @@ describe("TUI prompt status helpers", () => {
 	});
 
 	it("adds account hint only when multiple accounts are configured", () => {
+		expect(
+			formatPromptStatusText({
+				quota: {
+					...quota,
+					accountIndex: 2,
+					accountCount: 3,
+					accountEmail: "user2@example.com",
+				},
+				width: 120,
+			}),
+		).toBe(`[user2@example.com]${sep}5h 88%${sep}7d 83%`);
+
 		expect(
 			formatPromptStatusText({
 				quota: {
@@ -93,6 +105,21 @@ describe("TUI prompt status helpers", () => {
 		).toBe(`5h 88%${sep}7d 83%`);
 	});
 
+	it("prefers quota over variant when status space is tight", () => {
+		expect(
+			formatPromptStatusText({
+				variant: "xhigh",
+				quota: {
+					...quota,
+					accountIndex: 2,
+					accountCount: 3,
+					accountEmail: "user2@example.com",
+				},
+				width: 50,
+			}),
+		).toBe("5h 88%");
+	});
+
 	it("resolves prompt tone from quota thresholds", () => {
 		expect(resolveQuotaPromptTone(quota)).toBe("normal");
 		expect(
@@ -110,12 +137,35 @@ describe("TUI prompt status helpers", () => {
 		expect(resolveQuotaPromptTone({ ...quota, stale: true })).toBe("stale");
 	});
 
+	it("adds reset time to compact status only when quota is low", () => {
+		const resetStatus = formatPromptStatusText({
+			quota: {
+				...quota,
+				limits: [
+					{ label: "5h", leftPercent: 8, resetAtMs: Date.now() + 60_000 },
+					{ label: "7d", leftPercent: 83 },
+				],
+			},
+			width: 120,
+		});
+
+		expect(resetStatus).toMatch(/5h 8% resets \d{2}:\d{2}/);
+		expect(resetStatus).toContain("7d 83%");
+		expect(
+			formatPromptStatusText({
+				quota,
+				width: 120,
+			}),
+		).not.toContain("resets");
+	});
+
 	it("formats quota details for the command dialog", () => {
 		const details = formatQuotaDetailsText(
 			{
 				...quota,
 				accountIndex: 2,
 				accountCount: 3,
+				accountEmail: "neil@example.com",
 				accountLabel: "Account 2 (neil@example.com)",
 				source: "headers",
 				fetchedAt: 1_000,
@@ -125,7 +175,7 @@ describe("TUI prompt status helpers", () => {
 			31_000,
 		);
 
-		expect(details).toContain("Account: A2 (Account 2");
+		expect(details).toContain("Account: [neil@example.com] (Account 2");
 		expect(details).toContain("5h: 88% left");
 		expect(details).toContain("Plan: plus");
 		expect(details).toContain("Active limit: 40");

--- a/test/tui-status.test.ts
+++ b/test/tui-status.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	formatPromptStatusText,
+	resolvePromptReasoningVariant,
+	type CompactQuotaStatus,
+	type PromptStatusConfig,
+	type PromptStatusMessage,
+} from "../lib/tui-status.js";
+
+describe("TUI prompt status helpers", () => {
+	const quota: CompactQuotaStatus = {
+		type: "ready",
+		primaryLeftPercent: 88,
+		secondaryLeftPercent: 83,
+		stale: false,
+	};
+
+	it("formats full and compact prompt status text", () => {
+		expect(
+			formatPromptStatusText({
+				variant: "xhigh",
+				quota,
+				width: 120,
+			}),
+		).toBe("xhigh · 5h 88% · weekly 83%");
+
+		expect(
+			formatPromptStatusText({
+				variant: "xhigh",
+				quota,
+				width: 80,
+			}),
+		).toBe("xhigh · 5h 88 · wk 83");
+
+		expect(
+			formatPromptStatusText({
+				variant: "xhigh",
+				quota,
+				width: 50,
+			}),
+		).toBe("xhigh");
+	});
+
+	it("falls back to non-sensitive status when quota is unavailable", () => {
+		expect(
+			formatPromptStatusText({
+				variant: "high",
+				quota: { type: "unavailable" },
+				width: 120,
+			}),
+		).toBe("high · limits ?");
+		expect(
+			formatPromptStatusText({
+				quota: { type: "missing" },
+				width: 120,
+			}),
+		).toBe("no auth");
+	});
+
+	it("resolves the selected variant from session messages before config defaults", () => {
+		const messages: PromptStatusMessage[] = [
+			{
+				role: "assistant",
+				modelID: "gpt-5.5-high",
+				variant: "high",
+			},
+			{
+				role: "user",
+				userModel: {
+					modelID: "gpt-5.5",
+					variant: "xhigh",
+				},
+			},
+		];
+		const config: PromptStatusConfig = {
+			model: "openai/gpt-5.5-medium",
+		};
+
+		expect(resolvePromptReasoningVariant({ messages, config })).toBe("xhigh");
+	});
+
+	it("resolves legacy suffixes and provider reasoning options from config", () => {
+		expect(
+			resolvePromptReasoningVariant({
+				config: {
+					model: "openai/gpt-5.5-fast-medium",
+				},
+			}),
+		).toBe("medium");
+
+		expect(
+			resolvePromptReasoningVariant({
+				config: {
+					model: "openai/gpt-5.5",
+					provider: {
+						openai: {
+							options: {
+								reasoningEffort: "high",
+							},
+						},
+					},
+				},
+			}),
+		).toBe("high");
+	});
+});

--- a/test/tui-status.test.ts
+++ b/test/tui-status.test.ts
@@ -104,4 +104,26 @@ describe("TUI prompt status helpers", () => {
 			}),
 		).toBe("high");
 	});
+
+	it("prefers the selected agent reasoning effort over provider defaults", () => {
+		const config: PromptStatusConfig = {
+			model: "openai/gpt-5.5",
+			default_agent: "Sisyphus - Ultraworker",
+			agent: {
+				"Sisyphus - Ultraworker": {
+					model: "openai/gpt-5.5",
+					reasoningEffort: "xhigh",
+				},
+			},
+			provider: {
+				openai: {
+					options: {
+						reasoningEffort: "medium",
+					},
+				},
+			},
+		};
+
+		expect(resolvePromptReasoningVariant({ config })).toBe("xhigh");
+	});
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,6 +25,7 @@
   },
   "include": [
     "index.ts",
+    "tui.ts",
     "lib/**/*.ts",
     "lib/**/*.d.ts"
   ],

--- a/tui.ts
+++ b/tui.ts
@@ -15,20 +15,27 @@ import {
 } from "./lib/codex-usage.js";
 import {
 	formatPromptStatusText,
+	formatQuotaDetailsText,
+	resolveQuotaPromptTone,
 	type CompactQuotaLimit,
 	type CompactQuotaStatus,
 } from "./lib/tui-status.js";
+import {
+	createTuiQuotaSnapshot,
+	getTuiQuotaCachePath,
+	isTuiQuotaSnapshot,
+	readTuiQuotaSnapshot,
+	writeTuiQuotaSnapshot,
+	type TuiQuotaSnapshot,
+} from "./lib/tui-quota-cache.js";
 import { loadAccounts } from "./lib/storage.js";
 
 const CACHE_KEY = "oc-codex-multi-auth:tui-status:v2";
 const REFRESH_INTERVAL_MS = 5 * 60 * 1000;
 const EVENT_REFRESH_DEBOUNCE_MS = 750;
+const ACCOUNT_POLL_INTERVAL_MS = 1_000;
 
-type StoredQuotaStatus = {
-	fingerprint: string;
-	fetchedAt: number;
-	limits: CompactQuotaLimit[];
-};
+type StoredQuotaStatus = TuiQuotaSnapshot;
 
 type SolidRuntime = Pick<
 	typeof import("@opentui/solid"),
@@ -38,38 +45,8 @@ type SolidRuntime = Pick<
 
 let inFlightRefresh: Promise<CompactQuotaStatus> | undefined;
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-	return value !== null && typeof value === "object" && !Array.isArray(value);
-}
-
-function isNullablePercent(value: unknown): value is number | null {
-	return (
-		value === null ||
-		(typeof value === "number" &&
-			Number.isFinite(value) &&
-			value >= 0 &&
-			value <= 100)
-	);
-}
-
-function isStoredQuotaLimit(value: unknown): value is CompactQuotaLimit {
-	return (
-		isRecord(value) &&
-		typeof value.label === "string" &&
-		value.label.trim().length > 0 &&
-		isNullablePercent(value.leftPercent)
-	);
-}
-
 function isStoredQuotaStatus(value: unknown): value is StoredQuotaStatus {
-	return (
-		isRecord(value) &&
-		typeof value.fingerprint === "string" &&
-		typeof value.fetchedAt === "number" &&
-		Number.isFinite(value.fetchedAt) &&
-		Array.isArray(value.limits) &&
-		value.limits.every(isStoredQuotaLimit)
-	);
+	return isTuiQuotaSnapshot(value);
 }
 
 function readStoredQuotaStatus(
@@ -108,17 +85,77 @@ function toCompactQuotaStatus(
 		type: "ready",
 		limits: stored.limits,
 		stale,
+		source: stored.source,
+		fetchedAt: stored.fetchedAt,
+		fingerprint: stored.fingerprint,
+		accountIndex: stored.accountIndex,
+		accountCount: stored.accountCount,
+		accountLabel: stored.accountLabel,
+		planType: stored.planType,
+		activeLimit: stored.activeLimit,
 	};
 }
 
 function toCompactQuotaLimit(
-	window: { usedPercent?: number; windowMinutes?: number },
+	window: { usedPercent?: number; windowMinutes?: number; resetAtMs?: number },
 ): CompactQuotaLimit | undefined {
 	if (!hasUsageWindow(window)) return undefined;
 	return {
 		label: formatUsageWindowLabel(window.windowMinutes),
 		leftPercent: getUsageLeftPercent(window.usedPercent) ?? null,
+		usedPercent: window.usedPercent,
+		windowMinutes: window.windowMinutes,
+		resetAtMs: window.resetAtMs,
 	};
+}
+
+function formatTuiAccountLabel(
+	account: { email?: string; accountId?: string; organizationId?: string },
+	index: number,
+): string {
+	return (
+		account.email?.trim() ||
+		account.accountId?.trim() ||
+		account.organizationId?.trim() ||
+		`Account ${index + 1}`
+	);
+}
+
+function getSharedQuotaCachePath(api: TuiPluginApi): string {
+	return getTuiQuotaCachePath(api.state.path.state);
+}
+
+async function readSharedQuotaStatus(
+	api: TuiPluginApi,
+	fingerprint: string,
+): Promise<StoredQuotaStatus | undefined> {
+	const cachePath = getSharedQuotaCachePath(api);
+	const snapshot = await readTuiQuotaSnapshot(cachePath);
+	if (snapshot?.fingerprint === fingerprint) return snapshot;
+	const fallbackSnapshot = await readTuiQuotaSnapshot();
+	return fallbackSnapshot?.fingerprint === fingerprint
+		? fallbackSnapshot
+		: undefined;
+}
+
+async function writeSharedQuotaStatus(
+	api: TuiPluginApi,
+	status: StoredQuotaStatus,
+): Promise<void> {
+	try {
+		await writeTuiQuotaSnapshot(status, getSharedQuotaCachePath(api));
+	} catch {
+		// The prompt status is best-effort; shared cache write failures should
+		// not affect the OpenCode TUI.
+	}
+}
+
+async function resolveActiveQuotaFingerprint(): Promise<string | undefined> {
+	const storage = await loadAccounts();
+	const selection = storage ? resolveCodexUsageActiveAccount(storage) : null;
+	return selection
+		? createUsageAccountFingerprint(selection.account)
+		: undefined;
 }
 
 async function refreshQuotaStatusInner(
@@ -133,6 +170,11 @@ async function refreshQuotaStatusInner(
 		const selection = resolveCodexUsageActiveAccount(storage);
 		if (!selection) return { type: "missing" };
 		const fingerprint = createUsageAccountFingerprint(selection.account);
+		const shared = await readSharedQuotaStatus(api, fingerprint);
+		if (shared) {
+			writeStoredQuotaStatus(api, shared);
+			return toCompactQuotaStatus(shared, false);
+		}
 		const cached = readStoredQuotaStatus(api, fingerprint);
 		const now = Date.now();
 
@@ -157,12 +199,21 @@ async function refreshQuotaStatusInner(
 				toCompactQuotaLimit(usage.primary),
 				toCompactQuotaLimit(usage.secondary),
 			].filter((limit): limit is CompactQuotaLimit => Boolean(limit));
-			const stored: StoredQuotaStatus = {
+			const stored = createTuiQuotaSnapshot({
 				fingerprint,
-				fetchedAt: now,
+				source: "usage",
+				accountIndex: selection.index + 1,
+				accountCount: storage.accounts.length,
+				accountLabel: formatTuiAccountLabel(
+					selection.account,
+					selection.index,
+				),
+				planType: usage.planType ?? undefined,
 				limits,
-			};
+				fetchedAt: now,
+			});
 			writeStoredQuotaStatus(api, stored);
+			await writeSharedQuotaStatus(api, stored);
 			return toCompactQuotaStatus(stored, false);
 		} catch {
 			return cached ? toCompactQuotaStatus(cached, true) : { type: "unavailable" };
@@ -212,9 +263,15 @@ function createPromptStatus(
 	const [quota, setQuota] = solid.createSignal<CompactQuotaStatus>({
 		type: "loading",
 	});
+	let currentFingerprint: string | undefined;
+	const applyQuota = (next: CompactQuotaStatus): void => {
+		if (next.type === "ready") currentFingerprint = next.fingerprint;
+		if (next.type === "missing") currentFingerprint = undefined;
+		setQuota(next);
+	};
 	const refresh = (): void => {
-		void refreshQuotaStatus(api).then(setQuota, () => {
-			setQuota({ type: "unavailable" });
+		void refreshQuotaStatus(api).then(applyQuota, () => {
+			applyQuota({ type: "unavailable" });
 		});
 	};
 	let refreshTimeout: ReturnType<typeof setTimeout> | undefined;
@@ -228,6 +285,14 @@ function createPromptStatus(
 
 	refresh();
 	const interval = setInterval(refresh, REFRESH_INTERVAL_MS);
+	const accountInterval = setInterval(() => {
+		void resolveActiveQuotaFingerprint().then((fingerprint) => {
+			if (fingerprint === currentFingerprint) return;
+			currentFingerprint = fingerprint;
+			setQuota({ type: "loading" });
+			refresh();
+		});
+	}, ACCOUNT_POLL_INTERVAL_MS);
 	const disposeMessageUpdated = api.event.on("message.updated", (event) => {
 		if (shouldRefreshQuotaForEvent(event)) scheduleRefresh();
 	});
@@ -248,6 +313,7 @@ function createPromptStatus(
 	});
 	solid.onCleanup(() => {
 		clearInterval(interval);
+		clearInterval(accountInterval);
 		if (refreshTimeout) clearTimeout(refreshTimeout);
 		disposeMessageUpdated();
 		disposeMessagePartUpdated();
@@ -268,9 +334,13 @@ function createPromptStatus(
 			},
 			get fg() {
 				const current = quota();
-				return current.type === "ready"
-					? api.theme.current.textMuted
-					: api.theme.current.warning;
+				const tone = resolveQuotaPromptTone(current);
+				if (tone === "danger") return api.theme.current.error;
+				if (tone === "warning" || tone === "stale") {
+					return api.theme.current.warning;
+				}
+				if (tone === "normal") return api.theme.current.success;
+				return api.theme.current.textMuted;
 			},
 			selectable: false,
 			truncate: true,
@@ -279,6 +349,29 @@ function createPromptStatus(
 		false,
 	);
 	return node;
+}
+
+function showQuotaDetails(api: TuiPluginApi): void {
+	void refreshQuotaStatus(api).then(
+		(status) => {
+			api.ui.dialog.replace(() =>
+				api.ui.DialogAlert({
+					title: "Codex quota",
+					message: formatQuotaDetailsText(status),
+					onConfirm: () => api.ui.dialog.clear(),
+				}),
+			);
+		},
+		() => {
+			api.ui.dialog.replace(() =>
+				api.ui.DialogAlert({
+					title: "Codex quota",
+					message: formatQuotaDetailsText({ type: "unavailable" }),
+					onConfirm: () => api.ui.dialog.clear(),
+				}),
+			);
+		},
+	);
 }
 
 const module: TuiPluginModule = {
@@ -299,6 +392,17 @@ const module: TuiPluginModule = {
 				session_prompt_right: () => createPromptStatus(api, solid),
 			},
 		});
+		const disposeCommand = api.command.register(() => [
+			{
+				title: "Codex quota details",
+				value: "codex.quota.details",
+				description:
+					"Show active account usage, reset times, source, and last refresh.",
+				category: "Codex",
+				onSelect: () => showQuotaDetails(api),
+			},
+		]);
+		api.lifecycle.onDispose(disposeCommand);
 	},
 };
 

--- a/tui.ts
+++ b/tui.ts
@@ -1,4 +1,3 @@
-import type { Message } from "@opencode-ai/sdk/v2";
 import type { TuiPluginApi, TuiPluginModule } from "@opencode-ai/plugin/tui";
 import type { JSX } from "@opentui/solid";
 
@@ -15,10 +14,8 @@ import {
 } from "./lib/codex-usage.js";
 import {
 	formatPromptStatusText,
-	resolvePromptReasoningVariant,
 	type CompactQuotaLimit,
 	type CompactQuotaStatus,
-	type PromptStatusMessage,
 } from "./lib/tui-status.js";
 import { loadAccounts } from "./lib/storage.js";
 
@@ -30,10 +27,6 @@ type StoredQuotaStatus = {
 	fingerprint: string;
 	fetchedAt: number;
 	limits: CompactQuotaLimit[];
-};
-
-type StatusSlotInput = {
-	sessionID?: string;
 };
 
 type SolidRuntime = Pick<
@@ -127,35 +120,6 @@ function toCompactQuotaLimit(
 	};
 }
 
-function toPromptStatusMessage(message: Message): PromptStatusMessage {
-	if (message.role === "user") {
-		return {
-			role: "user",
-			userModel: {
-				modelID: message.model.modelID,
-				variant: message.model.variant,
-			},
-		};
-	}
-	return {
-		role: "assistant",
-		modelID: message.modelID,
-		variant: message.variant,
-	};
-}
-
-function resolveStatusMessages(
-	api: TuiPluginApi,
-	input: StatusSlotInput,
-): PromptStatusMessage[] {
-	if (!input.sessionID) return [];
-	try {
-		return api.state.session.messages(input.sessionID).map(toPromptStatusMessage);
-	} catch {
-		return [];
-	}
-}
-
 async function refreshQuotaStatusInner(
 	api: TuiPluginApi,
 ): Promise<CompactQuotaStatus> {
@@ -220,7 +184,6 @@ function refreshQuotaStatus(api: TuiPluginApi): Promise<CompactQuotaStatus> {
 
 function createPromptStatus(
 	api: TuiPluginApi,
-	input: StatusSlotInput,
 	solid: SolidRuntime,
 ): JSX.Element {
 	const [quota, setQuota] = solid.createSignal<CompactQuotaStatus>({
@@ -242,10 +205,6 @@ function createPromptStatus(
 		{
 			get content() {
 				return formatPromptStatusText({
-					variant: resolvePromptReasoningVariant({
-						messages: resolveStatusMessages(api, input),
-						config: api.state.config,
-					}),
 					quota: quota(),
 					width: api.renderer.width,
 				});
@@ -279,9 +238,8 @@ const module: TuiPluginModule = {
 
 		api.slots.register({
 			slots: {
-				home_prompt_right: () => createPromptStatus(api, {}, solid),
-				session_prompt_right: (_ctx, props) =>
-					createPromptStatus(api, { sessionID: props.session_id }, solid),
+				home_prompt_right: () => createPromptStatus(api, solid),
+				session_prompt_right: () => createPromptStatus(api, solid),
 			},
 		});
 	},

--- a/tui.ts
+++ b/tui.ts
@@ -6,7 +6,9 @@ import {
 	createUsageAccountFingerprint,
 	ensureCodexUsageAccessToken,
 	fetchCodexUsage,
+	formatUsageWindowLabel,
 	getUsageLeftPercent,
+	hasUsageWindow,
 	parseCodexUsagePayload,
 	resolveCodexUsageAccountId,
 	resolveCodexUsageActiveAccount,
@@ -14,20 +16,20 @@ import {
 import {
 	formatPromptStatusText,
 	resolvePromptReasoningVariant,
+	type CompactQuotaLimit,
 	type CompactQuotaStatus,
 	type PromptStatusMessage,
 } from "./lib/tui-status.js";
 import { loadAccounts } from "./lib/storage.js";
 
-const CACHE_KEY = "oc-codex-multi-auth:tui-status:v1";
+const CACHE_KEY = "oc-codex-multi-auth:tui-status:v2";
 const REFRESH_INTERVAL_MS = 5 * 60 * 1000;
 const MIN_FETCH_INTERVAL_MS = 2 * 60 * 1000;
 
 type StoredQuotaStatus = {
 	fingerprint: string;
 	fetchedAt: number;
-	primaryLeftPercent: number | null;
-	secondaryLeftPercent: number | null;
+	limits: CompactQuotaLimit[];
 };
 
 type StatusSlotInput = {
@@ -56,14 +58,23 @@ function isNullablePercent(value: unknown): value is number | null {
 	);
 }
 
+function isStoredQuotaLimit(value: unknown): value is CompactQuotaLimit {
+	return (
+		isRecord(value) &&
+		typeof value.label === "string" &&
+		value.label.trim().length > 0 &&
+		isNullablePercent(value.leftPercent)
+	);
+}
+
 function isStoredQuotaStatus(value: unknown): value is StoredQuotaStatus {
 	return (
 		isRecord(value) &&
 		typeof value.fingerprint === "string" &&
 		typeof value.fetchedAt === "number" &&
 		Number.isFinite(value.fetchedAt) &&
-		isNullablePercent(value.primaryLeftPercent) &&
-		isNullablePercent(value.secondaryLeftPercent)
+		Array.isArray(value.limits) &&
+		value.limits.every(isStoredQuotaLimit)
 	);
 }
 
@@ -101,9 +112,18 @@ function toCompactQuotaStatus(
 ): CompactQuotaStatus {
 	return {
 		type: "ready",
-		primaryLeftPercent: stored.primaryLeftPercent,
-		secondaryLeftPercent: stored.secondaryLeftPercent,
+		limits: stored.limits,
 		stale,
+	};
+}
+
+function toCompactQuotaLimit(
+	window: { usedPercent?: number; windowMinutes?: number },
+): CompactQuotaLimit | undefined {
+	if (!hasUsageWindow(window)) return undefined;
+	return {
+		label: formatUsageWindowLabel(window.windowMinutes),
+		leftPercent: getUsageLeftPercent(window.usedPercent) ?? null,
 	};
 }
 
@@ -171,12 +191,14 @@ async function refreshQuotaStatusInner(
 				organizationId: selection.account.organizationId,
 			});
 			const usage = parseCodexUsagePayload(payload);
+			const limits = [
+				toCompactQuotaLimit(usage.primary),
+				toCompactQuotaLimit(usage.secondary),
+			].filter((limit): limit is CompactQuotaLimit => Boolean(limit));
 			const stored: StoredQuotaStatus = {
 				fingerprint,
 				fetchedAt: now,
-				primaryLeftPercent: getUsageLeftPercent(usage.primary.usedPercent) ?? null,
-				secondaryLeftPercent:
-					getUsageLeftPercent(usage.secondary.usedPercent) ?? null,
+				limits,
 			};
 			writeStoredQuotaStatus(api, stored);
 			return toCompactQuotaStatus(stored, false);

--- a/tui.ts
+++ b/tui.ts
@@ -90,10 +90,25 @@ function toCompactQuotaStatus(
 		fingerprint: stored.fingerprint,
 		accountIndex: stored.accountIndex,
 		accountCount: stored.accountCount,
+		accountEmail: stored.accountEmail,
 		accountLabel: stored.accountLabel,
 		planType: stored.planType,
 		activeLimit: stored.activeLimit,
 	};
+}
+
+function getQuotaSnapshotRevision(snapshot: {
+	source?: string;
+	fetchedAt?: number;
+}): string | undefined {
+	if (
+		!snapshot.source ||
+		typeof snapshot.fetchedAt !== "number" ||
+		!Number.isFinite(snapshot.fetchedAt)
+	) {
+		return undefined;
+	}
+	return `${snapshot.source}:${snapshot.fetchedAt}`;
 }
 
 function toCompactQuotaLimit(
@@ -204,6 +219,7 @@ async function refreshQuotaStatusInner(
 				source: "usage",
 				accountIndex: selection.index + 1,
 				accountCount: storage.accounts.length,
+				accountEmail: selection.account.email?.trim() || undefined,
 				accountLabel: formatTuiAccountLabel(
 					selection.account,
 					selection.index,
@@ -264,9 +280,16 @@ function createPromptStatus(
 		type: "loading",
 	});
 	let currentFingerprint: string | undefined;
+	let currentSnapshotRevision: string | undefined;
 	const applyQuota = (next: CompactQuotaStatus): void => {
-		if (next.type === "ready") currentFingerprint = next.fingerprint;
-		if (next.type === "missing") currentFingerprint = undefined;
+		if (next.type === "ready") {
+			currentFingerprint = next.fingerprint;
+			currentSnapshotRevision = getQuotaSnapshotRevision(next);
+		}
+		if (next.type === "missing") {
+			currentFingerprint = undefined;
+			currentSnapshotRevision = undefined;
+		}
 		setQuota(next);
 	};
 	const refresh = (): void => {
@@ -285,14 +308,37 @@ function createPromptStatus(
 
 	refresh();
 	const interval = setInterval(refresh, REFRESH_INTERVAL_MS);
-	const accountInterval = setInterval(() => {
-		void resolveActiveQuotaFingerprint().then((fingerprint) => {
-			if (fingerprint === currentFingerprint) return;
-			currentFingerprint = fingerprint;
-			setQuota({ type: "loading" });
-			refresh();
+	let cachePollInFlight = false;
+	const pollSharedQuotaCache = (): void => {
+		if (cachePollInFlight) return;
+		cachePollInFlight = true;
+		void (async () => {
+			const fingerprint = await resolveActiveQuotaFingerprint();
+			if (!fingerprint) {
+				if (currentFingerprint) applyQuota({ type: "missing" });
+				return;
+			}
+			if (fingerprint !== currentFingerprint) {
+				currentFingerprint = fingerprint;
+				currentSnapshotRevision = undefined;
+				setQuota({ type: "loading" });
+				refresh();
+				return;
+			}
+			const shared = await readSharedQuotaStatus(api, fingerprint);
+			if (!shared) return;
+			const revision = getQuotaSnapshotRevision(shared);
+			if (!revision || revision === currentSnapshotRevision) return;
+			writeStoredQuotaStatus(api, shared);
+			applyQuota(toCompactQuotaStatus(shared, false));
+		})().finally(() => {
+			cachePollInFlight = false;
 		});
-	}, ACCOUNT_POLL_INTERVAL_MS);
+	};
+	const accountInterval = setInterval(
+		pollSharedQuotaCache,
+		ACCOUNT_POLL_INTERVAL_MS,
+	);
 	const disposeMessageUpdated = api.event.on("message.updated", (event) => {
 		if (shouldRefreshQuotaForEvent(event)) scheduleRefresh();
 	});

--- a/tui.ts
+++ b/tui.ts
@@ -1,0 +1,268 @@
+import type { Message } from "@opencode-ai/sdk/v2";
+import type { TuiPluginApi, TuiPluginModule } from "@opencode-ai/plugin/tui";
+import type { JSX } from "@opentui/solid";
+
+import {
+	createUsageAccountFingerprint,
+	ensureCodexUsageAccessToken,
+	fetchCodexUsage,
+	getUsageLeftPercent,
+	parseCodexUsagePayload,
+	resolveCodexUsageAccountId,
+	resolveCodexUsageActiveAccount,
+} from "./lib/codex-usage.js";
+import {
+	formatPromptStatusText,
+	resolvePromptReasoningVariant,
+	type CompactQuotaStatus,
+	type PromptStatusMessage,
+} from "./lib/tui-status.js";
+import { loadAccounts } from "./lib/storage.js";
+
+const CACHE_KEY = "oc-codex-multi-auth:tui-status:v1";
+const REFRESH_INTERVAL_MS = 5 * 60 * 1000;
+const MIN_FETCH_INTERVAL_MS = 2 * 60 * 1000;
+
+type StoredQuotaStatus = {
+	fingerprint: string;
+	fetchedAt: number;
+	primaryLeftPercent: number | null;
+	secondaryLeftPercent: number | null;
+};
+
+type StatusSlotInput = {
+	sessionID?: string;
+};
+
+type SolidRuntime = Pick<
+	typeof import("@opentui/solid"),
+	"createElement" | "spread"
+> &
+	Pick<typeof import("solid-js"), "createSignal" | "onCleanup">;
+
+let inFlightRefresh: Promise<CompactQuotaStatus> | undefined;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function isNullablePercent(value: unknown): value is number | null {
+	return (
+		value === null ||
+		(typeof value === "number" &&
+			Number.isFinite(value) &&
+			value >= 0 &&
+			value <= 100)
+	);
+}
+
+function isStoredQuotaStatus(value: unknown): value is StoredQuotaStatus {
+	return (
+		isRecord(value) &&
+		typeof value.fingerprint === "string" &&
+		typeof value.fetchedAt === "number" &&
+		Number.isFinite(value.fetchedAt) &&
+		isNullablePercent(value.primaryLeftPercent) &&
+		isNullablePercent(value.secondaryLeftPercent)
+	);
+}
+
+function readStoredQuotaStatus(
+	api: TuiPluginApi,
+	fingerprint: string,
+): StoredQuotaStatus | undefined {
+	if (!api.kv.ready) return undefined;
+	try {
+		const cached = api.kv.get<unknown>(CACHE_KEY);
+		return isStoredQuotaStatus(cached) && cached.fingerprint === fingerprint
+			? cached
+			: undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+function writeStoredQuotaStatus(
+	api: TuiPluginApi,
+	status: StoredQuotaStatus,
+): void {
+	if (!api.kv.ready) return;
+	try {
+		api.kv.set(CACHE_KEY, status);
+	} catch {
+		// The prompt status is best-effort; cache write failures should not
+		// affect the OpenCode TUI.
+	}
+}
+
+function toCompactQuotaStatus(
+	stored: StoredQuotaStatus,
+	stale: boolean,
+): CompactQuotaStatus {
+	return {
+		type: "ready",
+		primaryLeftPercent: stored.primaryLeftPercent,
+		secondaryLeftPercent: stored.secondaryLeftPercent,
+		stale,
+	};
+}
+
+function toPromptStatusMessage(message: Message): PromptStatusMessage {
+	if (message.role === "user") {
+		return {
+			role: "user",
+			userModel: {
+				modelID: message.model.modelID,
+				variant: message.model.variant,
+			},
+		};
+	}
+	return {
+		role: "assistant",
+		modelID: message.modelID,
+		variant: message.variant,
+	};
+}
+
+function resolveStatusMessages(
+	api: TuiPluginApi,
+	input: StatusSlotInput,
+): PromptStatusMessage[] {
+	if (!input.sessionID) return [];
+	try {
+		return api.state.session.messages(input.sessionID).map(toPromptStatusMessage);
+	} catch {
+		return [];
+	}
+}
+
+async function refreshQuotaStatusInner(
+	api: TuiPluginApi,
+): Promise<CompactQuotaStatus> {
+	try {
+		const storage = await loadAccounts();
+		if (!storage || storage.accounts.length === 0) {
+			return { type: "missing" };
+		}
+
+		const selection = resolveCodexUsageActiveAccount(storage);
+		if (!selection) return { type: "missing" };
+		const fingerprint = createUsageAccountFingerprint(selection.account);
+		const cached = readStoredQuotaStatus(api, fingerprint);
+		const now = Date.now();
+		if (cached && now - cached.fetchedAt < MIN_FETCH_INTERVAL_MS) {
+			return toCompactQuotaStatus(cached, false);
+		}
+
+		try {
+			const credentials = await ensureCodexUsageAccessToken({
+				storage,
+				account: selection.account,
+			});
+			const accountId = resolveCodexUsageAccountId({
+				account: selection.account,
+				accessToken: credentials.accessToken,
+			});
+			if (!accountId) throw new Error("Missing account id");
+
+			const payload = await fetchCodexUsage({
+				accountId,
+				accessToken: credentials.accessToken,
+				organizationId: selection.account.organizationId,
+			});
+			const usage = parseCodexUsagePayload(payload);
+			const stored: StoredQuotaStatus = {
+				fingerprint,
+				fetchedAt: now,
+				primaryLeftPercent: getUsageLeftPercent(usage.primary.usedPercent) ?? null,
+				secondaryLeftPercent:
+					getUsageLeftPercent(usage.secondary.usedPercent) ?? null,
+			};
+			writeStoredQuotaStatus(api, stored);
+			return toCompactQuotaStatus(stored, false);
+		} catch {
+			return cached ? toCompactQuotaStatus(cached, true) : { type: "unavailable" };
+		}
+	} catch {
+		return { type: "unavailable" };
+	}
+}
+
+function refreshQuotaStatus(api: TuiPluginApi): Promise<CompactQuotaStatus> {
+	if (inFlightRefresh) return inFlightRefresh;
+	inFlightRefresh = refreshQuotaStatusInner(api).finally(() => {
+		inFlightRefresh = undefined;
+	});
+	return inFlightRefresh;
+}
+
+function createPromptStatus(
+	api: TuiPluginApi,
+	input: StatusSlotInput,
+	solid: SolidRuntime,
+): JSX.Element {
+	const [quota, setQuota] = solid.createSignal<CompactQuotaStatus>({
+		type: "loading",
+	});
+	const refresh = (): void => {
+		void refreshQuotaStatus(api).then(setQuota, () => {
+			setQuota({ type: "unavailable" });
+		});
+	};
+
+	refresh();
+	const interval = setInterval(refresh, REFRESH_INTERVAL_MS);
+	solid.onCleanup(() => clearInterval(interval));
+
+	const node = solid.createElement("text");
+	solid.spread(
+		node,
+		{
+			get content() {
+				return formatPromptStatusText({
+					variant: resolvePromptReasoningVariant({
+						messages: resolveStatusMessages(api, input),
+						config: api.state.config,
+					}),
+					quota: quota(),
+					width: api.renderer.width,
+				});
+			},
+			get fg() {
+				const current = quota();
+				return current.type === "ready"
+					? api.theme.current.textMuted
+					: api.theme.current.warning;
+			},
+			selectable: false,
+			truncate: true,
+			wrapMode: "none",
+		},
+		false,
+	);
+	return node;
+}
+
+const module: TuiPluginModule = {
+	id: "oc-codex-multi-auth.status",
+	async tui(api) {
+		const [{ createElement, spread }, { createSignal, onCleanup }] =
+			await Promise.all([import("@opentui/solid"), import("solid-js")]);
+		const solid: SolidRuntime = {
+			createElement,
+			spread,
+			createSignal,
+			onCleanup,
+		};
+
+		api.slots.register({
+			slots: {
+				home_prompt_right: () => createPromptStatus(api, {}, solid),
+				session_prompt_right: (_ctx, props) =>
+					createPromptStatus(api, { sessionID: props.session_id }, solid),
+			},
+		});
+	},
+};
+
+export default module;

--- a/tui.ts
+++ b/tui.ts
@@ -434,7 +434,6 @@ const module: TuiPluginModule = {
 
 		api.slots.register({
 			slots: {
-				home_prompt_right: () => createPromptStatus(api, solid),
 				session_prompt_right: () => createPromptStatus(api, solid),
 			},
 		});

--- a/tui.ts
+++ b/tui.ts
@@ -1,4 +1,5 @@
 import type { TuiPluginApi, TuiPluginModule } from "@opencode-ai/plugin/tui";
+import type { Event } from "@opencode-ai/sdk/v2";
 import type { JSX } from "@opentui/solid";
 
 import {
@@ -21,7 +22,7 @@ import { loadAccounts } from "./lib/storage.js";
 
 const CACHE_KEY = "oc-codex-multi-auth:tui-status:v2";
 const REFRESH_INTERVAL_MS = 5 * 60 * 1000;
-const MIN_FETCH_INTERVAL_MS = 2 * 60 * 1000;
+const EVENT_REFRESH_DEBOUNCE_MS = 750;
 
 type StoredQuotaStatus = {
 	fingerprint: string;
@@ -134,9 +135,6 @@ async function refreshQuotaStatusInner(
 		const fingerprint = createUsageAccountFingerprint(selection.account);
 		const cached = readStoredQuotaStatus(api, fingerprint);
 		const now = Date.now();
-		if (cached && now - cached.fetchedAt < MIN_FETCH_INTERVAL_MS) {
-			return toCompactQuotaStatus(cached, false);
-		}
 
 		try {
 			const credentials = await ensureCodexUsageAccessToken({
@@ -182,6 +180,31 @@ function refreshQuotaStatus(api: TuiPluginApi): Promise<CompactQuotaStatus> {
 	return inFlightRefresh;
 }
 
+export function shouldRefreshQuotaForEvent(event: Event): boolean {
+	switch (event.type) {
+		case "message.updated":
+			return (
+				event.properties.info.role === "assistant" &&
+				typeof event.properties.info.time.completed === "number"
+			);
+		case "message.part.updated": {
+			const { part } = event.properties;
+			if (part.type === "step-finish") return true;
+			if (part.type !== "tool") return false;
+			return (
+				part.state.status === "completed" || part.state.status === "error"
+			);
+		}
+		case "session.idle":
+		case "session.error":
+			return true;
+		case "session.status":
+			return event.properties.status.type === "idle";
+		default:
+			return false;
+	}
+}
+
 function createPromptStatus(
 	api: TuiPluginApi,
 	solid: SolidRuntime,
@@ -194,10 +217,44 @@ function createPromptStatus(
 			setQuota({ type: "unavailable" });
 		});
 	};
+	let refreshTimeout: ReturnType<typeof setTimeout> | undefined;
+	const scheduleRefresh = (): void => {
+		if (refreshTimeout) clearTimeout(refreshTimeout);
+		refreshTimeout = setTimeout(() => {
+			refreshTimeout = undefined;
+			refresh();
+		}, EVENT_REFRESH_DEBOUNCE_MS);
+	};
 
 	refresh();
 	const interval = setInterval(refresh, REFRESH_INTERVAL_MS);
-	solid.onCleanup(() => clearInterval(interval));
+	const disposeMessageUpdated = api.event.on("message.updated", (event) => {
+		if (shouldRefreshQuotaForEvent(event)) scheduleRefresh();
+	});
+	const disposeMessagePartUpdated = api.event.on(
+		"message.part.updated",
+		(event) => {
+			if (shouldRefreshQuotaForEvent(event)) scheduleRefresh();
+		},
+	);
+	const disposeSessionIdle = api.event.on("session.idle", (event) => {
+		if (shouldRefreshQuotaForEvent(event)) scheduleRefresh();
+	});
+	const disposeSessionStatus = api.event.on("session.status", (event) => {
+		if (shouldRefreshQuotaForEvent(event)) scheduleRefresh();
+	});
+	const disposeSessionError = api.event.on("session.error", (event) => {
+		if (shouldRefreshQuotaForEvent(event)) scheduleRefresh();
+	});
+	solid.onCleanup(() => {
+		clearInterval(interval);
+		if (refreshTimeout) clearTimeout(refreshTimeout);
+		disposeMessageUpdated();
+		disposeMessagePartUpdated();
+		disposeSessionIdle();
+		disposeSessionStatus();
+		disposeSessionError();
+	});
 
 	const node = solid.createElement("text");
 	solid.spread(


### PR DESCRIPTION
## Summary
- adds a separate OpenCode TUI plugin export for the prompt-right status indicator
- shows compact reasoning variant plus remaining 5h/weekly quota beside the model label
- reuses the codex-limits usage parser/fetch path and installs the TUI plugin into tui.json

## Validation
- npm run typecheck
- npm run lint
- npm test
- npm run build
- npm pack --dry-run
- node import smoke test for ./dist/tui.js

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Codex quota status now displays in TUI with real-time remaining usage, limits, and reset times
  * Quota information updates automatically and can be viewed in detail via a command
  * Added quota caching for improved performance

* **Tests**
  * Added comprehensive test coverage for new quota display, caching, and configuration features

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

this pr adds a new `tui.ts` plugin export that displays real-time codex quota in the opencode `session_prompt_right` slot, backed by a shared disk cache (`tui-quota-cache.ts`) updated from response headers on every api call. inline usage logic from `codex-limits.ts` is cleanly extracted into `lib/codex-usage.ts` and reused by both paths.

<h3>Confidence Score: 5/5</h3>

safe to merge — all remaining findings are p2 style/cleanup; no correctness bugs found

codex-usage.ts extraction is faithful, atomic writes use the established windows-retry helper, the header parse path is fire-and-forget with full error suppression, and the duplicate function copies are cosmetic

tui.ts (1Hz disk polling, module-level inFlightRefresh, missing integration test coverage) and lib/tui-quota-cache.ts (formatWindowLabel duplication)

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| tui.ts | new TUI plugin entry point — quota polling, shared disk-cache read path, event-driven refresh, session_prompt_right slot registration; module-level inFlightRefresh and 1Hz disk reads warrant attention |
| lib/tui-quota-cache.ts | new shared disk cache — atomic writes with windows retry, dedup write skipping, robust JSON validation; formatWindowLabel duplicates formatUsageWindowLabel from codex-usage.ts |
| lib/tui-status.ts | new TUI status formatters — width-adaptive candidate selection for prompt-right text, tone resolution, details view; formatReset duplicates formatUsageReset from codex-usage.ts |
| lib/codex-usage.ts | new shared module extracted from codex-limits.ts — usage fetch, token refresh, fingerprinting, payload parsing; clean extraction |
| lib/tools/codex-limits.ts | ~370 lines of inline usage logic removed and replaced with calls to shared codex-usage.ts; functional parity preserved |
| lib/tools/codex-switch.ts | clears TUI quota cache after account switch so prompt status immediately reflects the new account |
| index.ts | hooks recordPromptQuotaHeaders (fire-and-forget) and clearPromptQuotaCache into the fetch/account-removal paths; errors caught and debug-logged |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant API as Codex API
    participant idx as index.ts (plugin)
    participant cache as tui-quota-cache.ts
    participant tui as tui.ts (TUI plugin)
    participant slot as session_prompt_right slot

    idx->>API: fetch (completion request)
    API-->>idx: response + x-codex-* headers
    idx->>cache: parseTuiQuotaSnapshotFromHeaders()
    cache-->>idx: TuiQuotaSnapshot
    idx->>cache: writeTuiQuotaSnapshot() [atomic rename, windows retry]

    tui->>tui: pollSharedQuotaCache() [1Hz]
    tui->>cache: readTuiQuotaSnapshot()
    cache-->>tui: TuiQuotaSnapshot (fingerprint matched)
    tui->>slot: applyQuota() then formatPromptStatusText()

    tui->>API: refreshQuotaStatusInner() [5min or event-driven]
    API-->>tui: UsagePayload
    tui->>cache: writeTuiQuotaSnapshot() [source: usage]
    tui->>slot: update prompt-right text + fg color (tone)
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Foc-codex-multi-auth%22%20on%20the%20existing%20branch%20%22codex%2Fopencode-tui-status-bar%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Fopencode-tui-status-bar%22.%0A%0AFix%20the%20following%205%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%205%0Alib%2Ftui-quota-cache.ts%3A107-118%0A**duplicate%20%60formatWindowLabel%60%20%E2%80%94%20import%20from%20%60codex-usage.ts%60%20instead**%0A%0A%60lib%2Ftui-quota-cache.ts%60%20defines%20a%20private%20%60formatWindowLabel%60%20that%20is%20byte-for-byte%20identical%20to%20the%20already-exported%20%60formatUsageWindowLabel%60%20in%20%60lib%2Fcodex-usage.ts%60.%20having%20two%20copies%20means%20future%20changes%20to%20the%20label%20logic%20only%20get%20applied%20in%20one%20place%20%E2%80%94%20e.g.%20adding%20a%20new%20magnitude%20bucket%20would%20silently%20miss%20the%20header-parsed%20path.%0A%0A%23%23%23%20Issue%202%20of%205%0Alib%2Ftui-status.ts%3A345-367%0A**%60formatReset%60%20duplicates%20%60formatUsageReset%60%20from%20%60codex-usage.ts%60**%0A%0Athe%20%60formatReset%60%20function%20here%20is%20identical%20to%20%60formatUsageReset%60%20already%20exported%20from%20%60lib%2Fcodex-usage.ts%60.%20%60tui-status.ts%60%20could%20import%20it%20directly%20to%20avoid%20divergence%20risk.%20%60formatResetTime%60%20%28time-only%2C%20no%20date%29%20is%20genuinely%20new%20and%20fine%20as-is.%0A%0A%23%23%23%20Issue%203%20of%205%0Atui.ts%3A311-341%0A**1Hz%20%60loadAccounts%28%29%60%20disk%20read%20%E2%80%94%20windows%20i%2Fo%20risk**%0A%0A%60pollSharedQuotaCache%60%20fires%20every%20%60ACCOUNT_POLL_INTERVAL_MS%20%3D%201_000%60%20ms%20and%20calls%20%60resolveActiveQuotaFingerprint%28%29%60%20%E2%86%92%20%60loadAccounts%28%29%60%2C%20a%20json%20file%20read.%20on%20windows%2C%20frequent%20reads%20against%20a%20path%20the%20main%20plugin%20process%20may%20also%20be%20writing%20to%20can%20hit%20sharing-mode%20conflicts%20or%20antivirus-induced%20delays.%20consider%20raising%20the%20interval%20to%203%E2%80%935%20s%20or%20debouncing%20after%20a%20successful%20shared-cache%20hit.%0A%0A%23%23%23%20Issue%204%20of%205%0Atui.ts%3A176-240%0A**missing%20vitest%20coverage%20for%20shared-cache%20read%20path%20in%20%60refreshQuotaStatusInner%60**%0A%0Athe%20%60shared%20%3D%20await%20readSharedQuotaStatus%28api%2C%20fingerprint%29%60%20branch%20%E2%80%94%20where%20a%20valid%20snapshot%20is%20found%20on%20disk%20and%20returned%20without%20a%20network%20call%20%E2%80%94%20has%20no%20unit%20test.%20a%20lightweight%20%60TuiPluginApi%60%20stub%20would%20protect%20the%20fingerprint-matching%20and%20stale-fallback%20logic.%0A%0A%23%23%23%20Issue%205%20of%205%0Atui.ts%3A46-48%0A**concurrency%20note%3A%20module-level%20%60inFlightRefresh%60%20shared%20across%20all%20%60createPromptStatus%60%20instances**%0A%0A%60inFlightRefresh%60%20is%20a%20module-level%20singleton.%20if%20%60createPromptStatus%60%20is%20ever%20mounted%20twice%20in%20the%20same%20process%20%28test%20fixture%2C%20hot-reload%29%2C%20the%20second%20call%20reuses%20a%20pending%20promise%20from%20the%20first%20instance's%20%60api%60%20context.%20worth%20a%20comment%20%E2%80%94%20stale%20%60applyQuota%60%20closures%20from%20disposed%20instances%20can%20still%20fire%20when%20the%20shared%20promise%20settles.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: lib/tui-quota-cache.ts
Line: 107-118

Comment:
**duplicate `formatWindowLabel` — import from `codex-usage.ts` instead**

`lib/tui-quota-cache.ts` defines a private `formatWindowLabel` that is byte-for-byte identical to the already-exported `formatUsageWindowLabel` in `lib/codex-usage.ts`. having two copies means future changes to the label logic only get applied in one place — e.g. adding a new magnitude bucket would silently miss the header-parsed path.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: lib/tui-status.ts
Line: 345-367

Comment:
**`formatReset` duplicates `formatUsageReset` from `codex-usage.ts`**

the `formatReset` function here is identical to `formatUsageReset` already exported from `lib/codex-usage.ts`. `tui-status.ts` could import it directly to avoid divergence risk. `formatResetTime` (time-only, no date) is genuinely new and fine as-is.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: tui.ts
Line: 311-341

Comment:
**1Hz `loadAccounts()` disk read — windows i/o risk**

`pollSharedQuotaCache` fires every `ACCOUNT_POLL_INTERVAL_MS = 1_000` ms and calls `resolveActiveQuotaFingerprint()` → `loadAccounts()`, a json file read. on windows, frequent reads against a path the main plugin process may also be writing to can hit sharing-mode conflicts or antivirus-induced delays. consider raising the interval to 3–5 s or debouncing after a successful shared-cache hit.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: tui.ts
Line: 176-240

Comment:
**missing vitest coverage for shared-cache read path in `refreshQuotaStatusInner`**

the `shared = await readSharedQuotaStatus(api, fingerprint)` branch — where a valid snapshot is found on disk and returned without a network call — has no unit test. a lightweight `TuiPluginApi` stub would protect the fingerprint-matching and stale-fallback logic.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: tui.ts
Line: 46-48

Comment:
**concurrency note: module-level `inFlightRefresh` shared across all `createPromptStatus` instances**

`inFlightRefresh` is a module-level singleton. if `createPromptStatus` is ever mounted twice in the same process (test fixture, hot-reload), the second call reuses a pending promise from the first instance's `api` context. worth a comment — stale `applyQuota` closures from disposed instances can still fire when the shared promise settles.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (3): Last reviewed commit: ["fix: avoid blocking on quota cache write..."](https://github.com/ndycode/oc-codex-multi-auth/commit/71da35ebb0fcb3707dd41899c1f51cdab09cc37b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29624514)</sub>

<!-- /greptile_comment -->