### PR TITLE
fix: handle normalized codex fallback

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -75,17 +75,21 @@ A barebones debug template is available at [`minimal-opencode.json`](./minimal-o
 
 ## Unsupported-model behavior
 
-Current defaults are strict entitlement handling:
-- `unsupportedCodexPolicy: "strict"` returns entitlement errors directly
-- set `unsupportedCodexPolicy: "fallback"` (or `CODEX_AUTH_UNSUPPORTED_MODEL_POLICY=fallback`) to enable automatic fallback retries
+Current defaults are strict entitlement handling except for default public selectors that are commonly entitlement-gated:
+- `gpt-5.5` and canonical `gpt-5-codex` can auto-fallback through `gpt-5.4`, `gpt-5.4-mini`, then `gpt-5.4-nano` when the backend reports the selected model is not supported for the active account/workspace
+- `unsupportedCodexPolicy: "strict"` returns other entitlement errors directly
+- set `unsupportedCodexPolicy: "fallback"` (or `CODEX_AUTH_UNSUPPORTED_MODEL_POLICY=fallback`) to enable the full fallback chain for manual/legacy selectors
 - `fallbackToGpt52OnUnsupportedGpt53: true` keeps the legacy `gpt-5.3-codex -> gpt-5.2-codex` edge inside fallback mode
-- `gpt-5.5 -> gpt-5.4` is included by default for accounts/workspaces that do not yet expose GPT-5.5
 - user-typed `gpt-5.5-pro*` is canonicalized to `gpt-5.5` before fallback because GPT-5.5 Pro is ChatGPT-only, not a Codex-routable model
+- legacy Codex selectors such as `gpt-5.2-codex`, `gpt-5.3-codex`, and `gpt-5.3-codex-spark` normalize to canonical `gpt-5-codex`; if that canonical Codex model is gated, the default auto-fallback can retry through the GPT-5.4 family
+- set `CODEX_AUTH_DISABLE_GPT55_AUTO_FALLBACK=1` to disable GPT-5.5 auto-fallback
+- set `CODEX_AUTH_DISABLE_CODEX_AUTO_FALLBACK=1` to disable canonical Codex/GPT-5.4-family auto-fallback
 - `gpt-5.4-pro -> gpt-5.4` remains available for older manual configs
 - `unsupportedCodexFallbackChain` lets you override fallback order per model
 
-Default fallback chain (when policy is `fallback`):
-- `gpt-5.5 -> gpt-5.4`
+Default fallback chain (auto-fallback for `gpt-5.5`/`gpt-5-codex` through the GPT-5.4 family; full chain when policy is `fallback`):
+- `gpt-5.5 -> gpt-5.4 -> gpt-5.4-mini -> gpt-5.4-nano`
+- `gpt-5-codex -> gpt-5.4 -> gpt-5.4-mini -> gpt-5.4-nano`
 - `gpt-5.4-pro -> gpt-5.4` (if you manually select `gpt-5.4-pro`)
 - `gpt-5.3-codex -> gpt-5-codex -> gpt-5.2-codex`
 - `gpt-5.3-codex-spark -> gpt-5-codex -> gpt-5.3-codex -> gpt-5.2-codex` (only relevant if Spark IDs are added manually)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -172,7 +172,7 @@ The sample above intentionally sets `"retryAllAccountsMaxRetries": 3` as a bound
 | `unsupportedCodexPolicy` | `strict` | unsupported-model behavior: `strict` (return entitlement error) or `fallback` (retry with configured fallback chain) |
 | `fallbackOnUnsupportedCodexModel` | `false` | legacy fallback toggle mapped to `unsupportedCodexPolicy` (prefer using `unsupportedCodexPolicy`) |
 | `fallbackToGpt52OnUnsupportedGpt53` | `true` | legacy compatibility toggle for the `gpt-5.3-codex -> gpt-5.2-codex` edge when generic fallback is enabled |
-| `unsupportedCodexFallbackChain` | `{}` | optional per-model fallback-chain override (map of `model -> [fallback1, fallback2, ...]`; default includes `gpt-5.5 -> gpt-5.4`). `gpt-5.5` auto-fallback is on by default during the rollout; set `CODEX_AUTH_DISABLE_GPT55_AUTO_FALLBACK=1` to opt out. GPT-5.5 Pro is not mapped: it is ChatGPT-only per OpenAI's 2026-04-23 launch. |
+| `unsupportedCodexFallbackChain` | `{}` | optional per-model fallback-chain override (map of `model -> [fallback1, fallback2, ...]`; default includes `gpt-5.5` and `gpt-5-codex` through the GPT-5.4 family). `gpt-5.5` and canonical Codex auto-fallbacks are on by default for common entitlement gates; set `CODEX_AUTH_DISABLE_GPT55_AUTO_FALLBACK=1` or `CODEX_AUTH_DISABLE_CODEX_AUTO_FALLBACK=1` to opt out. GPT-5.5 Pro is not mapped: it is ChatGPT-only per OpenAI's 2026-04-23 launch. |
 | `sessionRecovery` | `true` | auto-recover from common api errors |
 | `autoResume` | `true` | auto-resume after thinking block recovery |
 | `tokenRefreshSkewMs` | `60000` | refresh tokens this many ms before expiry |
@@ -191,12 +191,13 @@ this mode is intended for beginners who prefer quick failures + clearer recovery
 
 ### Unsupported-Model Behavior and Fallback Chain
 
-by default the plugin is strict (`unsupportedCodexPolicy: "strict"`). it returns entitlement errors directly for unsupported models.
+by default the plugin is strict (`unsupportedCodexPolicy: "strict"`) except for common default-selector entitlement gates. it returns other entitlement errors directly for unsupported models.
 
 set `unsupportedCodexPolicy: "fallback"` to enable model fallback after account/workspace attempts are exhausted.
 
 defaults when fallback policy is enabled and `unsupportedCodexFallbackChain` is empty:
-- `gpt-5.5 -> gpt-5.4`
+- `gpt-5.5 -> gpt-5.4 -> gpt-5.4-mini -> gpt-5.4-nano`
+- `gpt-5-codex -> gpt-5.4 -> gpt-5.4-mini -> gpt-5.4-nano`
 - `gpt-5.4-pro -> gpt-5.4` (if `gpt-5.4-pro` is selected manually)
 - `gpt-5.3-codex -> gpt-5-codex -> gpt-5.2-codex`
 - `gpt-5.3-codex-spark -> gpt-5-codex -> gpt-5.3-codex -> gpt-5.2-codex` (applies if you manually select Spark model IDs)
@@ -211,9 +212,10 @@ custom chain example:
   "unsupportedCodexPolicy": "fallback",
   "fallbackOnUnsupportedCodexModel": true,
   "unsupportedCodexFallbackChain": {
-    "gpt-5.5": ["gpt-5.4"],
+    "gpt-5.5": ["gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano"],
+    "gpt-5.4": ["gpt-5.4-mini", "gpt-5.4-nano"],
     "gpt-5.4-pro": ["gpt-5.4"],
-    "gpt-5-codex": ["gpt-5.2-codex"],
+    "gpt-5-codex": ["gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano"],
     "gpt-5.3-codex": ["gpt-5-codex", "gpt-5.2-codex"],
     "gpt-5.3-codex-spark": ["gpt-5-codex", "gpt-5.3-codex", "gpt-5.2-codex"]
   }
@@ -255,6 +257,7 @@ override any config with env vars:
 | `CODEX_AUTH_FALLBACK_UNSUPPORTED_MODEL=1` | legacy fallback toggle (prefer policy variable above) |
 | `CODEX_AUTH_FALLBACK_GPT53_TO_GPT52=0` | disable only the legacy `gpt-5.3-codex -> gpt-5.2-codex` edge |
 | `CODEX_AUTH_DISABLE_GPT55_AUTO_FALLBACK=1` | disable automatic `gpt-5.5 -> gpt-5.4` fallback during rollout |
+| `CODEX_AUTH_DISABLE_CODEX_AUTO_FALLBACK=1` | disable automatic canonical Codex/GPT-5.4-family fallback |
 | `CODEX_AUTH_ACCOUNT_ID=acc_xxx` | force specific workspace id |
 | `CODEX_AUTH_FETCH_TIMEOUT_MS=120000` | override fetch timeout |
 | `CODEX_AUTH_STREAM_STALL_TIMEOUT_MS=60000` | override SSE stall timeout |

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -362,44 +362,53 @@ resolvedConfig: { reasoningEffort: 'low', ... }  ← Should show your options
    opencode auth login
    ```
 2. Add another entitled account/workspace. The plugin tries remaining accounts/workspaces before model fallback.
-3. Enable fallback policy only if you want automatic model downgrades:
+3. Default public selectors that are commonly entitlement-gated (`gpt-5.5` and canonical `gpt-5-codex`) can auto-fallback through `gpt-5.4`, `gpt-5.4-mini`, then `gpt-5.4-nano`.
+4. Enable fallback policy if you also want automatic downgrades for manual/legacy selectors:
    ```bash
    CODEX_AUTH_UNSUPPORTED_MODEL_POLICY=fallback opencode
    ```
-4. Default fallback chain (when policy is `fallback` and not overridden):
-   - `gpt-5.5 -> gpt-5.4`
+5. Default fallback chain (auto-fallback for `gpt-5.5`/`gpt-5-codex` through the GPT-5.4 family; full chain when policy is `fallback` and not overridden):
+   - `gpt-5.5 -> gpt-5.4 -> gpt-5.4-mini -> gpt-5.4-nano`
+   - `gpt-5-codex -> gpt-5.4 -> gpt-5.4-mini -> gpt-5.4-nano`
    - `gpt-5.4-pro -> gpt-5.4` (if `gpt-5.4-pro` is selected manually)
    - `gpt-5.3-codex -> gpt-5-codex -> gpt-5.2-codex`
    - `gpt-5.3-codex-spark -> gpt-5-codex -> gpt-5.3-codex -> gpt-5.2-codex` (if Spark IDs are selected manually)
    - `gpt-5.2-codex -> gpt-5-codex`
    - `gpt-5.1-codex -> gpt-5-codex`
-5. Configure a custom fallback chain in `~/.opencode/openai-codex-auth-config.json`:
+6. Configure a custom fallback chain in `~/.opencode/openai-codex-auth-config.json`:
    ```json
    {
    "unsupportedCodexPolicy": "fallback",
    "fallbackOnUnsupportedCodexModel": true,
    "unsupportedCodexFallbackChain": {
-      "gpt-5.5": ["gpt-5.4"],
+      "gpt-5.5": ["gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano"],
+      "gpt-5.4": ["gpt-5.4-mini", "gpt-5.4-nano"],
       "gpt-5.4-pro": ["gpt-5.4"],
-      "gpt-5-codex": ["gpt-5.2-codex"],
+      "gpt-5-codex": ["gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano"],
       "gpt-5.3-codex": ["gpt-5-codex", "gpt-5.2-codex"],
        "gpt-5.3-codex-spark": ["gpt-5-codex", "gpt-5.3-codex", "gpt-5.2-codex"]
      }
    }
    ```
-6. Use strict mode (no model fallback) for explicit entitlement failures:
+7. Use strict mode for explicit entitlement failures outside the default public selector auto-fallbacks:
    ```bash
    CODEX_AUTH_UNSUPPORTED_MODEL_POLICY=strict opencode
    ```
-7. Legacy compatibility toggle (only controls `gpt-5.3-codex -> gpt-5.2-codex`):
+8. Disable default-selector auto-fallbacks when you need strict entitlement failures for those selectors:
+   ```bash
+   CODEX_AUTH_DISABLE_GPT55_AUTO_FALLBACK=1 opencode
+   CODEX_AUTH_DISABLE_CODEX_AUTO_FALLBACK=1 opencode
+   ```
+   `CODEX_AUTH_DISABLE_CODEX_AUTO_FALLBACK=1` only disables the automatic canonical Codex/GPT-5.4-family fallback path; explicit `unsupportedCodexPolicy: "fallback"` chains still apply.
+9. Legacy compatibility toggle (only controls `gpt-5.3-codex -> gpt-5.2-codex`):
    ```bash
    CODEX_AUTH_FALLBACK_GPT53_TO_GPT52=0 opencode
    ```
-8. Legacy generic fallback toggle compatibility:
+10. Legacy generic fallback toggle compatibility:
    ```bash
    CODEX_AUTH_FALLBACK_UNSUPPORTED_MODEL=1 opencode
    ```
-9. Verify effective upstream model when debugging Spark/fallback behavior:
+11. Verify effective upstream model when debugging Spark/fallback behavior:
    ```bash
    ENABLE_PLUGIN_REQUEST_LOGGING=1 CODEX_PLUGIN_LOG_BODIES=1 opencode run "ping" --model=openai/gpt-5.3-codex-spark
    ```

--- a/index.ts
+++ b/index.ts
@@ -2631,7 +2631,7 @@ while (attempted.size < Math.max(1, accountCount)) {
 										: waitMs > 0
 											? `All ${count} account(s) are rate-limited. Try again in ${waitLabel} or add another account with \`opencode auth login\`.`
 											: wasEntitlementExhaustion
-												? `All ${count} account(s) returned 'model not supported' for the requested model.${entitlementDetail} If this is a GPT-5.5 request during the rollout period, set \`unsupportedCodexPolicy: "fallback"\` (or \`CODEX_AUTH_UNSUPPORTED_MODEL_POLICY=fallback\`) to auto-fallback to gpt-5.4. See \`codex-health\` for per-account details.`
+												? `All ${count} account(s) returned 'model not supported' for the requested model.${entitlementDetail} Codex model access is account/workspace gated; default gpt-5.5/gpt-5-codex selectors auto-fallback through the GPT-5.4 family when possible. Set \`unsupportedCodexPolicy: "fallback"\` for the full manual fallback chain, or see \`codex-health\` for per-account details.`
 												: `All ${count} account(s) failed (server errors or auth issues). Check account health with \`codex-health\`.`;
 								runtimeMetrics.failedRequests++;
 								runtimeMetrics.lastError = message;

--- a/lib/request/fetch-helpers.ts
+++ b/lib/request/fetch-helpers.ts
@@ -54,13 +54,48 @@ const CHATGPT_CODEX_UNSUPPORTED_MODEL_PATTERN =
 const NORMALIZED_UNSUPPORTED_MODEL_PATTERN =
 	/the model ['"]([^'"]+)['"] is not currently available for this chatgpt account/i;
 export const DEFAULT_UNSUPPORTED_CODEX_FALLBACK_CHAIN: Record<string, string[]> = {
-	[GPT_55_MODEL_ID]: ["gpt-5.4"],
+	[GPT_55_MODEL_ID]: ["gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano"],
+	"gpt-5.4": ["gpt-5.4-mini", "gpt-5.4-nano"],
+	"gpt-5.4-mini": ["gpt-5.4-nano"],
 	"gpt-5.4-pro": ["gpt-5.4"],
+	"gpt-5-codex": ["gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano"],
+	// Legacy selectors normalize to `gpt-5-codex` before lookup during the
+	// request path. Keep these historical entries for direct helper callers and
+	// custom-chain documentation; the canonical `gpt-5-codex` edge above is the
+	// runtime path for default OpenCode selectors.
 	"gpt-5.3-codex-spark": ["gpt-5-codex", "gpt-5.3-codex", "gpt-5.2-codex"],
 	"gpt-5.3-codex": ["gpt-5-codex", "gpt-5.2-codex"],
 	"gpt-5.2-codex": ["gpt-5-codex"],
 	"gpt-5.1-codex": ["gpt-5-codex"],
 };
+
+const DEFAULT_AUTO_FALLBACK_ENTRY_OPT_OUT_ENV: Record<string, string> = {
+	[GPT_55_MODEL_ID]: "CODEX_AUTH_DISABLE_GPT55_AUTO_FALLBACK",
+	"gpt-5-codex": "CODEX_AUTH_DISABLE_CODEX_AUTO_FALLBACK",
+};
+
+const DEFAULT_AUTO_FALLBACK_CONTINUATION_MODELS = new Set([
+	"gpt-5.4",
+	"gpt-5.4-mini",
+]);
+
+function resolveAutoFallbackEntryModel(
+	currentModel: string,
+	attempted: Set<string>,
+): string | undefined {
+	if (DEFAULT_AUTO_FALLBACK_ENTRY_OPT_OUT_ENV[currentModel] !== undefined) {
+		return currentModel;
+	}
+	if (!DEFAULT_AUTO_FALLBACK_CONTINUATION_MODELS.has(currentModel)) {
+		return undefined;
+	}
+	for (const model of attempted) {
+		if (DEFAULT_AUTO_FALLBACK_ENTRY_OPT_OUT_ENV[model] !== undefined) {
+			return model;
+		}
+	}
+	return undefined;
+}
 
 export interface UnsupportedCodexModelInfo {
 	isUnsupported: boolean;
@@ -210,25 +245,32 @@ export function resolveUnsupportedCodexFallbackModel(
 	const currentModel = requestedModel ?? unsupported.unsupportedModel;
 	if (!currentModel) return undefined;
 
-	// During the GPT-5.5 rollout period, the backend gates `gpt-5.5` per-account
-	// even though the plugin maps every GPT-5.5 alias to it. Without a scoped
-	// auto-fallback, every one of the pooled accounts returns
-	// `model_not_supported_with_chatgpt_account` and rotation exhausts the pool
-	// with a misleading "server errors or auth issues" message. Gate this to
-	// gpt-5.5 only so legacy families keep their opt-in behavior.
-	const isGpt55AutoFallbackOptOut =
-		process.env.CODEX_AUTH_DISABLE_GPT55_AUTO_FALLBACK === "1";
-	const shouldAutoFallbackForGpt55 =
-		!isGpt55AutoFallbackOptOut && currentModel === GPT_55_MODEL_ID;
-
-	if (!options.fallbackOnUnsupportedCodexModel && !shouldAutoFallbackForGpt55) {
-		return undefined;
-	}
-
 	const attempted = new Set<string>();
 	for (const model of options.attemptedModels ?? []) {
 		const normalized = canonicalizeModelName(model);
 		if (normalized) attempted.add(normalized);
+	}
+
+	// The backend gates some public selector ids per account/workspace. When the
+	// selected id is a default UI selector, auto-fallback prevents exhausting every
+	// pooled account with the same unsupported-model response. Continuation models
+	// such as `gpt-5.4` only auto-fallback when the attempted set proves the chain
+	// started from a default entry point; direct user selection remains strict.
+	const autoFallbackEntryModel = resolveAutoFallbackEntryModel(
+		currentModel,
+		attempted,
+	);
+	const autoFallbackOptOutEnv = autoFallbackEntryModel
+		? DEFAULT_AUTO_FALLBACK_ENTRY_OPT_OUT_ENV[autoFallbackEntryModel]
+		: undefined;
+	const shouldAutoFallbackForDefaultSelector =
+		!!autoFallbackOptOutEnv && process.env[autoFallbackOptOutEnv] !== "1";
+
+	if (
+		!options.fallbackOnUnsupportedCodexModel &&
+		!shouldAutoFallbackForDefaultSelector
+	) {
+		return undefined;
 	}
 
 	const chain = normalizeFallbackChain(options.customChain);

--- a/test/fetch-helpers.test.ts
+++ b/test/fetch-helpers.test.ts
@@ -423,6 +423,229 @@ describe('Fetch Helpers Module', () => {
 			expect(legacyEdgeFallback).toBeUndefined();
 		});
 
+		it('falls back from canonical gpt-5-codex to gpt-5.4 when fallback policy is enabled', () => {
+			const fallback = resolveUnsupportedCodexFallbackModel({
+				requestedModel: 'gpt-5-codex',
+				errorBody: {
+					error: {
+						code: 'model_not_supported_with_chatgpt_account',
+						message:
+							"The 'gpt-5-codex' model is not supported when using Codex with a ChatGPT account.",
+					},
+				},
+				attemptedModels: ['gpt-5-codex'],
+				fallbackOnUnsupportedCodexModel: true,
+				fallbackToGpt52OnUnsupportedGpt53: true,
+			});
+			expect(fallback).toBe('gpt-5.4');
+		});
+
+		it('continues canonical Codex fallback to mini and nano when larger fallbacks are also unsupported', () => {
+			const errorBody = {
+				error: {
+					code: 'model_not_supported_with_chatgpt_account',
+					message:
+						"The 'gpt-5.4' model is not supported when using Codex with a ChatGPT account.",
+				},
+			};
+
+			const miniFallback = resolveUnsupportedCodexFallbackModel({
+				requestedModel: 'gpt-5.4',
+				errorBody,
+				attemptedModels: ['gpt-5-codex', 'gpt-5.4'],
+				fallbackOnUnsupportedCodexModel: false,
+				fallbackToGpt52OnUnsupportedGpt53: true,
+			});
+			expect(miniFallback).toBe('gpt-5.4-mini');
+
+			const nanoFallback = resolveUnsupportedCodexFallbackModel({
+				requestedModel: 'gpt-5.4-mini',
+				errorBody: {
+					error: {
+						code: 'model_not_supported_with_chatgpt_account',
+						message:
+							"The 'gpt-5.4-mini' model is not supported when using Codex with a ChatGPT account.",
+					},
+				},
+				attemptedModels: ['gpt-5-codex', 'gpt-5.4', 'gpt-5.4-mini'],
+				fallbackOnUnsupportedCodexModel: false,
+				fallbackToGpt52OnUnsupportedGpt53: true,
+			});
+			expect(nanoFallback).toBe('gpt-5.4-nano');
+		});
+
+		it('keeps directly selected GPT-5.4 family models strict when fallback policy is disabled', () => {
+			const miniFallback = resolveUnsupportedCodexFallbackModel({
+				requestedModel: 'gpt-5.4',
+				errorBody: {
+					error: {
+						code: 'model_not_supported_with_chatgpt_account',
+						message:
+							"The 'gpt-5.4' model is not supported when using Codex with a ChatGPT account.",
+					},
+				},
+				attemptedModels: ['gpt-5.4'],
+				fallbackOnUnsupportedCodexModel: false,
+				fallbackToGpt52OnUnsupportedGpt53: true,
+			});
+			expect(miniFallback).toBeUndefined();
+
+			const nanoFallback = resolveUnsupportedCodexFallbackModel({
+				requestedModel: 'gpt-5.4-mini',
+				errorBody: {
+					error: {
+						code: 'model_not_supported_with_chatgpt_account',
+						message:
+							"The 'gpt-5.4-mini' model is not supported when using Codex with a ChatGPT account.",
+					},
+				},
+				attemptedModels: ['gpt-5.4-mini'],
+				fallbackOnUnsupportedCodexModel: false,
+				fallbackToGpt52OnUnsupportedGpt53: true,
+			});
+			expect(nanoFallback).toBeUndefined();
+		});
+
+		it('covers legacy gpt-5.3-codex multi-hop through blocked canonical Codex', () => {
+			const canonicalFallback = resolveUnsupportedCodexFallbackModel({
+				requestedModel: 'gpt-5.3-codex',
+				errorBody: {
+					error: {
+						code: 'model_not_supported_with_chatgpt_account',
+						message:
+							"The 'gpt-5.3-codex' model is not supported when using Codex with a ChatGPT account.",
+					},
+				},
+				attemptedModels: ['gpt-5.3-codex'],
+				fallbackOnUnsupportedCodexModel: true,
+				fallbackToGpt52OnUnsupportedGpt53: true,
+			});
+			expect(canonicalFallback).toBe('gpt-5-codex');
+
+			const gpt54Fallback = resolveUnsupportedCodexFallbackModel({
+				requestedModel: canonicalFallback,
+				errorBody: {
+					error: {
+						code: 'model_not_supported_with_chatgpt_account',
+						message:
+							"The 'gpt-5-codex' model is not supported when using Codex with a ChatGPT account.",
+					},
+				},
+				attemptedModels: ['gpt-5.3-codex', 'gpt-5-codex'],
+				fallbackOnUnsupportedCodexModel: true,
+				fallbackToGpt52OnUnsupportedGpt53: true,
+			});
+			expect(gpt54Fallback).toBe('gpt-5.4');
+		});
+
+		it('covers legacy gpt-5.1-codex multi-hop through blocked canonical Codex', () => {
+			const canonicalFallback = resolveUnsupportedCodexFallbackModel({
+				requestedModel: 'gpt-5.1-codex',
+				errorBody: {
+					error: {
+						code: 'model_not_supported_with_chatgpt_account',
+						message:
+							"The 'gpt-5.1-codex' model is not supported when using Codex with a ChatGPT account.",
+					},
+				},
+				attemptedModels: ['gpt-5.1-codex'],
+				fallbackOnUnsupportedCodexModel: true,
+				fallbackToGpt52OnUnsupportedGpt53: true,
+			});
+			expect(canonicalFallback).toBe('gpt-5-codex');
+
+			const gpt54Fallback = resolveUnsupportedCodexFallbackModel({
+				requestedModel: canonicalFallback,
+				errorBody: {
+					error: {
+						code: 'model_not_supported_with_chatgpt_account',
+						message:
+							"The 'gpt-5-codex' model is not supported when using Codex with a ChatGPT account.",
+					},
+				},
+				attemptedModels: ['gpt-5.1-codex', 'gpt-5-codex'],
+				fallbackOnUnsupportedCodexModel: true,
+				fallbackToGpt52OnUnsupportedGpt53: true,
+			});
+			expect(gpt54Fallback).toBe('gpt-5.4');
+		});
+
+		it('auto-fallbacks canonical gpt-5-codex even when fallback policy is disabled', () => {
+			const fallback = resolveUnsupportedCodexFallbackModel({
+				requestedModel: 'gpt-5-codex',
+				errorBody: {
+					error: {
+						code: 'model_not_supported_with_chatgpt_account',
+						message:
+							"The 'gpt-5-codex' model is not supported when using Codex with a ChatGPT account.",
+					},
+				},
+				attemptedModels: ['gpt-5-codex'],
+				fallbackOnUnsupportedCodexModel: false,
+				fallbackToGpt52OnUnsupportedGpt53: true,
+			});
+			expect(fallback).toBe('gpt-5.4');
+		});
+
+		it('honors the default selector auto-fallback opt-out', () => {
+			const previous = process.env.CODEX_AUTH_DISABLE_CODEX_AUTO_FALLBACK;
+			try {
+				process.env.CODEX_AUTH_DISABLE_CODEX_AUTO_FALLBACK = '1';
+				const codexFallback = resolveUnsupportedCodexFallbackModel({
+					requestedModel: 'gpt-5-codex',
+					errorBody: {
+						error: {
+							code: 'model_not_supported_with_chatgpt_account',
+							message:
+								"The 'gpt-5-codex' model is not supported when using Codex with a ChatGPT account.",
+						},
+					},
+					attemptedModels: ['gpt-5-codex'],
+					fallbackOnUnsupportedCodexModel: false,
+					fallbackToGpt52OnUnsupportedGpt53: true,
+				});
+				expect(codexFallback).toBeUndefined();
+
+				const gpt54Fallback = resolveUnsupportedCodexFallbackModel({
+					requestedModel: 'gpt-5.4',
+					errorBody: {
+						error: {
+							code: 'model_not_supported_with_chatgpt_account',
+							message:
+								"The 'gpt-5.4' model is not supported when using Codex with a ChatGPT account.",
+						},
+					},
+					attemptedModels: ['gpt-5-codex', 'gpt-5.4'],
+					fallbackOnUnsupportedCodexModel: false,
+					fallbackToGpt52OnUnsupportedGpt53: true,
+				});
+				expect(gpt54Fallback).toBeUndefined();
+			} finally {
+				if (previous === undefined) {
+					delete process.env.CODEX_AUTH_DISABLE_CODEX_AUTO_FALLBACK;
+				} else {
+					process.env.CODEX_AUTH_DISABLE_CODEX_AUTO_FALLBACK = previous;
+				}
+			}
+		});
+
+		it('keeps manual gpt-5.4-pro strict when fallback policy is disabled', () => {
+			const fallback = resolveUnsupportedCodexFallbackModel({
+				requestedModel: 'gpt-5.4-pro',
+				errorBody: {
+					error: {
+						code: 'model_not_supported_with_chatgpt_account',
+						message:
+							"The 'gpt-5.4-pro' model is not supported when using Codex with a ChatGPT account.",
+					},
+				},
+				attemptedModels: ['gpt-5.4-pro'],
+				fallbackOnUnsupportedCodexModel: false,
+				fallbackToGpt52OnUnsupportedGpt53: true,
+			});
+			expect(fallback).toBeUndefined();
+		});
+
 		it('falls back from gpt-5.4-pro to gpt-5.4 when fallback policy is enabled', () => {
 			const fallback = resolveUnsupportedCodexFallbackModel({
 				requestedModel: 'gpt-5.4-pro',
@@ -495,7 +718,7 @@ describe('Fetch Helpers Module', () => {
 			expect(fallback).toBe('gpt-5.4');
 		});
 
-		it('does not fallback from GPT-5.5 when gpt-5.4 was already attempted', () => {
+		it('continues GPT-5.5 fallback when gpt-5.4 was already attempted', () => {
 			const fallback = resolveUnsupportedCodexFallbackModel({
 				requestedModel: 'gpt-5.5',
 				errorBody: {
@@ -509,12 +732,12 @@ describe('Fetch Helpers Module', () => {
 				fallbackOnUnsupportedCodexModel: true,
 				fallbackToGpt52OnUnsupportedGpt53: true,
 			});
-			expect(fallback).toBeUndefined();
+			expect(fallback).toBe('gpt-5.4-mini');
 		});
 
-		it('does not loop through gpt-5.5-pro once gpt-5.4 has been attempted', () => {
+		it('continues through gpt-5.5-pro fallback once gpt-5.4 has been attempted', () => {
 			// Pro canonicalizes to gpt-5.5, so once gpt-5.4 is in attemptedModels the
-			// chain has no further targets and the rotation returns undefined.
+			// chain continues to the smaller GPT-5.4 family fallbacks.
 			const fallback = resolveUnsupportedCodexFallbackModel({
 				requestedModel: 'gpt-5.5-pro',
 				errorBody: {
@@ -528,7 +751,7 @@ describe('Fetch Helpers Module', () => {
 				fallbackOnUnsupportedCodexModel: true,
 				fallbackToGpt52OnUnsupportedGpt53: true,
 			});
-			expect(fallback).toBeUndefined();
+			expect(fallback).toBe('gpt-5.4-mini');
 		});
 	});
 

--- a/test/model-map.test.ts
+++ b/test/model-map.test.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, it, expect } from "vitest";
 import { MODEL_MAP, getNormalizedModel, isKnownModel } from "../lib/request/helpers/model-map.js";
+import { resolveUnsupportedCodexFallbackModel } from "../lib/request/fetch-helpers.js";
 
 const testDir = path.dirname(fileURLToPath(import.meta.url));
 
@@ -138,13 +139,49 @@ describe("Model Map Module", () => {
 	      expect(MODEL_MAP["gpt-5.3-codex-xhigh"]).toBe("gpt-5-codex");
 	    });
 
-	    it("contains GPT-5.3 codex spark models", () => {
-	      expect(MODEL_MAP["gpt-5.3-codex-spark"]).toBe("gpt-5-codex");
+    it("contains GPT-5.3 codex spark models", () => {
+      expect(MODEL_MAP["gpt-5.3-codex-spark"]).toBe("gpt-5-codex");
 	      expect(MODEL_MAP["gpt-5.3-codex-spark-low"]).toBe("gpt-5-codex");
 	      expect(MODEL_MAP["gpt-5.3-codex-spark-medium"]).toBe("gpt-5-codex");
 	      expect(MODEL_MAP["gpt-5.3-codex-spark-high"]).toBe("gpt-5-codex");
-	      expect(MODEL_MAP["gpt-5.3-codex-spark-xhigh"]).toBe("gpt-5-codex");
-	    });
+      expect(MODEL_MAP["gpt-5.3-codex-spark-xhigh"]).toBe("gpt-5-codex");
+    });
+
+    it("keeps legacy Codex normalization aligned with canonical fallback", () => {
+      const normalizedCodex = getNormalizedModel("gpt-5.2-codex");
+      expect(normalizedCodex).toBe("gpt-5-codex");
+      expect(getNormalizedModel("gpt-5.3-codex-spark")).toBe("gpt-5-codex");
+
+      const fallback = resolveUnsupportedCodexFallbackModel({
+        requestedModel: normalizedCodex,
+        errorBody: {
+          error: {
+            code: "model_not_supported_with_chatgpt_account",
+            message:
+              "The 'gpt-5-codex' model is not supported when using Codex with a ChatGPT account.",
+          },
+        },
+        attemptedModels: [normalizedCodex ?? ""],
+        fallbackOnUnsupportedCodexModel: true,
+        fallbackToGpt52OnUnsupportedGpt53: true,
+      });
+      expect(fallback).toBe("gpt-5.4");
+
+      const secondStepFallback = resolveUnsupportedCodexFallbackModel({
+        requestedModel: fallback,
+        errorBody: {
+          error: {
+            code: "model_not_supported_with_chatgpt_account",
+            message:
+              "The 'gpt-5.4' model is not supported when using Codex with a ChatGPT account.",
+          },
+        },
+        attemptedModels: [normalizedCodex ?? "", fallback],
+        fallbackOnUnsupportedCodexModel: false,
+        fallbackToGpt52OnUnsupportedGpt53: true,
+      });
+      expect(secondStepFallback).toBe("gpt-5.4-mini");
+    });
 
     it("contains GPT-5.1 codex-mini models", () => {
       expect(MODEL_MAP["gpt-5.1-codex-mini"]).toBe("gpt-5.1-codex-mini");


### PR DESCRIPTION
Fixes #153

## Summary
- Add canonical `gpt-5-codex -> gpt-5.4 -> gpt-5.4-mini -> gpt-5.4-nano` fallback coverage for normalized Codex selectors.
- Auto-fallback default public selectors (`gpt-5.5` and canonical `gpt-5-codex`) through the GPT-5.4 family when the backend reports they are not supported for the active account/workspace, preventing account-pool exhaustion on entitlement-gated selectors.
- Keep manual/legacy fallback chains behind `unsupportedCodexPolicy: "fallback"`; document `CODEX_AUTH_DISABLE_GPT55_AUTO_FALLBACK=1` and `CODEX_AUTH_DISABLE_CODEX_AUTO_FALLBACK=1` escape hatches.
- Add multi-hop regression coverage for legacy Codex selectors reaching blocked canonical Codex and then GPT-5.4-family fallback.
- Update unsupported-model guidance plus config/troubleshooting/configuration docs for legacy selector normalization and GPT-5.4-family fallback.

## Risk
- Medium-low: changes unsupported-model handling for canonical default selectors so users degrade through available GPT-5.4-family models instead of exhausting every account with the same entitlement error.
- Manual fallback chains remain opt-in, and `CODEX_AUTH_DISABLE_CODEX_AUTO_FALLBACK=1` restores strict canonical Codex/GPT-5.4-family behavior if needed.

## Verification
- Base main SHA: e6f458cc40e0155ca4b6af98ecc605745f2aa97f
- `npx vitest run test/fetch-helpers.test.ts test/model-map.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm test`
- `npm run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Expanded model fallback chains: GPT-5.5 and canonical Codex now auto-fallback through the GPT-5.4 family when unsupported, providing broader model availability.
  * New environment variables (`CODEX_AUTH_DISABLE_GPT55_AUTO_FALLBACK`, `CODEX_AUTH_DISABLE_CODEX_AUTO_FALLBACK`) to control auto-fallback behavior.

* **Documentation**
  * Enhanced configuration and troubleshooting guides with detailed fallback chain explanations and updated examples.
  * Improved error messages clarifying fallback policies and account-specific model support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

this pr extends the canonical codex auto-fallback to cover `gpt-5-codex → gpt-5.4 → gpt-5.4-mini → gpt-5.4-nano` and adds `gpt-5.4-mini → gpt-5.4-nano` as continuation hops for `gpt-5.5`, preventing account-pool exhaustion on entitlement-gated default selectors without touching the opt-in `fallback` policy path.

- `DEFAULT_UNSUPPORTED_CODEX_FALLBACK_CHAIN` gains `gpt-5-codex`, `gpt-5.4`, and `gpt-5.4-mini` entries; `resolveAutoFallbackEntryModel` uses the `attempted` set to distinguish continuation hops from direct user selection so strict policy is preserved for manually-configured models.
- tests are added for canonical codex multi-hop, legacy codex → blocked canonical → gpt-5.4 paths, and the codex opt-out env; the gpt-5.5 opt-out env has no test parity with the new codex opt-out test.
- docs and the exhausted-account error message are updated consistently across `config/README.md`, `docs/configuration.md`, `docs/troubleshooting.md`, and `index.ts`.

<h3>Confidence Score: 5/5</h3>

safe to merge; manual fallback chains are unchanged, auto-fallback is scoped to the two default public selectors, and the opt-out escape hatches work correctly in the existing runtime path.

the core change — extending the gpt-5.4 family continuation hops and adding `resolveAutoFallbackEntryModel` — is logically sound and well-tested for the runtime paths the actual retry loop exercises. the two gaps (missing gpt-5.5 opt-out test and the set-ordering edge case in `resolveAutoFallbackEntryModel`) are non-firing in production today and do not affect correctness for any currently observed request path.

`lib/request/fetch-helpers.ts` and `test/fetch-helpers.test.ts` — specifically the `resolveAutoFallbackEntryModel` function and the missing gpt-5.5 opt-out test parity.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/request/fetch-helpers.ts | extends DEFAULT_UNSUPPORTED_CODEX_FALLBACK_CHAIN to cover gpt-5.4-mini/nano; adds resolveAutoFallbackEntryModel for continuation-hop detection; ambiguity exists when both entry models appear in `attempted` (Set order-dependent) |
| test/fetch-helpers.test.ts | adds multi-hop and auto-fallback tests for gpt-5-codex and the gpt-5.4 family; covers codex opt-out env but omits a parallel test for gpt-5.5 opt-out env |
| test/model-map.test.ts | adds cross-module test verifying legacy codex normalization aligns with canonical fallback chain; no logic issues |
| index.ts | updates exhausted-account error message to reflect new auto-fallback behavior; wording is clearer and accurate |
| config/README.md | documentation updated to reflect extended gpt-5.4-mini/nano fallback chains and new escape-hatch env vars; accurate and consistent with code changes |
| docs/configuration.md | config table and examples updated to include gpt-5-codex canonical chain and both opt-out env vars; custom chain example corrected to show full mini/nano ladder |
| docs/troubleshooting.md | troubleshooting steps renumbered and expanded with auto-fallback context and disable env vars; documentation is clear and consistent |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[requestedModel] --> B{canonicalize}
    B --> C[currentModel]
    C --> D{resolveAutoFallbackEntryModel}
    D -->|currentModel is entry point| E[return currentModel]
    D -->|currentModel is continuation model| F{scan attempted Set}
    F -->|entry model found in attempted| G[return entry model]
    F -->|no entry model found| H[return undefined]
    E --> I{check opt-out env}
    G --> I
    H --> J[shouldAutoFallback = false]
    I -->|env not set| K[shouldAutoFallback = true]
    I -->|env = 1| J
    K --> L{fallbackOnUnsupportedCodexModel OR shouldAutoFallback?}
    J --> L
    L -->|no| M[return undefined - strict]
    L -->|yes| N[lookup chain targets]
    N --> O{skip attempted + self}
    O --> P[return next target]
    O --> Q[return undefined - chain exhausted]
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Foc-codex-multi-auth%22%20on%20the%20existing%20branch%20%22fix%2Fcodex-fallback-chain-153%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fcodex-fallback-chain-153%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Atest%2Ffetch-helpers.test.ts%3A641-688%0A**missing%20gpt-5.5%20opt-out%20vitest%20coverage**%0A%0Athe%20pr%20adds%20a%20test%20covering%20the%20codex%20auto-fallback%20opt-out%20env%20for%20both%20the%20entry%20hop%20%28%60gpt-5-codex%60%29%20and%20the%20continuation%20hop%20%28%60gpt-5.4%60%29.%20a%20symmetric%20test%20for%20the%20gpt-5.5%20opt-out%20env%20does%20not%20exist%20anywhere%20in%20the%20test%20file.%20given%20the%20extended%20chain%20%28%60gpt-5.5%20%E2%86%92%20gpt-5.4%20%E2%86%92%20gpt-5.4-mini%20%E2%86%92%20gpt-5.4-nano%60%29%20and%20both%20escape%20hatches%20being%20documented%20symmetrically%2C%20a%20regression%20in%20the%20gpt-5.5%20opt-out%20enforcement%20would%20ship%20silently.%20the%20missing%20test%20should%20verify%3A%20%28a%29%20%60requestedModel%3A%20'gpt-5.5'%60%20with%20the%20opt-out%20env%20set%20returns%20%60undefined%60%2C%20and%20%28b%29%20%60requestedModel%3A%20'gpt-5.4'%60%20with%20%60attempted%3A%20%5B'gpt-5.5'%2C%20'gpt-5.4'%5D%60%20and%20the%20opt-out%20env%20set%20also%20returns%20%60undefined%60.%0A%0A%23%23%23%20Issue%202%20of%202%0Alib%2Frequest%2Ffetch-helpers.ts%3A82-98%0A**%60resolveAutoFallbackEntryModel%60%20is%20Set-iteration-order-dependent%20when%20both%20entry%20models%20appear%20in%20%60attempted%60**%0A%0Awhen%20%60currentModel%60%20is%20a%20continuation%20model%20like%20%60gpt-5.4%60%2C%20the%20function%20scans%20%60attempted%60%20and%20returns%20whichever%20of%20%60gpt-5.5%60%20%2F%20%60gpt-5-codex%60%20it%20encounters%20first%20%28insertion%20order%29.%20if%20both%20appear%20%E2%80%94%20e.g.%20via%20a%20manually-built%20%60attemptedModels%60%20%E2%80%94%20the%20wrong%20opt-out%20env%20key%20is%20selected%3A%20a%20caller%20with%20only%20the%20codex%20opt-out%20set%20could%20land%20on%20the%20gpt-5.5%20env%20key%20and%20silently%20ignore%20the%20intended%20opt-out.%20the%20actual%20retry%20loop%20in%20%60index.ts%60%20only%20ever%20adds%20one%20entry%20model%20to%20%60attempted%60%2C%20so%20this%20doesn't%20fire%20in%20production%20today%2C%20but%20it%20is%20unguarded.%20consider%20asserting%20or%20returning%20%60undefined%60%20if%20more%20than%20one%20entry%20model%20appears%2C%20or%20documenting%20the%20ordering%20assumption%20explicitly.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
test/fetch-helpers.test.ts:641-688
**missing gpt-5.5 opt-out vitest coverage**

the pr adds a test covering the codex auto-fallback opt-out env for both the entry hop (`gpt-5-codex`) and the continuation hop (`gpt-5.4`). a symmetric test for the gpt-5.5 opt-out env does not exist anywhere in the test file. given the extended chain (`gpt-5.5 → gpt-5.4 → gpt-5.4-mini → gpt-5.4-nano`) and both escape hatches being documented symmetrically, a regression in the gpt-5.5 opt-out enforcement would ship silently. the missing test should verify: (a) `requestedModel: 'gpt-5.5'` with the opt-out env set returns `undefined`, and (b) `requestedModel: 'gpt-5.4'` with `attempted: ['gpt-5.5', 'gpt-5.4']` and the opt-out env set also returns `undefined`.

### Issue 2 of 2
lib/request/fetch-helpers.ts:82-98
**`resolveAutoFallbackEntryModel` is Set-iteration-order-dependent when both entry models appear in `attempted`**

when `currentModel` is a continuation model like `gpt-5.4`, the function scans `attempted` and returns whichever of `gpt-5.5` / `gpt-5-codex` it encounters first (insertion order). if both appear — e.g. via a manually-built `attemptedModels` — the wrong opt-out env key is selected: a caller with only the codex opt-out set could land on the gpt-5.5 env key and silently ignore the intended opt-out. the actual retry loop in `index.ts` only ever adds one entry model to `attempted`, so this doesn't fire in production today, but it is unguarded. consider asserting or returning `undefined` if more than one entry model appears, or documenting the ordering assumption explicitly.

`````

</details>

<sub>Reviews (5): Last reviewed commit: ["fix: handle normalized codex fallback"](https://github.com/ndycode/oc-codex-multi-auth/commit/5c138aab8af673a56edffc7470e69ed912054005) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31557565)</sub>

<!-- /greptile_comment -->