### PR TITLE
fix: default missing function call arguments

### DIFF
--- a/lib/request/request-transformer.ts
+++ b/lib/request/request-transformer.ts
@@ -741,12 +741,21 @@ export function filterInput(
 		})
 		.map((item) => {
 			// Strip IDs from all items (Codex API stateless mode)
+			let normalizedItem = item;
 			if (item.id) {
 				const { id: _omit, ...itemWithoutId } = item;
 				void _omit;
-				return itemWithoutId as InputItem;
+				normalizedItem = itemWithoutId as InputItem;
 			}
-			return item;
+
+			if (
+				normalizedItem.type === "function_call" &&
+				(normalizedItem.arguments === undefined || normalizedItem.arguments === null)
+			) {
+				return { ...normalizedItem, arguments: "{}" } as InputItem;
+			}
+
+			return normalizedItem;
 		});
 }
 

--- a/test/request-transformer.test.ts
+++ b/test/request-transformer.test.ts
@@ -547,6 +547,20 @@ describe('Request Transformer Module', () => {
 			expect(result![1]).not.toHaveProperty('id');
 		});
 
+		it('should default missing function_call arguments to an empty JSON object', () => {
+			const input: InputItem[] = [
+				{ type: 'function_call', role: 'assistant', call_id: 'call_missing', name: 'read_file' },
+				{ type: 'function_call', role: 'assistant', call_id: 'call_null', name: 'list_files', arguments: null },
+				{ type: 'function_call', role: 'assistant', call_id: 'call_present', name: 'write_file', arguments: '{"path":"README.md"}' },
+			];
+
+			const result = filterInput(input);
+
+			expect(result![0].arguments).toBe('{}');
+			expect(result![1].arguments).toBe('{}');
+			expect(result![2].arguments).toBe('{"path":"README.md"}');
+		});
+
 		it('should return undefined for undefined input', () => {
 			expect(filterInput(undefined)).toBeUndefined();
 		});


### PR DESCRIPTION
## Summary
- Default missing or null function_call.arguments values to {} during input filtering.
- Keep existing function_call.arguments values unchanged.
- Add regression coverage for missing, null, and present arguments.

## Verification
- npm.cmd test -- --run test/request-transformer.test.ts
- npm.cmd run typecheck
- npm.cmd run build
- npm.cmd run lint

## Risk
- Low. The change only normalizes function_call input items before forwarding requests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced request transformation to normalize function call arguments when undefined or null, defaulting to empty JSON object format.

* **Tests**
  * Added comprehensive test coverage for function call argument normalization behavior and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

normalizes missing/null `function_call.arguments` to `\"{}\"` in `filterInput` before forwarding to the codex api. the fix is minimal, pure-sync, and correctly composes with the existing id-strip logic in the same `.map()` callback — no token safety or concurrency concerns introduced.

<h3>Confidence Score: 4/5</h3>

safe to merge; only p2 finding on a missing composed test case

no p0/p1 issues; single p2 for a missing vitest case covering id-strip + argument-default together. logic, ordering, and type handling are all correct.

test/request-transformer.test.ts — add the composed id+null-arguments test case before merging if you want full regression coverage

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/request/request-transformer.ts | adds null/undefined guard for function_call.arguments in filterInput; logic is correct and ordering with id-strip is safe |
| test/request-transformer.test.ts | adds three regression cases (missing, null, present arguments); missing a composed test for an item with both id and null/missing arguments |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[filterInput item] --> B{type is item_reference?}
    B -- yes --> C[filter out]
    B -- no --> D{item has id?}
    D -- yes --> E[strip id into normalizedItem]
    D -- no --> F[normalizedItem = item]
    E --> G{type is function_call AND arguments null or undefined?}
    F --> G
    G -- yes --> H[return spread with arguments defaulted to empty JSON]
    G -- no --> I[return normalizedItem unchanged]
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Foc-codex-multi-auth%22%20on%20the%20existing%20branch%20%22fix%2Ffunction-call-arguments-default%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Ffunction-call-arguments-default%22.%0A%0AFix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atest%2Frequest-transformer.test.ts%3A550-562%0A**missing%20composed-transformation%20coverage**%0A%0Athe%20test%20doesn't%20cover%20a%20%60function_call%60%20item%20that%20has%20both%20an%20%60id%60%20AND%20missing%2Fnull%20%60arguments%60.%20both%20normalizations%20%28id-strip%20%2B%20argument%20defaulting%29%20run%20in%20sequence%20in%20the%20same%20%60.map%28%29%60%20callback%2C%20so%20a%20combined%20case%20is%20worth%20a%20dedicated%20assertion%20to%20guard%20against%20future%20refactors%20breaking%20the%20ordering.%0A%0A%60%60%60ts%0Ait%28'should%20strip%20id%20AND%20default%20missing%20arguments%20on%20the%20same%20function_call%20item'%2C%20%28%29%20%3D%3E%20%7B%0A%20%20const%20input%3A%20InputItem%5B%5D%20%3D%20%5B%0A%20%20%20%20%7B%20id%3A%20'fc_1'%2C%20type%3A%20'function_call'%2C%20role%3A%20'assistant'%2C%20call_id%3A%20'call_combo'%2C%20name%3A%20'read_file'%20%7D%2C%0A%20%20%5D%3B%0A%20%20const%20result%20%3D%20filterInput%28input%29%3B%0A%20%20expect%28result!%5B0%5D%29.not.toHaveProperty%28'id'%29%3B%0A%20%20expect%28result!%5B0%5D.arguments%29.toBe%28'%7B%7D'%29%3B%0A%7D%29%3B%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: test/request-transformer.test.ts
Line: 550-562

Comment:
**missing composed-transformation coverage**

the test doesn't cover a `function_call` item that has both an `id` AND missing/null `arguments`. both normalizations (id-strip + argument defaulting) run in sequence in the same `.map()` callback, so a combined case is worth a dedicated assertion to guard against future refactors breaking the ordering.

```ts
it('should strip id AND default missing arguments on the same function_call item', () => {
  const input: InputItem[] = [
    { id: 'fc_1', type: 'function_call', role: 'assistant', call_id: 'call_combo', name: 'read_file' },
  ];
  const result = filterInput(input);
  expect(result![0]).not.toHaveProperty('id');
  expect(result![0].arguments).toBe('{}');
});
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: default missing function call argum..."](https://github.com/ndycode/oc-codex-multi-auth/commit/fefe3738982822e94720e6d7a85aae3359c9e037) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30187786)</sub>

<!-- /greptile_comment -->