### PR TITLE
fix: resolve open oauth diagnostics issues

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -2,5 +2,8 @@
   "name": "oc-codex-multi-auth",
   "version": "6.1.9",
   "description": "Install and operate oc-codex-multi-auth for OpenCode with ChatGPT Plus/Pro OAuth, Codex/GPT-5 routing, multi-account rotation, account switching, health checks, diagnostics, quota status, and recovery tools.",
-  "skills": "./skills/"
+  "skills": "./skills/",
+  "interface": {
+    "composerIcon": "./assets/icon.svg"
+  }
 }

--- a/assets/icon.svg
+++ b/assets/icon.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-label="oc-codex-multi-auth icon">
+  <rect width="512" height="512" rx="112" fill="#0b0f19"/>
+  <circle cx="168" cy="178" r="54" fill="#38bdf8" opacity=".95"/>
+  <circle cx="344" cy="178" r="54" fill="#a78bfa" opacity=".95"/>
+  <circle cx="256" cy="334" r="64" fill="#34d399" opacity=".95"/>
+  <path d="M206 205 256 282l50-77" fill="none" stroke="#f8fafc" stroke-width="34" stroke-linecap="round" stroke-linejoin="round" opacity=".92"/>
+  <path d="M144 334h224" fill="none" stroke="#f8fafc" stroke-width="28" stroke-linecap="round" opacity=".9"/>
+</svg>

--- a/lib/auth/scopes.ts
+++ b/lib/auth/scopes.ts
@@ -3,8 +3,6 @@ export const REQUIRED_OAUTH_SCOPES = [
 	"profile",
 	"email",
 	"offline_access",
-	"api.connectors.read",
-	"api.connectors.invoke",
 ] as const;
 
 export const SCOPE = REQUIRED_OAUTH_SCOPES.join(" ");

--- a/lib/storage/identity.ts
+++ b/lib/storage/identity.ts
@@ -150,6 +150,82 @@ function mergeAccountRecords<T extends AccountLike>(target: T, source: T): T {
   };
 }
 
+function sameOptionalIdentity(left: string | undefined, right: string | undefined): boolean {
+  const normalizedLeft = normalizeWorkspaceIdentityPart(left);
+  const normalizedRight = normalizeWorkspaceIdentityPart(right);
+  return !!normalizedLeft && !!normalizedRight && normalizedLeft === normalizedRight;
+}
+
+function isLegacyRefreshTokenDuplicate<T extends AccountLike>(left: T, right: T): boolean {
+  const refreshToken = normalizeWorkspaceIdentityPart(left.refreshToken);
+  const leftOrganizationId = normalizeWorkspaceIdentityPart(left.organizationId);
+  const rightOrganizationId = normalizeWorkspaceIdentityPart(right.organizationId);
+  if (leftOrganizationId && rightOrganizationId && leftOrganizationId !== rightOrganizationId) {
+    return false;
+  }
+  const leftOrgLike = !!leftOrganizationId || left.accountIdSource === "org";
+  const rightOrgLike = !!rightOrganizationId || right.accountIdSource === "org";
+  const leftTokenLike = !leftOrganizationId && left.accountIdSource === "token";
+  const rightTokenLike = !rightOrganizationId && right.accountIdSource === "token";
+  if (
+    ((leftOrgLike && rightTokenLike) || (rightOrgLike && leftTokenLike)) &&
+    (sameOptionalIdentity(left.email, right.email) ||
+      (!!refreshToken && refreshToken === normalizeWorkspaceIdentityPart(right.refreshToken)))
+  ) {
+    return true;
+  }
+  if (!refreshToken || refreshToken !== normalizeWorkspaceIdentityPart(right.refreshToken)) {
+    return false;
+  }
+
+  const leftAccountId = normalizeWorkspaceIdentityPart(left.accountId);
+  const rightAccountId = normalizeWorkspaceIdentityPart(right.accountId);
+  if (leftAccountId && rightAccountId && leftAccountId !== rightAccountId) {
+    return false;
+  }
+
+  return (
+    sameOptionalIdentity(left.accountId, right.accountId) ||
+    (!leftOrganizationId && !!rightOrganizationId && !left.accountId) ||
+    (!!leftOrganizationId && !rightOrganizationId && !right.accountId)
+  );
+}
+
+function deduplicateLegacyRefreshTokenDuplicates<T extends AccountLike>(accounts: T[]): T[] {
+  const working = [...accounts];
+  const indicesToRemove = new Set<number>();
+
+  for (let i = 0; i < working.length; i += 1) {
+    if (indicesToRemove.has(i)) continue;
+    const account = working[i];
+    if (!account) continue;
+
+    for (let j = i + 1; j < working.length; j += 1) {
+      if (indicesToRemove.has(j)) continue;
+      const candidate = working[j];
+      if (!candidate || !isLegacyRefreshTokenDuplicate(account, candidate)) continue;
+
+      const accountOrgLike = !!normalizeWorkspaceIdentityPart(account.organizationId) || account.accountIdSource === "org";
+      const candidateOrgLike = !!normalizeWorkspaceIdentityPart(candidate.organizationId) || candidate.accountIdSource === "org";
+      const newestIndex = accountOrgLike && !candidateOrgLike
+        ? i
+        : candidateOrgLike && !accountOrgLike
+          ? j
+          : pickNewestAccountIndex(working, i, j);
+      const obsoleteIndex = newestIndex === i ? j : i;
+      const target = working[newestIndex];
+      const source = working[obsoleteIndex];
+      if (target && source) {
+        working[newestIndex] = mergeAccountRecords(target, source);
+      }
+      indicesToRemove.add(obsoleteIndex);
+      if (obsoleteIndex === i) break;
+    }
+  }
+
+  return working.filter((account, index) => !!account && !indicesToRemove.has(index));
+}
+
 function deduplicateAccountsByKey<T extends AccountLike>(accounts: T[]): T[] {
   const working = [...accounts];
   const keyToIndex = new Map<string, number>();
@@ -282,5 +358,5 @@ export function deduplicateAccountsByEmail<T extends { organizationId?: string; 
  * 2) Then apply legacy email dedupe only for entries that still do not have organizationId/accountId.
  */
 export function deduplicateAccountsForStorage<T extends AccountLike & { email?: string }>(accounts: T[]): T[] {
-  return deduplicateAccountsByEmail(deduplicateAccountsByKey(accounts));
+  return deduplicateAccountsByEmail(deduplicateLegacyRefreshTokenDuplicates(deduplicateAccountsByKey(accounts)));
 }

--- a/scripts/install-oc-codex-multi-auth-core.js
+++ b/scripts/install-oc-codex-multi-auth-core.js
@@ -13,6 +13,43 @@ const STALE_MANAGED_MODEL_KEYS = new Set([
 	"gpt-5.3-codex",
 	"gpt-5.4",
 ]);
+const STANDALONE_COMMANDS = new Set(["doctor", "status", "list", "limits", "dashboard", "health", "diag"]);
+const INSTALLER_COMMANDS = new Set(["install"]);
+
+function splitCommandArgv(argv) {
+	const [first, ...rest] = argv;
+	if (!first) return { kind: "install", argv };
+	if (INSTALLER_COMMANDS.has(first)) return { kind: "install", argv: rest };
+	if (STANDALONE_COMMANDS.has(first)) return { kind: "standalone", command: first, argv: rest };
+	if (first.startsWith("-")) return { kind: "install", argv };
+	return { kind: "unknown", command: first, argv: rest };
+}
+
+function parseStandaloneArgs(argv) {
+	const options = {
+		json: false,
+		includeSensitive: false,
+		deep: false,
+		fix: false,
+		tag: undefined,
+		configPath: undefined,
+		help: false,
+	};
+	for (let index = 0; index < argv.length; index += 1) {
+		const arg = argv[index];
+		if (arg === "--json") options.json = true;
+		else if (arg === "--include-sensitive") options.includeSensitive = true;
+		else if (arg === "--deep") options.deep = true;
+		else if (arg === "--fix") options.fix = true;
+		else if (arg === "--tag") options.tag = argv[++index];
+		else if (arg.startsWith("--tag=")) options.tag = arg.slice("--tag=".length);
+		else if (arg === "--config-path") options.configPath = argv[++index];
+		else if (arg.startsWith("--config-path=")) options.configPath = arg.slice("--config-path=".length);
+		else if (arg === "--help" || arg === "-h") options.help = true;
+		else throw new Error(`Unknown option for standalone command: ${arg}`);
+	}
+	return options;
+}
 
 function getManagedPackageNames() {
 	return [PACKAGE_NAME, ...LEGACY_PACKAGE_NAMES];
@@ -37,7 +74,17 @@ export function isDirectRunPath(argvPath, modulePath, resolveRealPath = realpath
 }
 
 function printHelp() {
-	console.log(`Usage: ${PACKAGE_NAME} [--modern|--full|--legacy] [--dry-run] [--no-cache-clear]\n\n` +
+	console.log(`Usage: ${PACKAGE_NAME} [command] [options]\n\n` +
+		"Commands:\n" +
+		"  install             Install/update OpenCode config (default with no command)\n" +
+		"  doctor              Run local account/config diagnostics\n" +
+		"  status              Show account/config status\n" +
+		"  list                List configured accounts\n" +
+		"  limits              Show stored rate-limit state\n" +
+		"  dashboard           Print dashboard guidance\n" +
+		"  health              Check local token/account health\n" +
+		"  diag                Alias for doctor --deep\n\n" +
+		`Installer usage: ${PACKAGE_NAME} [--modern|--full|--legacy] [--dry-run] [--no-cache-clear]\n\n` +
 		"Default behavior:\n" +
 		"  - Installs/updates global config at ~/.config/opencode/opencode.json\n" +
 		"  - Enables the prompt status bar TUI plugin at ~/.config/opencode/tui.json\n" +
@@ -171,6 +218,183 @@ function mergeTuiConfig(existingConfig) {
 
 function formatJson(obj) {
 	return `${JSON.stringify(obj, null, 2)}\n`;
+}
+
+function getStandaloneStoragePath(options, env = process.env) {
+	if (options.configPath) return resolve(options.configPath);
+	return join(resolveHomeDirectory(env), ".opencode", "oc-codex-multi-auth-accounts.json");
+}
+
+async function readStandaloneStorage(path) {
+	try {
+		const raw = await readFile(path, "utf-8");
+		const parsed = JSON.parse(raw);
+		return {
+			storage: parsed && typeof parsed === "object" ? normalizeStandaloneStorage(parsed) : null,
+			error: null,
+		};
+	} catch (error) {
+		if (error?.code === "ENOENT") return { storage: null, error: null };
+		return { storage: null, error: formatErrorForLog(error) };
+	}
+}
+
+function normalizeStandaloneIdentityPart(value) {
+	return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function sameStandaloneIdentity(left, right) {
+	const normalizedLeft = normalizeStandaloneIdentityPart(left);
+	const normalizedRight = normalizeStandaloneIdentityPart(right);
+	return !!normalizedLeft && !!normalizedRight && normalizedLeft === normalizedRight;
+}
+
+function isStandaloneOrgTokenDuplicate(left, right) {
+	const leftOrganizationId = normalizeStandaloneIdentityPart(left?.organizationId);
+	const rightOrganizationId = normalizeStandaloneIdentityPart(right?.organizationId);
+	if (leftOrganizationId && rightOrganizationId && leftOrganizationId !== rightOrganizationId) return false;
+	const leftOrgLike = !!leftOrganizationId || left?.accountIdSource === "org";
+	const rightOrgLike = !!rightOrganizationId || right?.accountIdSource === "org";
+	const leftTokenLike = !leftOrganizationId && left?.accountIdSource === "token";
+	const rightTokenLike = !rightOrganizationId && right?.accountIdSource === "token";
+	if (!((leftOrgLike && rightTokenLike) || (rightOrgLike && leftTokenLike))) return false;
+	return sameStandaloneIdentity(left?.email, right?.email) ||
+		sameStandaloneIdentity(left?.refreshToken, right?.refreshToken);
+}
+
+function mergeStandaloneAccounts(target, source) {
+	const targetOrgLike = !!normalizeStandaloneIdentityPart(target?.organizationId) || target?.accountIdSource === "org";
+	const sourceOrgLike = !!normalizeStandaloneIdentityPart(source?.organizationId) || source?.accountIdSource === "org";
+	if (targetOrgLike || !sourceOrgLike) {
+		return {
+			...source,
+			...target,
+			organizationId: target.organizationId ?? source.organizationId,
+			accountId: target.accountId ?? source.accountId,
+			accountIdSource: target.accountIdSource ?? source.accountIdSource,
+			accountLabel: target.accountLabel ?? source.accountLabel,
+			email: target.email ?? source.email,
+		};
+	}
+	return mergeStandaloneAccounts(source, target);
+}
+
+function normalizeStandaloneStorage(storage) {
+	if (!Array.isArray(storage.accounts)) return storage;
+	const accounts = [...storage.accounts];
+	const removed = new Set();
+	for (let i = 0; i < accounts.length; i += 1) {
+		if (removed.has(i)) continue;
+		for (let j = i + 1; j < accounts.length; j += 1) {
+			if (removed.has(j) || !isStandaloneOrgTokenDuplicate(accounts[i], accounts[j])) continue;
+			const leftOrgLike = !!normalizeStandaloneIdentityPart(accounts[i]?.organizationId) ||
+				accounts[i]?.accountIdSource === "org";
+			const targetIndex = leftOrgLike ? i : j;
+			const sourceIndex = targetIndex === i ? j : i;
+			accounts[targetIndex] = mergeStandaloneAccounts(accounts[targetIndex], accounts[sourceIndex]);
+			removed.add(sourceIndex);
+			if (sourceIndex === i) break;
+		}
+	}
+	const normalizedAccounts = accounts.filter((_, index) => !removed.has(index));
+	return {
+		...storage,
+		accounts: normalizedAccounts,
+		activeIndex: Math.max(0, Math.min(storage.activeIndex ?? 0, Math.max(0, normalizedAccounts.length - 1))),
+	};
+}
+
+function maskValue(value, includeSensitive) {
+	if (includeSensitive || typeof value !== "string" || value.length <= 8) return value;
+	return `${value.slice(0, 4)}...${value.slice(-4)}`;
+}
+
+function summarizeStandaloneAccounts(storage, includeSensitive, tag) {
+	const accounts = Array.isArray(storage?.accounts) ? storage.accounts : [];
+	const normalizedTag = typeof tag === "string" ? tag.trim().toLowerCase() : "";
+	return accounts
+		.map((account, index) => ({ account, index }))
+		.filter(({ account }) => !normalizedTag ||
+			(Array.isArray(account?.accountTags) &&
+				account.accountTags.some((entry) => String(entry).toLowerCase() === normalizedTag)))
+		.map(({ account, index }) => ({
+			index,
+			label: account?.accountLabel ?? `Account ${index + 1}`,
+			email: maskValue(account?.email, includeSensitive),
+			accountId: maskValue(account?.accountId, includeSensitive),
+			accountIdSource: account?.accountIdSource,
+			enabled: account?.enabled !== false,
+			hasRefreshToken: typeof account?.refreshToken === "string" && account.refreshToken.length > 0,
+			hasAccessToken: typeof account?.accessToken === "string" && account.accessToken.length > 0,
+			expiresAt: account?.expiresAt,
+			expired: typeof account?.expiresAt === "number" ? account.expiresAt <= Date.now() : undefined,
+			tags: Array.isArray(account?.accountTags) ? account.accountTags : [],
+			note: account?.accountNote,
+			rateLimitResetTimes: account?.rateLimitResetTimes ?? {},
+		}));
+}
+
+function printStandaloneResult(command, payload, json) {
+	if (json) {
+		console.log(JSON.stringify(payload, null, 2));
+		return;
+	}
+	console.log(`oc-codex-multi-auth ${command}`);
+	if (payload.message) console.log(payload.message);
+	console.log(`Storage: ${payload.storagePath}`);
+	console.log(`Accounts: ${payload.totalAccounts}`);
+	if (Array.isArray(payload.accounts)) {
+		for (const account of payload.accounts) {
+			console.log(`- [${account.index}] ${account.label} enabled=${account.enabled} refresh=${account.hasRefreshToken} access=${account.hasAccessToken}`);
+		}
+	}
+	if (payload.error) console.log(`Error: ${payload.error}`);
+	if (payload.nextAction) console.log(`Next: ${payload.nextAction}`);
+}
+
+export async function runStandaloneCommand(command, argv = [], options = {}) {
+	const parsed = parseStandaloneArgs(argv);
+	if (command === "diag") {
+		command = "doctor";
+		parsed.deep = true;
+	}
+	if (parsed.help) {
+		printHelp();
+		return { exitCode: 0, action: "help" };
+	}
+	const { env = process.env } = options;
+	const storagePath = getStandaloneStoragePath(parsed, env);
+	const { storage, error } = await readStandaloneStorage(storagePath);
+	const accounts = summarizeStandaloneAccounts(storage, parsed.includeSensitive, parsed.tag);
+	const totalAccounts = Array.isArray(storage?.accounts) ? storage.accounts.length : 0;
+	const payload = {
+		command,
+		storagePath,
+		totalAccounts,
+		shownAccounts: accounts.length,
+		activeIndex: typeof storage?.activeIndex === "number" ? storage.activeIndex : 0,
+		activeIndexByFamily: storage?.activeIndexByFamily ?? {},
+		accounts,
+		error,
+	};
+	if (command === "dashboard") {
+		payload.message = "Standalone dashboard server is not launched by this safe CLI; use status/list/limits/health or OpenCode codex-dashboard.";
+		payload.nextAction = "Run oc-codex-multi-auth status or open OpenCode and call codex-dashboard.";
+	} else if (command === "doctor") {
+		payload.message = error ? "Storage could not be parsed." : totalAccounts > 0 ? "Local diagnostics completed." : "No accounts configured.";
+		payload.deep = parsed.deep;
+		payload.fixApplied = parsed.fix ? false : undefined;
+		payload.nextAction = totalAccounts > 0 ? "Run oc-codex-multi-auth health --json for scriptable checks." : "Run opencode auth login.";
+	} else if (command === "limits") {
+		payload.rateLimits = accounts.map((account) => ({ index: account.index, rateLimitResetTimes: account.rateLimitResetTimes }));
+	} else if (command === "health") {
+		payload.healthyCount = accounts.filter((account) => account.enabled && account.hasRefreshToken).length;
+		payload.unhealthyCount = accounts.filter((account) => !account.enabled || !account.hasRefreshToken).length;
+	} else if (command === "status") {
+		payload.message = totalAccounts > 0 ? "Account storage loaded." : "No accounts configured.";
+	}
+	printStandaloneResult(command, payload, parsed.json);
+	return { exitCode: error ? 1 : 0, action: command, storagePath };
 }
 
 // Top-level keys inside `provider.openai` that the installer owns absolutely.
@@ -443,7 +667,15 @@ async function clearCache(paths, dryRun, skipCacheClear) {
 }
 
 export async function runInstaller(argv = process.argv.slice(2), options = {}) {
-	const parsed = parseCliArgs(argv);
+	const split = splitCommandArgv(argv);
+	if (split.kind === "standalone") {
+		return runStandaloneCommand(split.command, split.argv, options);
+	}
+	if (split.kind === "unknown") {
+		printHelp();
+		throw new Error(`Unknown command: ${split.command}`);
+	}
+	const parsed = parseCliArgs(split.argv);
 	if (parsed.wantsHelp) {
 		printHelp();
 		return { exitCode: 0, action: "help" };
@@ -575,6 +807,8 @@ export const __test = {
 	mergeOpenaiProvider,
 	mergeTuiConfig,
 	parseCliArgs,
+	runStandaloneCommand,
+	splitCommandArgv,
 	writeFileAtomic,
 	renameWithWindowsRetry,
 	resolveHomeDirectory,

--- a/test/accounts.test.ts
+++ b/test/accounts.test.ts
@@ -205,21 +205,20 @@ describe("AccountManager", () => {
     expect(manager.getCurrentAccount()?.refreshToken).toBe("refresh-token");
   });
 
-  it("creates a disabled fallback account with a re-auth note when fallback scopes are missing", () => {
+  it("keeps fallback account enabled when connector scopes are missing", () => {
     const auth: OAuthAuthDetails = {
       type: "oauth",
       access: "access-token",
       refresh: "refresh-token",
       expires: Date.now() + 60_000,
+      scope: "openid profile email offline_access",
     };
 
     const manager = new AccountManager(auth, null);
     expect(manager.getAccountCount()).toBe(1);
     const account = manager.getCurrentAccount();
-    expect(account?.enabled).toBe(false);
-    expect(account?.accountNote).toContain("Re-auth required");
-    expect(account?.accountNote).toContain("api.connectors.read");
-    expect(account?.accountNote).toContain("api.connectors.invoke");
+    expect(account?.enabled).toBe(true);
+    expect(account?.accountNote).toBeUndefined();
   });
 
 	it("does not duplicate the re-auth note when the same fallback account is reloaded", () => {
@@ -230,8 +229,9 @@ describe("AccountManager", () => {
       accounts: [
         {
           refreshToken: "refresh-token",
+          oauthScope: "openid profile email offline_access",
           accountNote:
-            "Re-auth required for missing OAuth scope(s): openid, profile, email, offline_access, api.connectors.read, api.connectors.invoke.",
+            "Re-auth required for missing OAuth scope(s): api.connectors.read, api.connectors.invoke.",
           addedAt: now,
           lastUsed: now,
         },
@@ -247,8 +247,10 @@ describe("AccountManager", () => {
 
     const manager = new AccountManager(auth, stored);
     const account = manager.getCurrentAccount();
-    expect(account?.enabled).toBe(false);
-		expect(account?.accountNote?.match(/Re-auth required/g)).toHaveLength(1);
+    expect(account?.enabled).toBe(true);
+		expect(account?.accountNote).toBe(
+			"Re-auth required for missing OAuth scope(s): api.connectors.read, api.connectors.invoke.",
+		);
 	});
 
 	it("keeps stored accounts enabled when OAuth scope metadata is missing", () => {

--- a/test/auth.test.ts
+++ b/test/auth.test.ts
@@ -199,8 +199,8 @@ describe('Auth Module', () => {
 			expect(url.searchParams.get('client_id')).toBe(CLIENT_ID);
 			expect(url.searchParams.get('redirect_uri')).toBe(REDIRECT_URI);
 			expect(url.searchParams.get('scope')).toBe(SCOPE);
-			expect(SCOPE).toContain('api.connectors.read');
-			expect(SCOPE).toContain('api.connectors.invoke');
+			expect(SCOPE).not.toContain('api.connectors.read');
+			expect(SCOPE).not.toContain('api.connectors.invoke');
 			expect(url.searchParams.get('code_challenge_method')).toBe('S256');
 			expect(url.searchParams.get('code_challenge')).toBe(flow.pkce.challenge);
 			expect(url.searchParams.get('state')).toBe(flow.state);

--- a/test/doc-parity.test.ts
+++ b/test/doc-parity.test.ts
@@ -501,10 +501,13 @@ describe("runtime documentation parity", () => {
 		const pluginJson = JSON.parse(readRepoFile(".codex-plugin/plugin.json")) as {
 			description?: string;
 			version?: string;
+			interface?: { composerIcon?: string };
 		};
 		expect(pluginJson.version).toBe(packageJson.version);
 		expect(pluginJson.description).toContain("OpenCode");
 		expect(pluginJson.description).toContain("multi-account rotation");
+		expect(pluginJson.interface?.composerIcon).toBe("./assets/icon.svg");
+		expect(repoPathExists(pluginJson.interface?.composerIcon.replace(/^\.\//, "") ?? "")).toBe(true);
 
 		const installerPath = packageJson.bin?.["oc-codex-multi-auth"];
 		expect(installerPath).toBe("scripts/install-oc-codex-multi-auth.js");

--- a/test/standalone-cli.test.ts
+++ b/test/standalone-cli.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+async function createTempHome() {
+	return mkdtemp(join(tmpdir(), "oc-codex-standalone-"));
+}
+
+describe("standalone oc-codex-multi-auth CLI commands", () => {
+	let tempHome: string | null = null;
+
+	afterEach(async () => {
+		vi.restoreAllMocks();
+		if (tempHome) {
+			await rm(tempHome, { recursive: true, force: true });
+			tempHome = null;
+		}
+	});
+
+	it("runs status as JSON without installer writes", async () => {
+		vi.resetModules();
+		tempHome = await createTempHome();
+		const opencodeDir = join(tempHome, ".opencode");
+		await mkdir(opencodeDir, { recursive: true });
+		await writeFile(
+			join(opencodeDir, "oc-codex-multi-auth-accounts.json"),
+			JSON.stringify({
+				version: 3,
+				activeIndex: 0,
+				accounts: [
+					{
+						accountLabel: "Personal",
+						email: "user@example.com",
+						accountId: "acct_123456789",
+						accountIdSource: "token",
+						refreshToken: "refresh-token",
+						accessToken: "access-token",
+						addedAt: Date.now(),
+						lastUsed: Date.now(),
+					},
+				],
+			}, null, 2),
+			"utf-8",
+		);
+		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const { runInstaller } = await import("../scripts/install-oc-codex-multi-auth-core.js");
+
+		await expect(runInstaller(["status", "--json"], {
+			env: { ...process.env, HOME: tempHome, USERPROFILE: tempHome },
+		})).resolves.toMatchObject({ action: "status", exitCode: 0 });
+
+		const output = JSON.parse(String(logSpy.mock.calls.at(-1)?.[0]));
+		expect(output.totalAccounts).toBe(1);
+		expect(output.accounts[0].email).toBe("user....com");
+	});
+
+	it("rejects unknown positional commands instead of installing", async () => {
+		vi.resetModules();
+		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const { runInstaller } = await import("../scripts/install-oc-codex-multi-auth-core.js");
+
+		await expect(runInstaller(["wat"])).rejects.toThrow("Unknown command: wat");
+		expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("Commands:"));
+	});
+});
+

--- a/test/storage.test.ts
+++ b/test/storage.test.ts
@@ -339,8 +339,8 @@ describe("storage", () => {
           {
             accountId: "workspace-token",
             accountIdSource: "token",
-            refreshToken: "shared-refresh",
-            email: "user@example.com",
+            refreshToken: "other-refresh",
+            email: "other@example.com",
             addedAt: 101,
             lastUsed: 201,
             rateLimitResetTimes: {
@@ -365,7 +365,7 @@ describe("storage", () => {
       expect(tokenVariant?.rateLimitResetTimes?.["gpt-5.1"]).toBe(4_444);
       expect(tokenVariant?.coolingDownUntil).toBe(5_555);
       expect(tokenVariant?.cooldownReason).toBe("network-error");
-      expect(tokenVariant?.refreshToken).toBe("shared-refresh");
+      expect(tokenVariant?.refreshToken).toBe("other-refresh");
     });
 
     it("collapses same-organization records to newest during import and remaps active keys", async () => {
@@ -2214,7 +2214,7 @@ describe("storage", () => {
       await fs.rm(testWorkDir, { recursive: true, force: true });
     });
 
-    it("preserves org/token workspace variants sharing a refresh token when accountId differs", async () => {
+    it("collapses org/token duplicates for the same login identity", async () => {
       const now = Date.now();
       const storage = {
         version: 3 as const,
@@ -2243,12 +2243,10 @@ describe("storage", () => {
       await saveAccounts(storage);
 
       const loaded = await loadAccounts();
-      expect(loaded?.accounts).toHaveLength(2);
-      expect(loaded?.accounts.every((account) => account.refreshToken === "shared-refresh-kira")).toBe(true);
-      expect(loaded?.accounts.map((account) => account.accountId).sort()).toEqual([
-        "7ff374aa-1b2e-4e69-89f3-0cec62582efb",
-        "org-i1iYFgVqyAkR8CLrUKvNczIa",
-      ]);
+      expect(loaded?.accounts).toHaveLength(1);
+      expect(loaded?.accounts[0]?.refreshToken).toBe("shared-refresh-kira");
+      expect(loaded?.accounts[0]?.organizationId).toBe("org-i1iYFgVqyAkR8CLrUKvNczIa");
+      expect(loaded?.accounts[0]?.accountId).toBe("org-i1iYFgVqyAkR8CLrUKvNczIa");
     });
 
     it("retries on EPERM and succeeds on second attempt", async () => {


### PR DESCRIPTION
## Summary
- add marketplace-ready plugin icon metadata and asset coverage
- restrict required OAuth scopes to baseline OpenAI OAuth scopes and dedupe legacy personal workspace/token duplicates safely
- expose safe standalone diagnostic subcommands through the existing `oc-codex-multi-auth` bin

Closes #155
Closes #156
Closes #157

## Notes
- External `awesome-codex-plugins` marketplace icon copy remains follow-up and is not included here.
- No separate global `codex-doctor`-style binaries were added.

## Testing
- `npx vitest run test/auth.test.ts test/accounts.test.ts test/storage.test.ts test/doc-parity.test.ts test/install-oc-codex-multi-auth.test.ts test/standalone-cli.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm test`
- `npm run build`
- `npm run audit:ci`
- `npm pack --dry-run` (confirmed `assets/icon.svg` is included)
- Smoke: `node scripts/install-oc-codex-multi-auth.js status --json`
- Smoke: `node scripts/install-oc-codex-multi-auth.js wat` (prints help and fails unknown command instead of installing)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added standalone CLI diagnostic commands (`doctor`, `status`, `list`, `health`) for account management and troubleshooting.

* **Improvements**
  * Simplified OAuth permission requirements by removing connector-specific scopes.
  * Enhanced account deduplication to resolve legacy token conflicts.
  * Added plugin icon configuration support.

* **Tests**
  * Added comprehensive test coverage for standalone CLI functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

this pr fixes three open issues: strips connector-specific oauth scopes down to the openai baseline, adds legacy org/token duplicate collapse in the storage dedup pipeline, and exposes safe read-only diagnostic subcommands (`doctor`, `status`, `list`, `limits`, `health`, `diag`, `dashboard`) through the existing `oc-codex-multi-auth` bin. a marketplace plugin icon is also wired in.

- **scopes**: `api.connectors.read` and `api.connectors.invoke` removed from `REQUIRED_OAUTH_SCOPES`; fallback-account tests updated to match.
- **identity dedup**: `deduplicateLegacyRefreshTokenDuplicates` added to `lib/storage/identity.ts` and inserted into the `deduplicateAccountsForStorage` pipeline to collapse org/token pairs sharing the same login identity.
- **standalone cli**: `splitCommandArgv` routes known diagnostic commands to `runStandaloneCommand`, which reads storage read-only and prints or emits json; `normalizeStandaloneStorage` also deduplicates accounts in the standalone path.

<h3>Confidence Score: 4/5</h3>

safe to merge for the scope/icon/dedup core changes; the new standalone diagnostic path has an activeIndex remapping defect that causes wrong active-account reporting in json output after legacy duplicates are collapsed

the scopes change and identity.ts dedup logic are well-tested and clean. the standalone diagnostic commands are read-only and cannot corrupt stored data. however, normalizeStandaloneStorage clamps activeIndex instead of remapping it after filtering removed entries, so when the active account is the token-like duplicate that gets merged away, status/health --json reports the wrong activeIndex, misleading any script keying off that field

scripts/install-oc-codex-multi-auth-core.js — normalizeStandaloneStorage activeIndex remapping

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| scripts/install-oc-codex-multi-auth-core.js | adds standalone CLI subcommands (doctor/status/list/limits/health/diag/dashboard) with a read-only storage snapshot path; activeIndex remapping after dedup is broken (reports wrong active account when token variant was active) |
| lib/storage/identity.ts | adds isLegacyRefreshTokenDuplicate + deduplicateLegacyRefreshTokenDuplicates and wires them into deduplicateAccountsForStorage; stale-snapshot issue in inner loop already tracked in previous review thread |
| lib/auth/scopes.ts | removes api.connectors.read and api.connectors.invoke from REQUIRED_OAUTH_SCOPES, reducing to baseline openid/profile/email/offline_access |
| test/standalone-cli.test.ts | new test file covers status --json and unknown-command rejection; doctor/diag/health/limits/dashboard/list and flag edge cases remain uncovered (noted in prior thread) |
| test/storage.test.ts | updates existing test to reflect new collapse-to-one behaviour for org/token same-login-identity duplicates |
| test/accounts.test.ts | updates fallback-account tests to reflect that connector scopes are no longer required; disabled/re-auth note expectations corrected |
| .codex-plugin/plugin.json | adds interface.composerIcon pointing to the new assets/icon.svg for marketplace plugin icon support |
| assets/icon.svg | new SVG icon asset with role/aria-label, no security concerns |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["bin: oc-codex-multi-auth argv"] --> B["splitCommandArgv"]
    B -->|"standalone command"| C["runStandaloneCommand"]
    B -->|"install / flags"| D["runInstaller (existing)"]
    B -->|"unknown"| E["printHelp + throw"]
    C --> F["parseStandaloneArgs"]
    F -->|"--help / -h"| G["printHelp exit 0"]
    F --> H["getStandaloneStoragePath"]
    H -->|"--config-path"| I["resolve(configPath)"]
    H -->|"default"| J["HOME/.opencode/accounts.json"]
    I --> K["readStandaloneStorage"]
    J --> K
    K --> L["normalizeStandaloneStorage dedup"]
    L --> M["summarizeStandaloneAccounts mask"]
    M --> N["printStandaloneResult or --json"]
    subgraph "identity.ts dedup pipeline"
        P["deduplicateAccountsForStorage"] --> Q["deduplicateAccountsByKey"]
        Q --> R["deduplicateLegacyRefreshTokenDuplicates new"]
        R --> S["deduplicateAccountsByEmail"]
    end
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Foc-codex-multi-auth%22%20on%20the%20existing%20branch%20%22fix%2Fopen-issues-155-156-157%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fopen-issues-155-156-157%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Ascripts%2Finstall-oc-codex-multi-auth-core.js%3A282-304%0A**%60activeIndex%60%20not%20remapped%20after%20dedup%20filter**%0A%0Awhen%20a%20token-like%20account%20is%20chosen%20as%20%60sourceIndex%60%20and%20merged%20into%20the%20org-like%20%60targetIndex%60%2C%20the%20token%20slot%20is%20added%20to%20%60removed%60%20and%20filtered%20out%20%E2%80%94%20but%20%60normalizeStandaloneStorage%60%20only%20clamps%20%60storage.activeIndex%60%20to%20%60%5B0%2C%20length-1%5D%60%20instead%20of%20remapping%20it%20to%20the%20account's%20new%20position.%20concrete%20failure%3A%20with%20%60accounts%20%3D%20%5Borg%280%29%2C%20token%281%29%2C%20other%282%29%5D%60%20where%20%60activeIndex%3D1%60%2C%20dedup%20sets%20%60removed%3D%7B1%7D%60%20%E2%86%92%20%60normalizedAccounts%20%3D%20%5Bmerged%280%29%2C%20other%281%29%5D%60%2C%20then%20%60Math.min%281%2C%201%29%20%3D%201%60%20reports%20%22other%22%20as%20active%2C%20silently%20dropping%20the%20correct%20pointer%20to%20the%20merged%20org%20account.%20any%20%60status%20--json%60%20or%20%60health%20--json%60%20consumer%20scripting%20off%20%60activeIndex%60%20will%20see%20the%20wrong%20account.%0A%0A%23%23%23%20Issue%202%20of%202%0Ascripts%2Finstall-oc-codex-multi-auth-core.js%3A38-53%0A**%60--tag%60%20%2F%20%60--config-path%60%20silently%20drop%20trailing%20valueless%20flag**%0A%0A%60--tag%60%20%28line%2044%29%20and%20%60--config-path%60%20%28line%2046%29%20consume%20the%20next%20%60argv%5B%2B%2Bindex%5D%60.%20when%20either%20flag%20is%20the%20last%20token%20in%20%60argv%60%2C%20%60argv%5B%2B%2Bindex%5D%60%20is%20%60undefined%60%20and%20%60options.tag%60%20%2F%20%60options.configPath%60%20stay%20%60undefined%60%20%E2%80%94%20no%20error%2C%20no%20diagnostic%20message.%20the%20user%20likely%20intended%20to%20set%20a%20value%20and%20will%20see%20unexpected%20%22all%20accounts%22%20%2F%20default-path%20behavior%20with%20no%20indication%20of%20what%20went%20wrong.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
scripts/install-oc-codex-multi-auth-core.js:282-304
**`activeIndex` not remapped after dedup filter**

when a token-like account is chosen as `sourceIndex` and merged into the org-like `targetIndex`, the token slot is added to `removed` and filtered out — but `normalizeStandaloneStorage` only clamps `storage.activeIndex` to `[0, length-1]` instead of remapping it to the account's new position. concrete failure: with `accounts = [org(0), token(1), other(2)]` where `activeIndex=1`, dedup sets `removed={1}` → `normalizedAccounts = [merged(0), other(1)]`, then `Math.min(1, 1) = 1` reports "other" as active, silently dropping the correct pointer to the merged org account. any `status --json` or `health --json` consumer scripting off `activeIndex` will see the wrong account.

### Issue 2 of 2
scripts/install-oc-codex-multi-auth-core.js:38-53
**`--tag` / `--config-path` silently drop trailing valueless flag**

`--tag` (line 44) and `--config-path` (line 46) consume the next `argv[++index]`. when either flag is the last token in `argv`, `argv[++index]` is `undefined` and `options.tag` / `options.configPath` stay `undefined` — no error, no diagnostic message. the user likely intended to set a value and will see unexpected "all accounts" / default-path behavior with no indication of what went wrong.

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: resolve open oauth diagnostics issu..."](https://github.com/ndycode/oc-codex-multi-auth/commit/bc63edfc691b1a500a3b33025fac3e6b6aa2591c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33143287)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->