### PR TITLE
[codex] auto-refresh opencode plugin cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ What the installer does:
 - normalizes the plugin entry to `"oc-codex-multi-auth"`
 - clears the cached plugin copy so OpenCode reinstalls the latest package
 
+After install, the plugin checks npm once per day. When a newer version exists, it clears its OpenCode-managed cached package on exit; restart OpenCode and the latest package is installed automatically. Disable this with `"autoUpdate": false` in `~/.opencode/openai-codex-auth-config.json` or `CODEX_AUTH_AUTO_UPDATE=0`.
+
 By default, the installer writes the compact UI config:
 - model picker entries stay on actual OAuth model families such as `gpt-5.5` and `gpt-5.5-fast`
 - reasoning presets are selected through OpenCode's model variant picker (`none`, `low`, `medium`, `high`, `xhigh`)
@@ -86,6 +88,7 @@ OpenCode users often want the same GPT-5 and Codex model experience they use in 
 - Beginner-focused commands such as `codex-setup`, `codex-help`, `codex-doctor`, and `codex-next`
 - Interactive account switching, labeling, tagging, and backup/import commands
 - Stateless request handling with `reasoning.encrypted_content` for multi-turn sessions
+- Daily npm update detection with OpenCode cache refresh on restart
 - Request logging and troubleshooting hooks for debugging OpenCode integration issues
 
 ## Common Workflows

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -131,6 +131,7 @@ advanced settings go in `~/.opencode/openai-codex-auth-config.json`:
     "server": 2
   },
   "perProjectAccounts": true,
+  "autoUpdate": true,
   "toastDurationMs": 5000,
   "retryAllAccountsRateLimited": true,
   "retryAllAccountsMaxWaitMs": 0,
@@ -163,6 +164,7 @@ The sample above intentionally sets `"retryAllAccountsMaxRetries": 3` as a bound
 | `retryProfile` | `balanced` | retry budget profile for request classes (`conservative`, `balanced`, `aggressive`) |
 | `retryBudgetOverrides` | `{}` | optional per-class budget overrides (`authRefresh`, `network`, `server`, `rateLimitShort`, `rateLimitGlobal`, `emptyResponse`) |
 | `perProjectAccounts` | `true` | each project gets its own account storage |
+| `autoUpdate` | `true` | check npm daily and clear the OpenCode-managed plugin cache on exit when a newer version is available; restart OpenCode to install it |
 | `toastDurationMs` | `5000` | how long toast notifications stay visible (ms) |
 | `retryAllAccountsRateLimited` | `true` | wait and retry when all accounts hit rate limits |
 | `retryAllAccountsMaxWaitMs` | `0` | max wait time in ms (0 = unlimited) |
@@ -244,6 +246,7 @@ override any config with env vars:
 | `CODEX_AUTH_BEGINNER_SAFE_MODE=1` | enable beginner-safe retry behavior |
 | `CODEX_AUTH_RETRY_PROFILE=aggressive` | override retry profile (`conservative`, `balanced`, `aggressive`) |
 | `CODEX_AUTH_PER_PROJECT_ACCOUNTS=0` | disable per-project accounts |
+| `CODEX_AUTH_AUTO_UPDATE=0` | disable automatic OpenCode plugin cache refresh when npm has a newer plugin version |
 | `CODEX_AUTH_TOAST_DURATION_MS=8000` | set toast duration |
 | `CODEX_AUTH_RETRY_ALL_RATE_LIMITED=0` | disable wait-and-retry |
 | `CODEX_AUTH_RETRY_ALL_MAX_WAIT_MS=30000` | set max wait time |

--- a/index.ts
+++ b/index.ts
@@ -70,6 +70,7 @@ import {
 	getTokenRefreshSkewMs,
 	getSessionRecovery,
 	getAutoResume,
+	getAutoUpdate,
 	getToastDurationMs,
 	getPerProjectAccounts,
 	getEmptyResponseMaxRetries,
@@ -1545,6 +1546,7 @@ export const OpenAIOAuthPlugin: Plugin = async ({ client }: PluginInput) => {
 
 				const sessionRecoveryEnabled = getSessionRecovery(pluginConfig);
 				const autoResumeEnabled = getAutoResume(pluginConfig);
+				const autoUpdateEnabled = getAutoUpdate(pluginConfig);
 				const emptyResponseMaxRetries = getEmptyResponseMaxRetries(pluginConfig);
 				const emptyResponseRetryDelayMs = getEmptyResponseRetryDelayMs(pluginConfig);
 				const pidOffsetEnabled = getPidOffsetEnabled(pluginConfig);
@@ -1591,7 +1593,7 @@ export const OpenAIOAuthPlugin: Plugin = async ({ client }: PluginInput) => {
 
 			checkAndNotify(async (message, variant) => {
 				await showToast(message, variant);
-			}).catch((err) => {
+			}, { autoUpdate: autoUpdateEnabled }).catch((err) => {
 				logDebug(`Update check failed: ${err instanceof Error ? err.message : String(err)}`);
 			});
 			await runStartupPreflight();

--- a/lib/auto-update-checker.ts
+++ b/lib/auto-update-checker.ts
@@ -1,4 +1,4 @@
-import { readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
+import { readFileSync, writeFileSync, existsSync, mkdirSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { homedir } from "node:os";
 import { createLogger } from "./logger.js";
@@ -6,10 +6,13 @@ import { createLogger } from "./logger.js";
 const log = createLogger("update-checker");
 
 const PACKAGE_NAME = "oc-codex-multi-auth";
+const LEGACY_PACKAGE_NAMES = ["oc-chatgpt-multi-auth"];
 const NPM_REGISTRY_URL = `https://registry.npmjs.org/${PACKAGE_NAME}/latest`;
 const CACHE_DIR = join(homedir(), ".opencode", "cache");
 const CACHE_FILE = join(CACHE_DIR, "update-check-cache.json");
+const OPENCODE_CACHE_DIR = join(homedir(), ".cache", "opencode");
 const CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000;
+let cacheEvictionScheduled = false;
 
 interface UpdateCheckCache {
   lastCheck: number;
@@ -98,6 +101,52 @@ export interface UpdateCheckResult {
   updateCommand: string;
 }
 
+export interface CheckAndNotifyOptions {
+  autoUpdate?: boolean;
+  scheduleCacheClear?: () => boolean;
+}
+
+function getManagedPackageNames(): string[] {
+  return [PACKAGE_NAME, ...LEGACY_PACKAGE_NAMES];
+}
+
+function getManagedCachePaths(): string[] {
+  return getManagedPackageNames().flatMap((name) => [
+    join(OPENCODE_CACHE_DIR, "packages", `${name}@latest`),
+    join(OPENCODE_CACHE_DIR, "node_modules", name),
+  ]);
+}
+
+export function clearManagedOpenCodePluginCache(paths = getManagedCachePaths()): boolean {
+  let cleared = false;
+
+  for (const cachePath of paths) {
+    try {
+      if (!existsSync(cachePath)) continue;
+      rmSync(cachePath, { recursive: true, force: true });
+      cleared = true;
+      log.info("Cleared OpenCode plugin cache for update", { path: cachePath });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      log.warn("Failed to clear OpenCode plugin cache for update", {
+        path: cachePath,
+        error: message,
+      });
+    }
+  }
+
+  return cleared;
+}
+
+export function scheduleOpenCodePluginCacheClearOnExit(): boolean {
+  if (cacheEvictionScheduled) return true;
+  cacheEvictionScheduled = true;
+  process.once("exit", () => {
+    clearManagedOpenCodePluginCache();
+  });
+  return true;
+}
+
 export async function checkForUpdates(force = false): Promise<UpdateCheckResult> {
   const currentVersion = getCurrentVersion();
   const cache = loadCache();
@@ -133,6 +182,7 @@ export async function checkForUpdates(force = false): Promise<UpdateCheckResult>
 
 export async function checkAndNotify(
   showToast?: (message: string, variant: "info" | "warning") => Promise<void>,
+  options: CheckAndNotifyOptions = {},
 ): Promise<void> {
   try {
     const result = await checkForUpdates();
@@ -140,12 +190,16 @@ export async function checkAndNotify(
     if (result.hasUpdate && result.latestVersion) {
       const message = `Update available: ${PACKAGE_NAME} v${result.latestVersion} (current: v${result.currentVersion})`;
       log.info(message);
+      const autoUpdate = options.autoUpdate ?? true;
+      const scheduled = autoUpdate
+        ? (options.scheduleCacheClear ?? scheduleOpenCodePluginCacheClearOnExit)()
+        : false;
 
       if (showToast) {
-        await showToast(
-          `Plugin update available: v${result.latestVersion}. Run: ${result.updateCommand}`,
-          "info",
-        );
+        const instruction = scheduled
+          ? "Restart OpenCode to install it automatically."
+          : `Run: ${result.updateCommand}`;
+        await showToast(`Plugin update available: v${result.latestVersion}. ${instruction}`, "info");
       }
     }
   } catch (error) {

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -54,6 +54,7 @@ const DEFAULT_CONFIG: PluginConfig = {
 	perProjectAccounts: true,
 	sessionRecovery: true,
 	autoResume: true,
+	autoUpdate: true,
 	parallelProbing: false,
 	parallelProbingMaxConcurrency: 2,
 	emptyResponseMaxRetries: 2,
@@ -495,6 +496,14 @@ export function getAutoResume(pluginConfig: PluginConfig): boolean {
 	return resolveBooleanSetting(
 		"CODEX_AUTH_AUTO_RESUME",
 		pluginConfig.autoResume,
+		true,
+	);
+}
+
+export function getAutoUpdate(pluginConfig: PluginConfig): boolean {
+	return resolveBooleanSetting(
+		"CODEX_AUTH_AUTO_UPDATE",
+		pluginConfig.autoUpdate,
 		true,
 	);
 }

--- a/lib/schemas.ts
+++ b/lib/schemas.ts
@@ -45,6 +45,7 @@ export const PluginConfigSchema = z.object({
 	perProjectAccounts: z.boolean().optional(),
 	sessionRecovery: z.boolean().optional(),
 	autoResume: z.boolean().optional(),
+	autoUpdate: z.boolean().optional(),
 	parallelProbing: z.boolean().optional(),
 	parallelProbingMaxConcurrency: z.number().min(1).max(5).optional(),
 	emptyResponseMaxRetries: z.number().min(0).optional(),

--- a/test/auto-update-checker.test.ts
+++ b/test/auto-update-checker.test.ts
@@ -5,6 +5,7 @@ vi.mock("node:fs", () => ({
 	writeFileSync: vi.fn(),
 	existsSync: vi.fn(),
 	mkdirSync: vi.fn(),
+	rmSync: vi.fn(),
 }));
 
 describe("auto-update-checker", () => {
@@ -12,6 +13,7 @@ describe("auto-update-checker", () => {
 	let checkForUpdates: typeof import("../lib/auto-update-checker.js").checkForUpdates;
 	let checkAndNotify: typeof import("../lib/auto-update-checker.js").checkAndNotify;
 	let clearUpdateCache: typeof import("../lib/auto-update-checker.js").clearUpdateCache;
+	let clearManagedOpenCodePluginCache: typeof import("../lib/auto-update-checker.js").clearManagedOpenCodePluginCache;
 
 	const mockPackageJson = { version: "4.12.0" };
 
@@ -21,6 +23,7 @@ describe("auto-update-checker", () => {
 		vi.setSystemTime(new Date("2026-01-30T12:00:00Z"));
 
 		fs = await import("node:fs");
+		vi.clearAllMocks();
 		vi.mocked(fs.readFileSync).mockImplementation((path: unknown) => {
 			if (String(path).includes("package.json")) {
 				return JSON.stringify(mockPackageJson);
@@ -35,6 +38,7 @@ describe("auto-update-checker", () => {
 		checkForUpdates = module.checkForUpdates;
 		checkAndNotify = module.checkAndNotify;
 		clearUpdateCache = module.clearUpdateCache;
+		clearManagedOpenCodePluginCache = module.clearManagedOpenCodePluginCache;
 	});
 
 	afterEach(() => {
@@ -233,19 +237,41 @@ describe("auto-update-checker", () => {
 	});
 
 	describe("checkAndNotify", () => {
-		it("shows toast when update available", async () => {
+		it("shows restart toast and schedules cache clear when update available", async () => {
 			vi.mocked(globalThis.fetch).mockResolvedValue({
 				ok: true,
 				json: async () => ({ version: "5.0.0" }),
 			} as Response);
 			const showToast = vi.fn().mockResolvedValue(undefined);
+			const scheduleCacheClear = vi.fn(() => true);
 
-			await checkAndNotify(showToast);
+			await checkAndNotify(showToast, { scheduleCacheClear });
 
 			expect(showToast).toHaveBeenCalledWith(
-				expect.stringContaining("v5.0.0"),
+				expect.stringContaining("Restart OpenCode to install it automatically"),
 				"info"
 			);
+			expect(scheduleCacheClear).toHaveBeenCalledOnce();
+		});
+
+		it("keeps manual update command when autoUpdate is disabled", async () => {
+			vi.mocked(globalThis.fetch).mockResolvedValue({
+				ok: true,
+				json: async () => ({ version: "5.0.0" }),
+			} as Response);
+			const showToast = vi.fn().mockResolvedValue(undefined);
+			const scheduleCacheClear = vi.fn(() => true);
+
+			await checkAndNotify(showToast, {
+				autoUpdate: false,
+				scheduleCacheClear,
+			});
+
+			expect(showToast).toHaveBeenCalledWith(
+				expect.stringContaining("Run: npm update -g"),
+				"info"
+			);
+			expect(scheduleCacheClear).not.toHaveBeenCalled();
 		});
 
 		it("does not show toast when no update", async () => {
@@ -299,6 +325,38 @@ describe("auto-update-checker", () => {
 			clearUpdateCache();
 
 			expect(fs.writeFileSync).not.toHaveBeenCalled();
+		});
+	});
+
+	describe("clearManagedOpenCodePluginCache", () => {
+		it("removes managed OpenCode package cache paths", () => {
+			vi.mocked(fs.existsSync).mockReturnValue(true);
+
+			const cleared = clearManagedOpenCodePluginCache([
+				"C:\\cache\\packages\\oc-codex-multi-auth@latest",
+				"C:\\cache\\node_modules\\oc-codex-multi-auth",
+			]);
+
+			expect(cleared).toBe(true);
+			expect(fs.rmSync).toHaveBeenCalledWith(
+				"C:\\cache\\packages\\oc-codex-multi-auth@latest",
+				{ recursive: true, force: true },
+			);
+			expect(fs.rmSync).toHaveBeenCalledWith(
+				"C:\\cache\\node_modules\\oc-codex-multi-auth",
+				{ recursive: true, force: true },
+			);
+		});
+
+		it("returns false when no managed cache paths exist", () => {
+			vi.mocked(fs.existsSync).mockReturnValue(false);
+
+			const cleared = clearManagedOpenCodePluginCache([
+				"C:\\cache\\packages\\oc-codex-multi-auth@latest",
+			]);
+
+			expect(cleared).toBe(false);
+			expect(fs.rmSync).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -125,6 +125,7 @@ vi.mock("../lib/config.js", () => ({
 	getTokenRefreshSkewMs: () => 60000,
 	getSessionRecovery: () => false,
 	getAutoResume: () => false,
+	getAutoUpdate: () => true,
 	getToastDurationMs: () => 5000,
 	getPerProjectAccounts: () => false,
 	getEmptyResponseMaxRetries: () => 2,

--- a/test/plugin-config.test.ts
+++ b/test/plugin-config.test.ts
@@ -20,6 +20,7 @@ import {
 	getRequestTransformMode,
 	getFetchTimeoutMs,
 	getStreamStallTimeoutMs,
+	getAutoUpdate,
 } from '../lib/config.js';
 import type { PluginConfig } from '../lib/types.js';
 import * as fs from 'node:fs';
@@ -63,6 +64,7 @@ describe('Plugin Configuration', () => {
 		'CODEX_AUTH_UNSUPPORTED_MODEL_POLICY',
 		'CODEX_AUTH_FALLBACK_UNSUPPORTED_MODEL',
 		'CODEX_AUTH_FALLBACK_GPT53_TO_GPT52',
+		'CODEX_AUTH_AUTO_UPDATE',
 	] as const;
 	const originalEnv: Partial<Record<(typeof envKeys)[number], string | undefined>> = {};
 
@@ -115,6 +117,7 @@ describe('Plugin Configuration', () => {
 				perProjectAccounts: true,
 				sessionRecovery: true,
 				autoResume: true,
+				autoUpdate: true,
 				parallelProbing: false,
 				parallelProbingMaxConcurrency: 2,
 				emptyResponseMaxRetries: 2,
@@ -159,6 +162,7 @@ describe('Plugin Configuration', () => {
 				perProjectAccounts: true,
 				sessionRecovery: true,
 				autoResume: true,
+				autoUpdate: true,
 				parallelProbing: false,
 				parallelProbingMaxConcurrency: 2,
 				emptyResponseMaxRetries: 2,
@@ -200,6 +204,7 @@ describe('Plugin Configuration', () => {
 				perProjectAccounts: true,
 				sessionRecovery: true,
 				autoResume: true,
+				autoUpdate: true,
 				parallelProbing: false,
 				parallelProbingMaxConcurrency: 2,
 				emptyResponseMaxRetries: 2,
@@ -252,6 +257,7 @@ describe('Plugin Configuration', () => {
 		perProjectAccounts: true,
 		sessionRecovery: true,
 		autoResume: true,
+		autoUpdate: true,
 		parallelProbing: false,
 		parallelProbingMaxConcurrency: 2,
 		emptyResponseMaxRetries: 2,
@@ -298,6 +304,7 @@ describe('Plugin Configuration', () => {
 			perProjectAccounts: true,
 			sessionRecovery: true,
 			autoResume: true,
+			autoUpdate: true,
 			parallelProbing: false,
 			parallelProbingMaxConcurrency: 2,
 			emptyResponseMaxRetries: 2,
@@ -447,6 +454,25 @@ describe('Plugin Configuration', () => {
 			expect(getFastSession({ fastSession: true })).toBe(false);
 			process.env.CODEX_AUTH_FAST_SESSION = '1';
 			expect(getFastSession({ fastSession: false })).toBe(true);
+		});
+	});
+
+	describe('getAutoUpdate', () => {
+		it('should default to true', () => {
+			delete process.env.CODEX_AUTH_AUTO_UPDATE;
+			expect(getAutoUpdate({})).toBe(true);
+		});
+
+		it('should use config value when env var not set', () => {
+			delete process.env.CODEX_AUTH_AUTO_UPDATE;
+			expect(getAutoUpdate({ autoUpdate: false })).toBe(false);
+		});
+
+		it('should prioritize env var over config', () => {
+			process.env.CODEX_AUTH_AUTO_UPDATE = '0';
+			expect(getAutoUpdate({ autoUpdate: true })).toBe(false);
+			process.env.CODEX_AUTH_AUTO_UPDATE = '1';
+			expect(getAutoUpdate({ autoUpdate: false })).toBe(true);
 		});
 	});
 

--- a/test/schemas.test.ts
+++ b/test/schemas.test.ts
@@ -51,6 +51,7 @@ describe("PluginConfigSchema", () => {
 			perProjectAccounts: true,
 			sessionRecovery: true,
 			autoResume: false,
+			autoUpdate: true,
 			fetchTimeoutMs: 60000,
 			streamStallTimeoutMs: 45000,
 		};


### PR DESCRIPTION
## Summary

- enables the existing npm update checker to trigger OpenCode-managed plugin cache refreshes on process exit
- adds an `autoUpdate` config setting plus `CODEX_AUTH_AUTO_UPDATE=0` escape hatch
- documents the restart-to-update behavior and covers the new cache-clear path in tests

## Behavior

When npm reports a newer `oc-codex-multi-auth` version, the plugin schedules removal of the managed OpenCode package cache on exit. Restarting OpenCode then installs the latest package from npm. If auto-update is disabled, the toast keeps the manual `npm update -g oc-codex-multi-auth` instruction.

## Validation

- `npm test -- test/auto-update-checker.test.ts test/plugin-config.test.ts test/schemas.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm test`

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

this pr wires the existing npm update checker into opencode's plugin cache lifecycle — when a newer version is detected, it schedules a `rmSync`-based cache eviction on `process.once("exit")` so opencode auto-reinstalls on next startup. the `autoUpdate` config flag and env escape hatch are cleanly layered using the existing `resolveBooleanSetting` pattern, consistent with the rest of the config module.

<h3>Confidence Score: 4/5</h3>

safe to merge — only p2 findings, core logic is correct and windows cache path matches opencode docs

p2s only: missing direct vitest coverage for `scheduleOpenCodePluginCacheClearOnExit` dedup behavior, and logger calls inside the `exit` handler may not flush on all platforms. no p1/p0 issues found.

lib/auto-update-checker.ts — exit handler logging and missing unit test for the dedup guard

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/auto-update-checker.ts | adds cache-clear logic and `process.once("exit")` hook; windows path for OPENCODE_CACHE_DIR matches opencode docs (`%USERPROFILE%\.cache\opencode`), but `scheduleOpenCodePluginCacheClearOnExit` lacks direct unit test coverage and logger calls inside the exit handler may not flush on all platforms |
| test/auto-update-checker.test.ts | good coverage for `clearManagedOpenCodePluginCache` and toast variants; `scheduleOpenCodePluginCacheClearOnExit` itself (dedup flag + process.once registration) is never directly exercised |
| lib/config.ts | adds `getAutoUpdate` using the existing `resolveBooleanSetting` pattern, consistent with neighboring config getters; no issues |
| index.ts | threads `autoUpdateEnabled` into `checkAndNotify` options; straightforward wiring, no issues |
| lib/schemas.ts | adds `autoUpdate: z.boolean().optional()` to PluginConfigSchema — minimal, correct change |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant OC as OpenCode startup
    participant Plugin as oc-codex-multi-auth
    participant Checker as auto-update-checker
    participant NPM as npm registry
    participant Cache as ~/.cache/opencode

    OC->>Plugin: load plugin
    Plugin->>Checker: checkAndNotify({ autoUpdate: true })
    Checker->>NPM: fetch /oc-codex-multi-auth/latest
    NPM-->>Checker: { version: x.y.z }
    alt newer version available
        Checker->>Checker: scheduleOpenCodePluginCacheClearOnExit()
        Note over Checker: registers process.once(exit, ...)
        Checker->>Plugin: showToast(Restart OpenCode to install it automatically)
    else no update
        Checker-->>Plugin: (silent)
    end
    Note over OC,Cache: user quits OpenCode
    OC->>Checker: process exit event fires
    Checker->>Cache: rmSync(packages/oc-codex-multi-auth@latest)
    Checker->>Cache: rmSync(node_modules/oc-codex-multi-auth)
    Note over OC,Cache: user restarts OpenCode - fresh install from npm
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Foc-codex-multi-auth%22%20on%20the%20existing%20branch%20%22codex%2Fauto-update-cache-refresh%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Fauto-update-cache-refresh%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Alib%2Fauto-update-checker.ts%3A141-148%0A**no%20direct%20unit%20test%20for%20%60scheduleOpenCodePluginCacheClearOnExit%60**%0A%0Athe%20dedup%20guard%20%28%60cacheEvictionScheduled%60%29%20and%20the%20%60process.once%28%22exit%22%2C%20...%29%60%20registration%20are%20never%20exercised%20directly%20%E2%80%94%20tests%20always%20inject%20a%20%60scheduleCacheClear%60%20mock%2C%20so%20the%20real%20path%20is%20untested.%20there's%20no%20coverage%20verifying%20that%20calling%20the%20function%20twice%20registers%20exactly%20one%20exit%20handler.%20at%20minimum%20a%20test%20that%20calls%20%60scheduleOpenCodePluginCacheClearOnExit%28%29%60%20twice%20and%20asserts%20%60process.once%60%20was%20called%20once%20would%20catch%20any%20future%20regression%20here.%0A%0A%23%23%23%20Issue%202%20of%202%0Alib%2Fauto-update-checker.ts%3A144-146%0A**log%20inside%20%60exit%60%20handler%20may%20not%20flush**%0A%0A%60process.on%28%22exit%22%2C%20...%29%60%20only%20supports%20synchronous%20operations%20%E2%80%94%20async%20i%2Fo%20won't%20complete%2C%20and%20if%20%60log.info%60%20%2F%20%60log.warn%60%20buffer%20writes%20to%20a%20file%20or%20network%20sink%2C%20those%20writes%20may%20be%20silently%20dropped.%20%60rmSync%60%20itself%20is%20fine%20here%2C%20but%20the%20structured%20log%20calls%20that%20follow%20it%20%28lines%20128%E2%80%93134%29%20may%20not%20reach%20disk%20on%20windows%2C%20where%20the%20flush%20behavior%20of%20stdio%20streams%20during%20process%20exit%20differs.%20consider%20using%20%60process.stderr.write%28...%29%60%20directly%20or%20omitting%20logging%20in%20the%20exit%20callback%20entirely.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: lib/auto-update-checker.ts
Line: 141-148

Comment:
**no direct unit test for `scheduleOpenCodePluginCacheClearOnExit`**

the dedup guard (`cacheEvictionScheduled`) and the `process.once("exit", ...)` registration are never exercised directly — tests always inject a `scheduleCacheClear` mock, so the real path is untested. there's no coverage verifying that calling the function twice registers exactly one exit handler. at minimum a test that calls `scheduleOpenCodePluginCacheClearOnExit()` twice and asserts `process.once` was called once would catch any future regression here.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: lib/auto-update-checker.ts
Line: 144-146

Comment:
**log inside `exit` handler may not flush**

`process.on("exit", ...)` only supports synchronous operations — async i/o won't complete, and if `log.info` / `log.warn` buffer writes to a file or network sink, those writes may be silently dropped. `rmSync` itself is fine here, but the structured log calls that follow it (lines 128–134) may not reach disk on windows, where the flush behavior of stdio streams during process exit differs. consider using `process.stderr.write(...)` directly or omitting logging in the exit callback entirely.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: auto-refresh opencode plugin cache"](https://github.com/ndycode/oc-codex-multi-auth/commit/a9b8adb49700a67fcfd6c11b08932f45b267bd87) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29690643)</sub>

<!-- /greptile_comment -->