### PR TITLE
[codex] fix dependency security alerts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,9 +12,9 @@
         "@napi-rs/keyring": "~1.2.0",
         "@openauthjs/openauth": "^0.4.3",
         "@opencode-ai/plugin": "^1.14.22",
-        "@opentui/core": "^0.1.99",
-        "@opentui/solid": "^0.1.99",
-        "hono": "4.12.14",
+        "@opentui/core": "0.2.6",
+        "@opentui/solid": "0.2.6",
+        "hono": "4.12.18",
         "solid-js": "^1.9.11",
         "web-tree-sitter": "^0.25.10",
         "zod": "^4.3.6"
@@ -472,13 +472,6 @@
       "engines": {
         "node": ">=18"
       }
-    },
-    "node_modules/@dimforge/rapier2d-simd-compat": {
-      "version": "0.17.3",
-      "resolved": "https://registry.npmjs.org/@dimforge/rapier2d-simd-compat/-/rapier2d-simd-compat-0.17.3.tgz",
-      "integrity": "sha512-bijvwWz6NHsNj5e5i1vtd3dU2pDhthSaTUZSh14DUGGKJfw8eMnlWZsxwHBxB/a3AXVNDjL9abuHw1k9FGR+jg==",
-      "license": "Apache-2.0",
-      "optional": true
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.27.7",
@@ -1144,562 +1137,6 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
-    "node_modules/@jimp/core": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@jimp/core/-/core-1.6.0.tgz",
-      "integrity": "sha512-EQQlKU3s9QfdJqiSrZWNTxBs3rKXgO2W+GxNXDtwchF3a4IqxDheFX1ti+Env9hdJXDiYLp2jTRjlxhPthsk8w==",
-      "license": "MIT",
-      "dependencies": {
-        "@jimp/file-ops": "1.6.0",
-        "@jimp/types": "1.6.0",
-        "@jimp/utils": "1.6.0",
-        "await-to-js": "^3.0.0",
-        "exif-parser": "^0.1.12",
-        "file-type": "^16.0.0",
-        "mime": "3"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@jimp/diff": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@jimp/diff/-/diff-1.6.0.tgz",
-      "integrity": "sha512-+yUAQ5gvRC5D1WHYxjBHZI7JBRusGGSLf8AmPRPCenTzh4PA+wZ1xv2+cYqQwTfQHU5tXYOhA0xDytfHUf1Zyw==",
-      "license": "MIT",
-      "dependencies": {
-        "@jimp/plugin-resize": "1.6.0",
-        "@jimp/types": "1.6.0",
-        "@jimp/utils": "1.6.0",
-        "pixelmatch": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@jimp/file-ops": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@jimp/file-ops/-/file-ops-1.6.0.tgz",
-      "integrity": "sha512-Dx/bVDmgnRe1AlniRpCKrGRm5YvGmUwbDzt+MAkgmLGf+jvBT75hmMEZ003n9HQI/aPnm/YKnXjg/hOpzNCpHQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@jimp/js-bmp": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@jimp/js-bmp/-/js-bmp-1.6.0.tgz",
-      "integrity": "sha512-FU6Q5PC/e3yzLyBDXupR3SnL3htU7S3KEs4e6rjDP6gNEOXRFsWs6YD3hXuXd50jd8ummy+q2WSwuGkr8wi+Gw==",
-      "license": "MIT",
-      "dependencies": {
-        "@jimp/core": "1.6.0",
-        "@jimp/types": "1.6.0",
-        "@jimp/utils": "1.6.0",
-        "bmp-ts": "^1.0.9"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@jimp/js-gif": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@jimp/js-gif/-/js-gif-1.6.0.tgz",
-      "integrity": "sha512-N9CZPHOrJTsAUoWkWZstLPpwT5AwJ0wge+47+ix3++SdSL/H2QzyMqxbcDYNFe4MoI5MIhATfb0/dl/wmX221g==",
-      "license": "MIT",
-      "dependencies": {
-        "@jimp/core": "1.6.0",
-        "@jimp/types": "1.6.0",
-        "gifwrap": "^0.10.1",
-        "omggif": "^1.0.10"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@jimp/js-jpeg": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@jimp/js-jpeg/-/js-jpeg-1.6.0.tgz",
-      "integrity": "sha512-6vgFDqeusblf5Pok6B2DUiMXplH8RhIKAryj1yn+007SIAQ0khM1Uptxmpku/0MfbClx2r7pnJv9gWpAEJdMVA==",
-      "license": "MIT",
-      "dependencies": {
-        "@jimp/core": "1.6.0",
-        "@jimp/types": "1.6.0",
-        "jpeg-js": "^0.4.4"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@jimp/js-png": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@jimp/js-png/-/js-png-1.6.0.tgz",
-      "integrity": "sha512-AbQHScy3hDDgMRNfG0tPjL88AV6qKAILGReIa3ATpW5QFjBKpisvUaOqhzJ7Reic1oawx3Riyv152gaPfqsBVg==",
-      "license": "MIT",
-      "dependencies": {
-        "@jimp/core": "1.6.0",
-        "@jimp/types": "1.6.0",
-        "pngjs": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@jimp/js-tiff": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@jimp/js-tiff/-/js-tiff-1.6.0.tgz",
-      "integrity": "sha512-zhReR8/7KO+adijj3h0ZQUOiun3mXUv79zYEAKvE0O+rP7EhgtKvWJOZfRzdZSNv0Pu1rKtgM72qgtwe2tFvyw==",
-      "license": "MIT",
-      "dependencies": {
-        "@jimp/core": "1.6.0",
-        "@jimp/types": "1.6.0",
-        "utif2": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@jimp/plugin-blit": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-blit/-/plugin-blit-1.6.0.tgz",
-      "integrity": "sha512-M+uRWl1csi7qilnSK8uxK4RJMSuVeBiO1AY0+7APnfUbQNZm6hCe0CCFv1Iyw1D/Dhb8ph8fQgm5mwM0eSxgVA==",
-      "license": "MIT",
-      "dependencies": {
-        "@jimp/types": "1.6.0",
-        "@jimp/utils": "1.6.0",
-        "zod": "^3.23.8"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@jimp/plugin-blit/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/@jimp/plugin-blur": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-blur/-/plugin-blur-1.6.0.tgz",
-      "integrity": "sha512-zrM7iic1OTwUCb0g/rN5y+UnmdEsT3IfuCXCJJNs8SZzP0MkZ1eTvuwK9ZidCuMo4+J3xkzCidRwYXB5CyGZTw==",
-      "license": "MIT",
-      "dependencies": {
-        "@jimp/core": "1.6.0",
-        "@jimp/utils": "1.6.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@jimp/plugin-circle": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-circle/-/plugin-circle-1.6.0.tgz",
-      "integrity": "sha512-xt1Gp+LtdMKAXfDp3HNaG30SPZW6AQ7dtAtTnoRKorRi+5yCJjKqXRgkewS5bvj8DEh87Ko1ydJfzqS3P2tdWw==",
-      "license": "MIT",
-      "dependencies": {
-        "@jimp/types": "1.6.0",
-        "zod": "^3.23.8"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@jimp/plugin-circle/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/@jimp/plugin-color": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-color/-/plugin-color-1.6.0.tgz",
-      "integrity": "sha512-J5q8IVCpkBsxIXM+45XOXTrsyfblyMZg3a9eAo0P7VPH4+CrvyNQwaYatbAIamSIN1YzxmO3DkIZXzRjFSz1SA==",
-      "license": "MIT",
-      "dependencies": {
-        "@jimp/core": "1.6.0",
-        "@jimp/types": "1.6.0",
-        "@jimp/utils": "1.6.0",
-        "tinycolor2": "^1.6.0",
-        "zod": "^3.23.8"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@jimp/plugin-color/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/@jimp/plugin-contain": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-contain/-/plugin-contain-1.6.0.tgz",
-      "integrity": "sha512-oN/n+Vdq/Qg9bB4yOBOxtY9IPAtEfES8J1n9Ddx+XhGBYT1/QTU/JYkGaAkIGoPnyYvmLEDqMz2SGihqlpqfzQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@jimp/core": "1.6.0",
-        "@jimp/plugin-blit": "1.6.0",
-        "@jimp/plugin-resize": "1.6.0",
-        "@jimp/types": "1.6.0",
-        "@jimp/utils": "1.6.0",
-        "zod": "^3.23.8"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@jimp/plugin-contain/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/@jimp/plugin-cover": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-cover/-/plugin-cover-1.6.0.tgz",
-      "integrity": "sha512-Iow0h6yqSC269YUJ8HC3Q/MpCi2V55sMlbkkTTx4zPvd8mWZlC0ykrNDeAy9IJegrQ7v5E99rJwmQu25lygKLA==",
-      "license": "MIT",
-      "dependencies": {
-        "@jimp/core": "1.6.0",
-        "@jimp/plugin-crop": "1.6.0",
-        "@jimp/plugin-resize": "1.6.0",
-        "@jimp/types": "1.6.0",
-        "zod": "^3.23.8"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@jimp/plugin-cover/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/@jimp/plugin-crop": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-crop/-/plugin-crop-1.6.0.tgz",
-      "integrity": "sha512-KqZkEhvs+21USdySCUDI+GFa393eDIzbi1smBqkUPTE+pRwSWMAf01D5OC3ZWB+xZsNla93BDS9iCkLHA8wang==",
-      "license": "MIT",
-      "dependencies": {
-        "@jimp/core": "1.6.0",
-        "@jimp/types": "1.6.0",
-        "@jimp/utils": "1.6.0",
-        "zod": "^3.23.8"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@jimp/plugin-crop/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/@jimp/plugin-displace": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-displace/-/plugin-displace-1.6.0.tgz",
-      "integrity": "sha512-4Y10X9qwr5F+Bo5ME356XSACEF55485j5nGdiyJ9hYzjQP9nGgxNJaZ4SAOqpd+k5sFaIeD7SQ0Occ26uIng5Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@jimp/types": "1.6.0",
-        "@jimp/utils": "1.6.0",
-        "zod": "^3.23.8"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@jimp/plugin-displace/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/@jimp/plugin-dither": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-dither/-/plugin-dither-1.6.0.tgz",
-      "integrity": "sha512-600d1RxY0pKwgyU0tgMahLNKsqEcxGdbgXadCiVCoGd6V6glyCvkNrnnwC0n5aJ56Htkj88PToSdF88tNVZEEQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@jimp/types": "1.6.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@jimp/plugin-fisheye": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-fisheye/-/plugin-fisheye-1.6.0.tgz",
-      "integrity": "sha512-E5QHKWSCBFtpgZarlmN3Q6+rTQxjirFqo44ohoTjzYVrDI6B6beXNnPIThJgPr0Y9GwfzgyarKvQuQuqCnnfbA==",
-      "license": "MIT",
-      "dependencies": {
-        "@jimp/types": "1.6.0",
-        "@jimp/utils": "1.6.0",
-        "zod": "^3.23.8"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@jimp/plugin-fisheye/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/@jimp/plugin-flip": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-flip/-/plugin-flip-1.6.0.tgz",
-      "integrity": "sha512-/+rJVDuBIVOgwoyVkBjUFHtP+wmW0r+r5OQ2GpatQofToPVbJw1DdYWXlwviSx7hvixTWLKVgRWQ5Dw862emDg==",
-      "license": "MIT",
-      "dependencies": {
-        "@jimp/types": "1.6.0",
-        "zod": "^3.23.8"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@jimp/plugin-flip/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/@jimp/plugin-hash": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-hash/-/plugin-hash-1.6.0.tgz",
-      "integrity": "sha512-wWzl0kTpDJgYVbZdajTf+4NBSKvmI3bRI8q6EH9CVeIHps9VWVsUvEyb7rpbcwVLWYuzDtP2R0lTT6WeBNQH9Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@jimp/core": "1.6.0",
-        "@jimp/js-bmp": "1.6.0",
-        "@jimp/js-jpeg": "1.6.0",
-        "@jimp/js-png": "1.6.0",
-        "@jimp/js-tiff": "1.6.0",
-        "@jimp/plugin-color": "1.6.0",
-        "@jimp/plugin-resize": "1.6.0",
-        "@jimp/types": "1.6.0",
-        "@jimp/utils": "1.6.0",
-        "any-base": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@jimp/plugin-mask": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-mask/-/plugin-mask-1.6.0.tgz",
-      "integrity": "sha512-Cwy7ExSJMZszvkad8NV8o/Z92X2kFUFM8mcDAhNVxU0Q6tA0op2UKRJY51eoK8r6eds/qak3FQkXakvNabdLnA==",
-      "license": "MIT",
-      "dependencies": {
-        "@jimp/types": "1.6.0",
-        "zod": "^3.23.8"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@jimp/plugin-mask/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/@jimp/plugin-print": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-print/-/plugin-print-1.6.0.tgz",
-      "integrity": "sha512-zarTIJi8fjoGMSI/M3Xh5yY9T65p03XJmPsuNet19K/Q7mwRU6EV2pfj+28++2PV2NJ+htDF5uecAlnGyxFN2A==",
-      "license": "MIT",
-      "dependencies": {
-        "@jimp/core": "1.6.0",
-        "@jimp/js-jpeg": "1.6.0",
-        "@jimp/js-png": "1.6.0",
-        "@jimp/plugin-blit": "1.6.0",
-        "@jimp/types": "1.6.0",
-        "parse-bmfont-ascii": "^1.0.6",
-        "parse-bmfont-binary": "^1.0.6",
-        "parse-bmfont-xml": "^1.1.6",
-        "simple-xml-to-json": "^1.2.2",
-        "zod": "^3.23.8"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@jimp/plugin-print/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/@jimp/plugin-quantize": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-quantize/-/plugin-quantize-1.6.0.tgz",
-      "integrity": "sha512-EmzZ/s9StYQwbpG6rUGBCisc3f64JIhSH+ncTJd+iFGtGo0YvSeMdAd+zqgiHpfZoOL54dNavZNjF4otK+mvlg==",
-      "license": "MIT",
-      "dependencies": {
-        "image-q": "^4.0.0",
-        "zod": "^3.23.8"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@jimp/plugin-quantize/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/@jimp/plugin-resize": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-resize/-/plugin-resize-1.6.0.tgz",
-      "integrity": "sha512-uSUD1mqXN9i1SGSz5ov3keRZ7S9L32/mAQG08wUwZiEi5FpbV0K8A8l1zkazAIZi9IJzLlTauRNU41Mi8IF9fA==",
-      "license": "MIT",
-      "dependencies": {
-        "@jimp/core": "1.6.0",
-        "@jimp/types": "1.6.0",
-        "zod": "^3.23.8"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@jimp/plugin-resize/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/@jimp/plugin-rotate": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-rotate/-/plugin-rotate-1.6.0.tgz",
-      "integrity": "sha512-JagdjBLnUZGSG4xjCLkIpQOZZ3Mjbg8aGCCi4G69qR+OjNpOeGI7N2EQlfK/WE8BEHOW5vdjSyglNqcYbQBWRw==",
-      "license": "MIT",
-      "dependencies": {
-        "@jimp/core": "1.6.0",
-        "@jimp/plugin-crop": "1.6.0",
-        "@jimp/plugin-resize": "1.6.0",
-        "@jimp/types": "1.6.0",
-        "@jimp/utils": "1.6.0",
-        "zod": "^3.23.8"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@jimp/plugin-rotate/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/@jimp/plugin-threshold": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-threshold/-/plugin-threshold-1.6.0.tgz",
-      "integrity": "sha512-M59m5dzLoHOVWdM41O8z9SyySzcDn43xHseOH0HavjsfQsT56GGCC4QzU1banJidbUrePhzoEdS42uFE8Fei8w==",
-      "license": "MIT",
-      "dependencies": {
-        "@jimp/core": "1.6.0",
-        "@jimp/plugin-color": "1.6.0",
-        "@jimp/plugin-hash": "1.6.0",
-        "@jimp/types": "1.6.0",
-        "@jimp/utils": "1.6.0",
-        "zod": "^3.23.8"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@jimp/plugin-threshold/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/@jimp/types": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@jimp/types/-/types-1.6.0.tgz",
-      "integrity": "sha512-7UfRsiKo5GZTAATxm2qQ7jqmUXP0DxTArztllTcYdyw6Xi5oT4RaoXynVtCD4UyLK5gJgkZJcwonoijrhYFKfg==",
-      "license": "MIT",
-      "dependencies": {
-        "zod": "^3.23.8"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@jimp/types/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/@jimp/utils": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@jimp/utils/-/utils-1.6.0.tgz",
-      "integrity": "sha512-gqFTGEosKbOkYF/WFj26jMHOI5OH2jeP1MmC/zbK6BF6VJBf8rIC5898dPfSzZEbSA0wbbV5slbntWVc5PKLFA==",
-      "license": "MIT",
-      "dependencies": {
-        "@jimp/types": "1.6.0",
-        "tinycolor2": "^1.6.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -2103,37 +1540,34 @@
       }
     },
     "node_modules/@opentui/core": {
-      "version": "0.1.99",
-      "resolved": "https://registry.npmjs.org/@opentui/core/-/core-0.1.99.tgz",
-      "integrity": "sha512-I3+AEgGzqNWIpWX9g2WOscSPwtQDNOm4KlBjxBWCZjLxkF07u77heWXF7OiAdhKLtNUW6TFiyt6yznqAZPdG3A==",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/@opentui/core/-/core-0.2.6.tgz",
+      "integrity": "sha512-dBpMaWVM7wtW2/2TlGPrkPjg6gOL3MVU/5XXk+U1LDJB8L4q4NeYWVdzfAVNcEvgmuuCy/cVqdY2D4ei+e7MMg==",
       "license": "MIT",
       "dependencies": {
-        "bun-ffi-structs": "0.1.2",
-        "diff": "8.0.2",
-        "jimp": "1.6.0",
+        "bun-ffi-structs": "0.2.2",
+        "diff": "9.0.0",
         "marked": "17.0.1",
+        "string-width": "7.2.0",
+        "strip-ansi": "7.1.2",
         "yoga-layout": "3.2.1"
       },
       "optionalDependencies": {
-        "@dimforge/rapier2d-simd-compat": "^0.17.3",
-        "@opentui/core-darwin-arm64": "0.1.99",
-        "@opentui/core-darwin-x64": "0.1.99",
-        "@opentui/core-linux-arm64": "0.1.99",
-        "@opentui/core-linux-x64": "0.1.99",
-        "@opentui/core-win32-arm64": "0.1.99",
-        "@opentui/core-win32-x64": "0.1.99",
-        "bun-webgpu": "0.1.5",
-        "planck": "^1.4.2",
-        "three": "0.177.0"
+        "@opentui/core-darwin-arm64": "0.2.6",
+        "@opentui/core-darwin-x64": "0.2.6",
+        "@opentui/core-linux-arm64": "0.2.6",
+        "@opentui/core-linux-x64": "0.2.6",
+        "@opentui/core-win32-arm64": "0.2.6",
+        "@opentui/core-win32-x64": "0.2.6"
       },
       "peerDependencies": {
         "web-tree-sitter": "0.25.10"
       }
     },
     "node_modules/@opentui/core-darwin-arm64": {
-      "version": "0.1.99",
-      "resolved": "https://registry.npmjs.org/@opentui/core-darwin-arm64/-/core-darwin-arm64-0.1.99.tgz",
-      "integrity": "sha512-bzVrqeX2vb5iWrc/ftOUOqeUY8XO+qSgoTwj5TXHuwagavgwD3Hpeyjx8+icnTTeM4pao0som1WR9xfye6/X5Q==",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/@opentui/core-darwin-arm64/-/core-darwin-arm64-0.2.6.tgz",
+      "integrity": "sha512-hR5nsxNj+059utzenTCF0kealUlibON6fLuebFUCGM/5kJnqa+shIh0XbUDFm0+F47vqVUgZufBdUuieQZIbvQ==",
       "cpu": [
         "arm64"
       ],
@@ -2144,9 +1578,9 @@
       ]
     },
     "node_modules/@opentui/core-darwin-x64": {
-      "version": "0.1.99",
-      "resolved": "https://registry.npmjs.org/@opentui/core-darwin-x64/-/core-darwin-x64-0.1.99.tgz",
-      "integrity": "sha512-VE4FrXBYpkxnvkqcCV1a8aN9jyyMJMihVW+V2NLCtp+4yQsj0AapG5TiUSN76XnmSZRptxDy5rBmEempeoIZbg==",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/@opentui/core-darwin-x64/-/core-darwin-x64-0.2.6.tgz",
+      "integrity": "sha512-pJ/bH4WC/mbBaakM1YdH6TVo67jhy0KPd61bCz97w0I/PJGr8fmNKvhmMt/AwyFgOQi3FYZiEKLMpGdvUcSsrQ==",
       "cpu": [
         "x64"
       ],
@@ -2157,9 +1591,9 @@
       ]
     },
     "node_modules/@opentui/core-linux-arm64": {
-      "version": "0.1.99",
-      "resolved": "https://registry.npmjs.org/@opentui/core-linux-arm64/-/core-linux-arm64-0.1.99.tgz",
-      "integrity": "sha512-viXQsbpS7yHjYkl7+am32JdvG96QU9lvHh1UiZtpOxcNUUqiYmA2ZwZFPD2Bi54jNyj5l2hjH6YkD3DzE2FEWA==",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/@opentui/core-linux-arm64/-/core-linux-arm64-0.2.6.tgz",
+      "integrity": "sha512-9Pnd3kOxig8ii+/IqYheOPEgferylsQA0L6tKBnHQ9jRlCJOcu0Rv65Jepueh212vevdV9DzPURJnhejG06J6g==",
       "cpu": [
         "arm64"
       ],
@@ -2170,9 +1604,9 @@
       ]
     },
     "node_modules/@opentui/core-linux-x64": {
-      "version": "0.1.99",
-      "resolved": "https://registry.npmjs.org/@opentui/core-linux-x64/-/core-linux-x64-0.1.99.tgz",
-      "integrity": "sha512-WLoEFINOSp0tZSR9y4LUuGc7n4Y7H1wcpjUPzQ9vChkYDXrfZltEanzoDWbDcQ4kZQW5tHVC7LrZHpAsRLwFZg==",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/@opentui/core-linux-x64/-/core-linux-x64-0.2.6.tgz",
+      "integrity": "sha512-458Mx9tBzEPzfft8cSt5ZaIpEepoxBXBOL6AUVmDTKWaZ3uouraPcEKraGAyvOTDQp2XDI3R8c/2GdaR77FaUQ==",
       "cpu": [
         "x64"
       ],
@@ -2183,9 +1617,9 @@
       ]
     },
     "node_modules/@opentui/core-win32-arm64": {
-      "version": "0.1.99",
-      "resolved": "https://registry.npmjs.org/@opentui/core-win32-arm64/-/core-win32-arm64-0.1.99.tgz",
-      "integrity": "sha512-yWMOLWCEO8HdrctU1dMkgZC8qGkiO4Dwr4/e11tTvVpRmYhDsP/IR89ZjEEtOwnKwFOFuB/MxvflqaEWVQ2g5Q==",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/@opentui/core-win32-arm64/-/core-win32-arm64-0.2.6.tgz",
+      "integrity": "sha512-BDUrdrT1RCcVnQoHJmUut4y811jDBAEtc6GJFB4Gs265Be8SrTjVCus6p2fSQ7j9sZQ1OcjO+5+4NkheSZICDQ==",
       "cpu": [
         "arm64"
       ],
@@ -2196,9 +1630,9 @@
       ]
     },
     "node_modules/@opentui/core-win32-x64": {
-      "version": "0.1.99",
-      "resolved": "https://registry.npmjs.org/@opentui/core-win32-x64/-/core-win32-x64-0.1.99.tgz",
-      "integrity": "sha512-aYRlsL2w8YRL6vPd7/hrqlNVkXU3QowWb01TOvAcHS8UAsXaGFUr47kSDyjxDi1wg1MzmVduCfsC7T3NoThV1w==",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/@opentui/core-win32-x64/-/core-win32-x64-0.2.6.tgz",
+      "integrity": "sha512-SUYAzRJ9TSoD2Qt8kn6FJz6dbTrFEPVig5mScB4zFGgGQO/Bbod2/Q31vLS/IQrX+FDb67WaErD+kuMCnMPPLA==",
       "cpu": [
         "x64"
       ],
@@ -2208,22 +1642,54 @@
         "win32"
       ]
     },
+    "node_modules/@opentui/core/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@opentui/core/node_modules/strip-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
     "node_modules/@opentui/solid": {
-      "version": "0.1.99",
-      "resolved": "https://registry.npmjs.org/@opentui/solid/-/solid-0.1.99.tgz",
-      "integrity": "sha512-DrqqO4h2V88FmeIP2cErYkMU0ZK5MrUsZw3w6IzZpoXyyiL4/9qpWzUq+CXx+r16VP2iGxDJwGKUmtFAzUch2Q==",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/@opentui/solid/-/solid-0.2.6.tgz",
+      "integrity": "sha512-2y225WlOGi/fCaajkxBmLyVW8Cr+OmhowHdvrYcz5w2kBD15sKbJLIYu1G9DxceirT1uIyasGy2TGzRRcVkTDg==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "7.28.0",
         "@babel/preset-typescript": "7.27.1",
-        "@opentui/core": "0.1.99",
+        "@opentui/core": "0.2.6",
         "babel-plugin-module-resolver": "5.0.2",
-        "babel-preset-solid": "1.9.10",
+        "babel-preset-solid": "1.9.12",
         "entities": "7.0.1",
         "s-js": "^0.4.9"
       },
       "peerDependencies": {
-        "solid-js": "1.9.11"
+        "solid-js": "1.9.12"
       }
     },
     "node_modules/@oslojs/asn1": {
@@ -2678,12 +2144,6 @@
       "version": "1.0.0-beta.3",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0-beta.3.tgz",
       "integrity": "sha512-0ifF3BjA1E8SY9C+nUew8RefNOIq0cDlYALPty4rhUm8Rrl6tCM8hBT4bhGhx7I7iXD0uAgt50lgo8dD73ACMw==",
-      "license": "MIT"
-    },
-    "node_modules/@tokenizer/token": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
-      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
       "license": "MIT"
     },
     "node_modules/@types/chai": {
@@ -3154,25 +2614,6 @@
         "url": "https://opencollective.com/vitest"
       }
     },
-    "node_modules/@webgpu/types": {
-      "version": "0.1.69",
-      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.69.tgz",
-      "integrity": "sha512-RPmm6kgRbI8e98zSD3RVACvnuktIja5+yLgDAkTmxLr90BEwdTXRQWNLF3ETTTyH/8mKhznZuN5AveXYFEsMGQ==",
-      "license": "BSD-3-Clause",
-      "optional": true
-    },
-    "node_modules/abort-controller": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
-      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-      "license": "MIT",
-      "dependencies": {
-        "event-target-shim": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=6.5"
-      }
-    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -3233,7 +2674,6 @@
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
       "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -3254,12 +2694,6 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
-    },
-    "node_modules/any-base": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/any-base/-/any-base-1.1.0.tgz",
-      "integrity": "sha512-uMgjozySS8adZZYePpaWs8cxB9/kdzmpX6SgJZ+wbz1K5eYk5QMYDVJaZKhxyIHUdnnJkfR7SVgStgH7LkGUyg==",
-      "license": "MIT"
     },
     "node_modules/arctic": {
       "version": "2.3.4",
@@ -3301,15 +2735,6 @@
       "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/await-to-js": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/await-to-js/-/await-to-js-3.0.0.tgz",
-      "integrity": "sha512-zJAaP9zxTcvTHRlejau3ZOY4V7SRpiByf3/dxx2uyKxxor19tpmpV2QRsTKikckwhaPmr2dVpxxMr7jOCYVp5g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.0.0"
-      }
     },
     "node_modules/aws4fetch": {
       "version": "1.0.20",
@@ -3359,16 +2784,16 @@
       }
     },
     "node_modules/babel-preset-solid": {
-      "version": "1.9.10",
-      "resolved": "https://registry.npmjs.org/babel-preset-solid/-/babel-preset-solid-1.9.10.tgz",
-      "integrity": "sha512-HCelrgua/Y+kqO8RyL04JBWS/cVdrtUv/h45GntgQY+cJl4eBcKkCDV3TdMjtKx1nXwRaR9QXslM/Npm1dxdZQ==",
+      "version": "1.9.12",
+      "resolved": "https://registry.npmjs.org/babel-preset-solid/-/babel-preset-solid-1.9.12.tgz",
+      "integrity": "sha512-LLqnuKVDlKpyBlMPcH6qEvs/wmS9a+NczppxJ3ryS/c0O5IiSFOIBQi9GzyiGDSbcJpx4Gr87jyFTos1MyEuWg==",
       "license": "MIT",
       "dependencies": {
-        "babel-plugin-jsx-dom-expressions": "^0.40.3"
+        "babel-plugin-jsx-dom-expressions": "^0.40.6"
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0",
-        "solid-js": "^1.9.10"
+        "solid-js": "^1.9.12"
       },
       "peerDependenciesMeta": {
         "solid-js": {
@@ -3382,26 +2807,6 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "license": "MIT"
     },
-    "node_modules/base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.21",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.21.tgz",
@@ -3413,12 +2818,6 @@
       "engines": {
         "node": ">=6.0.0"
       }
-    },
-    "node_modules/bmp-ts": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/bmp-ts/-/bmp-ts-1.0.9.tgz",
-      "integrity": "sha512-cTEHk2jLrPyi+12M3dhpEbnnPOsaZuq7C45ylbbQIiWgDFZq4UVYPEY5mlqjvsj/6gJv9qX5sa+ebDzLXT28Vw==",
-      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "2.1.0",
@@ -3462,106 +2861,14 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
-    "node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
-      }
-    },
     "node_modules/bun-ffi-structs": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/bun-ffi-structs/-/bun-ffi-structs-0.1.2.tgz",
-      "integrity": "sha512-Lh1oQAYHDcnesJauieA4UNkWGXY9hYck7OA5IaRwE3Bp6K2F2pJSNYqq+hIy7P3uOvo3km3oxS8304g5gDMl/w==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/bun-ffi-structs/-/bun-ffi-structs-0.2.2.tgz",
+      "integrity": "sha512-N/ZWtyN0piZlrXQT7TO0V+q952orYqkfhXRXM1Hcbb+R3QSiBH4vLnib187Mrs1H7pWIYECAmPeapGYDOMCl+w==",
       "license": "MIT",
       "peerDependencies": {
         "typescript": "^5"
       }
-    },
-    "node_modules/bun-webgpu": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/bun-webgpu/-/bun-webgpu-0.1.5.tgz",
-      "integrity": "sha512-91/K6S5whZKX7CWAm9AylhyKrLGRz6BUiiPiM/kXadSnD4rffljCD/q9cNFftm5YXhx4MvLqw33yEilxogJvwA==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@webgpu/types": "^0.1.60"
-      },
-      "optionalDependencies": {
-        "bun-webgpu-darwin-arm64": "^0.1.5",
-        "bun-webgpu-darwin-x64": "^0.1.5",
-        "bun-webgpu-linux-x64": "^0.1.5",
-        "bun-webgpu-win32-x64": "^0.1.5"
-      }
-    },
-    "node_modules/bun-webgpu-darwin-arm64": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/bun-webgpu-darwin-arm64/-/bun-webgpu-darwin-arm64-0.1.6.tgz",
-      "integrity": "sha512-lIsDkPzJzPl6yrB5CUOINJFPnTRv6fF/Q8J1mAr43ogSp86WZEg9XZKaT6f3EUJ+9ETogGoMnoj1q0AwHUTbAQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/bun-webgpu-darwin-x64": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/bun-webgpu-darwin-x64/-/bun-webgpu-darwin-x64-0.1.6.tgz",
-      "integrity": "sha512-uEddf5U7GvKIkM/BV18rUKtYHL6d0KeqBjNHwfqDH9QgEo9KVSKvJXS5I/sMefk5V5pIYE+8tQhtrREevhocng==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/bun-webgpu-linux-x64": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/bun-webgpu-linux-x64/-/bun-webgpu-linux-x64-0.1.6.tgz",
-      "integrity": "sha512-Y/f15j9r8ba0xUz+3lATtS74OE+PPzQXO7Do/1eCluJcuOlfa77kMjvBK/ShWnem3Y9xqi59pebTPOGRB+CaJA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/bun-webgpu-win32-x64": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/bun-webgpu-win32-x64/-/bun-webgpu-win32-x64-0.1.6.tgz",
-      "integrity": "sha512-MHSFAKqizISb+C5NfDrFe3g0Al5Njnu0j/A+oO2Q+bIWX+fUYjBSowiYE1ZXJx65KuryuB+tiM7Qh6cQbVvkEg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
     },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001790",
@@ -3704,9 +3011,9 @@
       }
     },
     "node_modules/diff": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.2.tgz",
-      "integrity": "sha512-sSuxWU5j5SR9QQji/o2qMvqRNYRDOcBTgsJ/DeCf4iSN4gW+gNMXM7wFIP+fdXZxoNiAnHUTGjCr+TSWXdRDKg==",
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.3.tgz",
+      "integrity": "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
@@ -3746,7 +3053,6 @@
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
       "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/entities": {
@@ -4091,35 +3397,12 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/event-target-shim": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/eventemitter3": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/events": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
-      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.x"
-      }
-    },
-    "node_modules/exif-parser": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/exif-parser/-/exif-parser-0.1.12.tgz",
-      "integrity": "sha512-c2bQfLNbMzLPmzQuOr8fy0csy84WmwnER81W88DzTp9CYNPJ6yzOj2EZAh9pywYpqHnshVLHQJ8WzldAyfY+Iw=="
     },
     "node_modules/expect-type": {
       "version": "1.3.0",
@@ -4210,23 +3493,6 @@
       },
       "engines": {
         "node": ">=16.0.0"
-      }
-    },
-    "node_modules/file-type": {
-      "version": "16.5.4",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-16.5.4.tgz",
-      "integrity": "sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw==",
-      "license": "MIT",
-      "dependencies": {
-        "readable-web-to-node-stream": "^3.0.0",
-        "strtok3": "^6.2.4",
-        "token-types": "^4.1.1"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/file-type?sponsor=1"
       }
     },
     "node_modules/find-babel-config": {
@@ -4325,23 +3591,12 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
       "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/gifwrap": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/gifwrap/-/gifwrap-0.10.1.tgz",
-      "integrity": "sha512-2760b1vpJHNmLzZ/ubTtNnEx5WApN/PYWJvXvgS+tL1egTTthayFYIQQNi136FLEDcN/IyEY2EcGpIITD6eYUw==",
-      "license": "MIT",
-      "dependencies": {
-        "image-q": "^4.0.0",
-        "omggif": "^1.0.10"
       }
     },
     "node_modules/glob": {
@@ -4399,9 +3654,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.14",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
-      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
+      "version": "4.12.18",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
+      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -4436,26 +3691,6 @@
         "url": "https://github.com/sponsors/typicode"
       }
     },
-    "node_modules/ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "BSD-3-Clause"
-    },
     "node_modules/ignore": {
       "version": "7.0.5",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
@@ -4465,21 +3700,6 @@
       "engines": {
         "node": ">= 4"
       }
-    },
-    "node_modules/image-q": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/image-q/-/image-q-4.0.0.tgz",
-      "integrity": "sha512-PfJGVgIfKQJuq3s0tTDOKtztksibuUEbJQIYT3by6wctQo+Rdlh7ef4evJ5NCdxY4CfMbvFkocEwbl4BF8RlJw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "16.9.1"
-      }
-    },
-    "node_modules/image-q/node_modules/@types/node": {
-      "version": "16.9.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.9.1.tgz",
-      "integrity": "sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g==",
-      "license": "MIT"
     },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
@@ -4599,44 +3819,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/jimp": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/jimp/-/jimp-1.6.0.tgz",
-      "integrity": "sha512-YcwCHw1kiqEeI5xRpDlPPBGL2EOpBKLwO4yIBJcXWHPj5PnA5urGq0jbyhM5KoNpypQ6VboSoxc9D8HyfvngSg==",
-      "license": "MIT",
-      "dependencies": {
-        "@jimp/core": "1.6.0",
-        "@jimp/diff": "1.6.0",
-        "@jimp/js-bmp": "1.6.0",
-        "@jimp/js-gif": "1.6.0",
-        "@jimp/js-jpeg": "1.6.0",
-        "@jimp/js-png": "1.6.0",
-        "@jimp/js-tiff": "1.6.0",
-        "@jimp/plugin-blit": "1.6.0",
-        "@jimp/plugin-blur": "1.6.0",
-        "@jimp/plugin-circle": "1.6.0",
-        "@jimp/plugin-color": "1.6.0",
-        "@jimp/plugin-contain": "1.6.0",
-        "@jimp/plugin-cover": "1.6.0",
-        "@jimp/plugin-crop": "1.6.0",
-        "@jimp/plugin-displace": "1.6.0",
-        "@jimp/plugin-dither": "1.6.0",
-        "@jimp/plugin-fisheye": "1.6.0",
-        "@jimp/plugin-flip": "1.6.0",
-        "@jimp/plugin-hash": "1.6.0",
-        "@jimp/plugin-mask": "1.6.0",
-        "@jimp/plugin-print": "1.6.0",
-        "@jimp/plugin-quantize": "1.6.0",
-        "@jimp/plugin-resize": "1.6.0",
-        "@jimp/plugin-rotate": "1.6.0",
-        "@jimp/plugin-threshold": "1.6.0",
-        "@jimp/types": "1.6.0",
-        "@jimp/utils": "1.6.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/jose": {
       "version": "5.9.6",
       "resolved": "https://registry.npmjs.org/jose/-/jose-5.9.6.tgz",
@@ -4645,12 +3827,6 @@
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
-    },
-    "node_modules/jpeg-js": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.4.tgz",
-      "integrity": "sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg==",
-      "license": "BSD-3-Clause"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -4900,18 +4076,6 @@
         "node": ">= 20"
       }
     },
-    "node_modules/mime": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
-      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
-      "license": "MIT",
-      "bin": {
-        "mime": "cli.js"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/mimic-function": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
@@ -5060,12 +4224,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/omggif": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/omggif/-/omggif-1.0.10.tgz",
-      "integrity": "sha512-LMJTtvgc/nugXj0Vcrrs68Mn2D1r0zf630VNtqtpI1FEO7e+O9FP4gqs9AcnBaSEeoHIPm28u6qgPR0oyEpGSw==",
-      "license": "MIT"
-    },
     "node_modules/onetime": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
@@ -5139,34 +4297,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/pako": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
-      "license": "(MIT AND Zlib)"
-    },
-    "node_modules/parse-bmfont-ascii": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/parse-bmfont-ascii/-/parse-bmfont-ascii-1.0.6.tgz",
-      "integrity": "sha512-U4RrVsUFCleIOBsIGYOMKjn9PavsGOXxbvYGtMOEfnId0SVNsgehXh1DxUdVPLoxd5mvcEtvmKs2Mmf0Mpa1ZA==",
-      "license": "MIT"
-    },
-    "node_modules/parse-bmfont-binary": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/parse-bmfont-binary/-/parse-bmfont-binary-1.0.6.tgz",
-      "integrity": "sha512-GxmsRea0wdGdYthjuUeWTMWPqm2+FAd4GI8vCvhgJsFnoGhTrLhXDDupwTo7rXVAgaLIGoVHDZS9p/5XbSqeWA==",
-      "license": "MIT"
-    },
-    "node_modules/parse-bmfont-xml": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/parse-bmfont-xml/-/parse-bmfont-xml-1.1.6.tgz",
-      "integrity": "sha512-0cEliVMZEhrFDwMh4SxIyVJpqYoOWDJ9P895tFuS+XuNzI5UBmBk5U5O4KuJdTnZpSBI4LFA2+ZiJaiwfSwlMA==",
-      "license": "MIT",
-      "dependencies": {
-        "xml-parse-from-string": "^1.0.0",
-        "xml2js": "^0.5.0"
       }
     },
     "node_modules/parse5": {
@@ -5256,19 +4386,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/peek-readable": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-4.1.0.tgz",
-      "integrity": "sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Borewit"
-      }
-    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -5286,27 +4403,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/pixelmatch": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/pixelmatch/-/pixelmatch-5.3.0.tgz",
-      "integrity": "sha512-o8mkY4E/+LNUf6LzX96ht6k6CEDi65k9G2rjMtBe9Oo+VPKSvl+0GKHuH/AlG+GA5LPG/i5hrekkxUc3s2HU+Q==",
-      "license": "ISC",
-      "dependencies": {
-        "pngjs": "^6.0.0"
-      },
-      "bin": {
-        "pixelmatch": "bin/pixelmatch"
-      }
-    },
-    "node_modules/pixelmatch/node_modules/pngjs": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-6.0.0.tgz",
-      "integrity": "sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.13.0"
       }
     },
     "node_modules/pkg-up": {
@@ -5382,28 +4478,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/planck": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/planck/-/planck-1.5.0.tgz",
-      "integrity": "sha512-dlvqJE+FscZgrGUXJ5ybd0o5bvZ5XXyZNbm08xGsXp9WjXeAyWSFT6n9s/1PQcUBo4546fDXA5RMA4wbDyZw6g==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=24.0"
-      },
-      "peerDependencies": {
-        "stage-js": "^1.0.0-alpha.12"
-      }
-    },
-    "node_modules/pngjs": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-7.0.0.tgz",
-      "integrity": "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.19.0"
-      }
-    },
     "node_modules/postcss": {
       "version": "8.5.10",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
@@ -5443,15 +4517,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/process": {
-      "version": "0.11.10",
-      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6.0"
-      }
-    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -5477,38 +4542,6 @@
         }
       ],
       "license": "MIT"
-    },
-    "node_modules/readable-stream": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
-      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
-      "license": "MIT",
-      "dependencies": {
-        "abort-controller": "^3.0.0",
-        "buffer": "^6.0.3",
-        "events": "^3.3.0",
-        "process": "^0.11.10",
-        "string_decoder": "^1.3.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
-    "node_modules/readable-web-to-node-stream": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.4.tgz",
-      "integrity": "sha512-9nX56alTf5bwXQ3ZDipHJhusu9NTQJ/CVPtb/XHAJCXihZeitfJvIRS4GqQ/mfIoOE3IelHMrpayVrosdHBuLw==",
-      "license": "MIT",
-      "dependencies": {
-        "readable-stream": "^4.7.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Borewit"
-      }
     },
     "node_modules/reselect": {
       "version": "4.1.8",
@@ -5612,35 +4645,6 @@
       "integrity": "sha512-RtpOm+cM6O0sHg6IA70wH+UC3FZcND+rccBZpBAHzlUgNO2Bm5BN+FnM8+OBxzXdwpKWFwX11JGF0MFRkhSoIQ==",
       "license": "MIT"
     },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/sax": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
-      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=11.0.0"
-      }
-    },
     "node_modules/semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
@@ -5712,15 +4716,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/simple-xml-to-json": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/simple-xml-to-json/-/simple-xml-to-json-1.2.7.tgz",
-      "integrity": "sha512-mz9VXphOxQWX3eQ/uXCtm6upltoN0DLx8Zb5T4TFC4FHB7S9FDPGre8CfLWqPWQQH/GrQYd2AXhhVM5LDpYx6Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.12.2"
-      }
-    },
     "node_modules/sirv": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.2.tgz",
@@ -5754,9 +4749,9 @@
       }
     },
     "node_modules/solid-js": {
-      "version": "1.9.11",
-      "resolved": "https://registry.npmjs.org/solid-js/-/solid-js-1.9.11.tgz",
-      "integrity": "sha512-WEJtcc5mkh/BnHA6Yrg4whlF8g6QwpmXXRg4P2ztPmcKeHHlH4+djYecBLhSpecZY2RRECXYUwIc/C2r3yzQ4Q==",
+      "version": "1.9.12",
+      "resolved": "https://registry.npmjs.org/solid-js/-/solid-js-1.9.12.tgz",
+      "integrity": "sha512-QzKaSJq2/iDrWR1As6MHZQ8fQkdOBf8GReYb7L5iKwMGceg7HxDcaOHk0at66tNgn9U2U7dXo8ZZpLIAmGMzgw==",
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.1.0",
@@ -5781,32 +4776,12 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/stage-js": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/stage-js/-/stage-js-1.0.2.tgz",
-      "integrity": "sha512-EWTRBYlg7Qv9wGUao99/PfRe3KaiQqWmgSvTOXvaWnu1Jk/q/vV8yJVu6bi/3EqDZeMVnCPAjheba6OFc5k1GQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=24.0"
-      }
-    },
     "node_modules/std-env": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
       "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
-      }
     },
     "node_modules/string-argv": {
       "version": "0.3.2",
@@ -5851,23 +4826,6 @@
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
-    "node_modules/strtok3": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-6.3.0.tgz",
-      "integrity": "sha512-fZtbhtvI9I48xDSywd/somNqgUHl2L2cstmXCCif0itOf96jeW18MBSyrLuNicYQVkvpOxkZtkzujiTJ9LW5Jw==",
-      "license": "MIT",
-      "dependencies": {
-        "@tokenizer/token": "^0.3.0",
-        "peek-readable": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Borewit"
-      }
-    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -5893,24 +4851,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/three": {
-      "version": "0.177.0",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.177.0.tgz",
-      "integrity": "sha512-EiXv5/qWAaGI+Vz2A+JfavwYCMdGjxVsrn3oBwllUoqYeaBO75J63ZfyaQKoiLrqNHoTlUc6PFgMXnS0kI45zg==",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
       "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/tinycolor2": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
-      "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==",
       "license": "MIT"
     },
     "node_modules/tinyexec": {
@@ -5948,23 +4893,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
-      }
-    },
-    "node_modules/token-types": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/token-types/-/token-types-4.2.1.tgz",
-      "integrity": "sha512-6udB24Q737UD/SDsKAHI9FCRP7Bqc9D/MQUV02ORQg5iskjtLJlZJNdN4kKtcdtwCeWIwIHDGaUsTsCCAa8sFQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@tokenizer/token": "^0.3.0",
-        "ieee754": "^1.2.1"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Borewit"
       }
     },
     "node_modules/toml": {
@@ -6085,19 +5013,10 @@
         "punycode": "^2.1.0"
       }
     },
-    "node_modules/utif2": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/utif2/-/utif2-4.1.0.tgz",
-      "integrity": "sha512-+oknB9FHrJ7oW7A2WZYajOcv4FcDR4CfoGB0dPNfxbi4GO05RRnFmt5oa23+9w32EanrYcSJWspUiJkLMs+37w==",
-      "license": "MIT",
-      "dependencies": {
-        "pako": "^1.0.11"
-      }
-    },
     "node_modules/uuid": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
-      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.1.tgz",
+      "integrity": "sha512-9ezox2roIft6ExBVTVqibSd5dc5/47Sw/uY6b4SjQUT2TzQ0tltNquWA46y4xPQmdZYqvnio22SgWd41M86+jw==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -6362,34 +5281,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/xml-parse-from-string": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/xml-parse-from-string/-/xml-parse-from-string-1.0.1.tgz",
-      "integrity": "sha512-ErcKwJTF54uRzzNMXq2X5sMIy88zJvfN2DmdoQvy7PAFJ+tPRU6ydWuOKNMyfmOjdyBQTFREi60s0Y0SyI0G0g==",
-      "license": "MIT"
-    },
-    "node_modules/xml2js": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
-      "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
-      "license": "MIT",
-      "dependencies": {
-        "sax": ">=0.6.0",
-        "xmlbuilder": "~11.0.0"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/xmlbuilder": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
-      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
       }
     },
     "node_modules/yallist": {

--- a/package.json
+++ b/package.json
@@ -121,16 +121,16 @@
     "@napi-rs/keyring": "~1.2.0",
     "@openauthjs/openauth": "^0.4.3",
     "@opencode-ai/plugin": "^1.14.22",
-    "@opentui/core": "^0.1.99",
-    "@opentui/solid": "^0.1.99",
-    "hono": "4.12.14",
+    "@opentui/core": "0.2.6",
+    "@opentui/solid": "0.2.6",
+    "hono": "4.12.18",
     "solid-js": "^1.9.11",
     "web-tree-sitter": "^0.25.10",
     "zod": "^4.3.6"
   },
   "overrides": {
     "flatted": "3.4.2",
-    "hono": "4.12.14",
+    "hono": "4.12.18",
     "rollup": "4.60.0",
     "vite": "^7.3.2",
     "yaml": "^2.8.3",
@@ -142,6 +142,9 @@
     "picomatch@>=4.0.0 <4.0.4": "^4.0.4",
     "@typescript-eslint/typescript-estree": {
       "minimatch": "^9.0.7"
-    }
+    },
+    "uuid": "13.0.1",
+    "diff": "8.0.3",
+    "file-type": "21.3.1"
   }
 }


### PR DESCRIPTION
## What changed
- Updated `hono` to `4.12.18` to clear the open Hono Dependabot advisories.
- Updated `@opentui/core` and `@opentui/solid` to `0.2.6`, removing vulnerable transitive `jimp` / `file-type` and `diff` paths.
- Added explicit overrides for `uuid`, `diff`, and `file-type` patched versions so the lockfile stays on safe releases.

## Why
GitHub Security and quality showed open Dependabot alerts on `main` for `hono`, `uuid`, `file-type`, and `diff` via the npm manifests/lockfile.

## Validation
- `npm audit` during install: found 0 vulnerabilities
- `npm run audit:ci`
- `npm run typecheck`
- `npm test` (84 files, 2370 passed, 1 skipped)
- `npm run lint`
- `npm run build`

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

this PR bumps `hono` to 4.12.18 (fixes multiple CVEs including ip-restriction bypass and cookie-prefix bypass), upgrades `@opentui/core` and `@opentui/solid` to 0.2.6 (removing the vulnerable `jimp`/`file-type` transitive dependency tree), and adds npm overrides for `uuid`, `diff`, and `file-type` to keep the lockfile on patched releases.

- `hono` upgrade is correct; 4.12.18 is the current non-vulnerable release per snyk and advisory history.
- `uuid` override pins to `13.0.1`, but GHSA-w5hq-g745-h8pq lists the only patched release as `14.0.0` — 13.0.1 is in an ambiguous gap between the advisory boundary and the official fix.
- `diff` override forces `8.0.3` onto `@opentui/core@0.2.6`, which itself declares `diff@9.0.0`; this is a major-version downgrade via npm override that could silently break opentui rendering paths not covered by the vitest suite.

<h3>Confidence Score: 3/5</h3>

the hono and opentui changes are safe, but two overrides carry real risk: uuid is pinned below the officially-patched version, and the diff override is a major-version downgrade onto a package that explicitly requires the newer release.

the diff override silently forces 8.0.3 onto @opentui/core@0.2.6 which declared 9.0.0 — a major-version gap that could break opentui rendering at runtime on paths the vitest suite does not exercise. the uuid override relies on an advisory boundary that was written before 13.0.1 existed and the official fix is 14.0.0, leaving the protection on uncertain ground.

package.json — specifically the `uuid` and `diff` entries in the overrides block

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| package.json | bumps hono to 4.12.18 (correct fix), opentui to 0.2.6 (removes jimp/file-type), and adds overrides for uuid/diff/file-type — but uuid 13.0.1 sits below the advisory-patched version (14.0.0), and the diff 8.0.3 override is a major-version downgrade from what @opentui/core@0.2.6 declares (9.0.0) |
| package-lock.json | lockfile reflects all declared changes — jimp/rapier2d packages removed, diff resolved to 8.0.3 via override, opentui win32 binaries now present, uuid bumped from 13.0.0 to 13.0.1 |

</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Foc-codex-multi-auth%22%20on%20the%20existing%20branch%20%22codex%2Ffix-security-quality-alerts%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Ffix-security-quality-alerts%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Apackage.json%3A144%0A**%60diff%60%20override%20downgrade%20conflicts%20with%20%60%40opentui%2Fcore%400.2.6%60**%0A%0Athe%20%60diff%3A%20%228.0.3%22%60%20override%20forces%20a%20major-version%20downgrade%3A%20%60%40opentui%2Fcore%400.2.6%60%20declares%20%60diff%409.0.0%60%20as%20its%20own%20dependency%20%28visible%20in%20the%20lock%20file%20entry%20for%20that%20package%29%2C%20but%20npm's%20override%20machinery%20installs%208.0.3%20instead.%20diff%209.0.0%20is%20a%20major%20bump%20from%208.x%20and%20is%20expected%20to%20carry%20breaking%20API%20changes.%20any%20opentui%20rendering%20code%20path%20that%20calls%20a%209.0.0-only%20API%20will%20silently%20receive%20the%20wrong%20function%20or%20throw%20at%20runtime.%20the%20test%20suite%20passing%20doesn't%20rule%20this%20out%20since%20vitest%20coverage%20of%20the%20opentui%20paint%2Fdiff%20path%20appears%20absent%20from%20this%20PR.%0A%0A%23%23%23%20Issue%202%20of%203%0Apackage.json%3A143%0A**%60uuid%60%20override%20may%20not%20clear%20the%20advisory**%0A%0AGHSA-w5hq-g745-h8pq%20%28missing%20buffer-bounds%20check%20in%20%60v3%60%2F%60v5%60%2F%60v6%60%20when%20%60buf%60%20is%20provided%29%20lists%20affected%20versions%20as%20%60%3C%3D13.0.0%60%20and%20the%20official%20patched%20release%20as%20%6014.0.0%60.%20pinning%20to%20%6013.0.1%60%20sits%20in%20an%20ambiguous%20gap%3A%2013.0.1%20was%20released%20after%20the%20advisory%20was%20published%20and%20there%20is%20an%20open%20upstream%20issue%20requesting%20a%2013.x%20backport%20that%20had%20not%20landed%20when%20this%20PR%20was%20written.%20if%20github's%20advisory%20database%20widens%20the%20affected%20range%20to%20include%2013.0.1%20%28or%20if%20the%20project%20uses%20%60uuid.v3%2Fv5%2Fv6%60%20with%20a%20caller-supplied%20%60buf%60%29%2C%20the%20alert%20resurfaces%20and%20the%20protection%20assumed%20here%20never%20existed.%20consider%20overriding%20to%20%60%3E%3D14.0.0%60%20to%20track%20the%20explicitly%20patched%20branch.%0A%0A%23%23%23%20Issue%203%20of%203%0Apackage.json%3A122-123%0A**exact%20pin%20on%20%60%40opentui%60%20prevents%20automatic%20patch%20updates**%0A%0Achanging%20from%20%60%22%5E0.1.99%22%60%20to%20%60%220.2.6%22%60%20%28no%20caret%29%20is%20intentional%20to%20lock%20out%20dep%20drift%2C%20which%20is%20fine.%20just%20note%20that%20any%20future%20security%20or%20bugfix%20release%20of%20%60%40opentui%2Fcore%60%20or%20%60%40opentui%2Fsolid%60%20%E2%80%94%20including%20windows-path%20or%20token-handling%20fixes%20%E2%80%94%20will%20require%20a%20manual%20lockfile%20update.%20the%20existing%20win32%20binaries%20%28%60%40opentui%2Fcore-win32-arm64%60%2C%20%60%40opentui%2Fcore-win32-x64%60%29%20are%20now%20present%20in%20the%20lock%20file%2C%20which%20is%20an%20improvement%2C%20but%20they'll%20remain%20pinned%20at%200.2.6%20until%20deliberately%20bumped.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
package.json:144
**`diff` override downgrade conflicts with `@opentui/core@0.2.6`**

the `diff: "8.0.3"` override forces a major-version downgrade: `@opentui/core@0.2.6` declares `diff@9.0.0` as its own dependency (visible in the lock file entry for that package), but npm's override machinery installs 8.0.3 instead. diff 9.0.0 is a major bump from 8.x and is expected to carry breaking API changes. any opentui rendering code path that calls a 9.0.0-only API will silently receive the wrong function or throw at runtime. the test suite passing doesn't rule this out since vitest coverage of the opentui paint/diff path appears absent from this PR.

### Issue 2 of 3
package.json:143
**`uuid` override may not clear the advisory**

GHSA-w5hq-g745-h8pq (missing buffer-bounds check in `v3`/`v5`/`v6` when `buf` is provided) lists affected versions as `<=13.0.0` and the official patched release as `14.0.0`. pinning to `13.0.1` sits in an ambiguous gap: 13.0.1 was released after the advisory was published and there is an open upstream issue requesting a 13.x backport that had not landed when this PR was written. if github's advisory database widens the affected range to include 13.0.1 (or if the project uses `uuid.v3/v5/v6` with a caller-supplied `buf`), the alert resurfaces and the protection assumed here never existed. consider overriding to `>=14.0.0` to track the explicitly patched branch.

### Issue 3 of 3
package.json:122-123
**exact pin on `@opentui` prevents automatic patch updates**

changing from `"^0.1.99"` to `"0.2.6"` (no caret) is intentional to lock out dep drift, which is fine. just note that any future security or bugfix release of `@opentui/core` or `@opentui/solid` — including windows-path or token-handling fixes — will require a manual lockfile update. the existing win32 binaries (`@opentui/core-win32-arm64`, `@opentui/core-win32-x64`) are now present in the lock file, which is an improvement, but they'll remain pinned at 0.2.6 until deliberately bumped.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["deps: fix security alerts"](https://github.com/ndycode/oc-codex-multi-auth/commit/c6af0af0a0abde1d7bf8ea475ec73dcb4ad73c47) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31486197)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Context used - speak in lowercase, concise sentences. act like th... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->