### PR TITLE
chore: bump version to 6.1.10

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "oc-codex-multi-auth",
-  "version": "6.1.9",
+  "version": "6.1.10",
   "description": "Install and operate oc-codex-multi-auth for OpenCode with ChatGPT Plus/Pro OAuth, Codex/GPT-5 routing, multi-account rotation, account switching, health checks, diagnostics, quota status, and recovery tools.",
   "skills": "./skills/",
   "interface": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oc-codex-multi-auth",
-  "version": "6.1.9",
+  "version": "6.1.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oc-codex-multi-auth",
-      "version": "6.1.9",
+      "version": "6.1.10",
       "license": "MIT",
       "dependencies": {
         "@napi-rs/keyring": "~1.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oc-codex-multi-auth",
-  "version": "6.1.9",
+  "version": "6.1.10",
   "description": "OpenCode plugin for ChatGPT Plus/Pro OAuth with Codex/GPT-5 routing, multi-account rotation, account switching, health checks, diagnostics, and recovery tools",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Summary
- Bump package/plugin metadata from 6.1.9 to 6.1.10 after merging the open-issues fix PR.

## Testing
- `npm run typecheck`
- `npm run lint`
- `npx vitest run test/doc-parity.test.ts test/install-oc-codex-multi-auth.test.ts test/standalone-cli.test.ts`
- `npm run build`
- `npm pack --dry-run` (verified `oc-codex-multi-auth-6.1.10.tgz` and `assets/icon.svg`)

## Release notes draft
- Adds Codex marketplace icon metadata and packaged icon asset.
- Fixes OpenAI OAuth scope gating to require only baseline scopes.
- Deduplicates duplicate personal workspace/token account entries from the same login.
- Adds safe standalone terminal diagnostics via `oc-codex-multi-auth doctor/status/list/limits/dashboard/health/diag`.

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

bumps the package and plugin metadata from 6.1.9 to 6.1.10 across all three version-carrying files. all three entries are consistent at 6.1.10 and the lock file's two version fields are both updated correctly.

- `package.json` and `package-lock.json` (root + `packages[\"\"]`) both updated to 6.1.10 — no dependency graph changes.
- `.codex-plugin/plugin.json` version aligned to match npm version — no skill paths or interface fields touched.

<h3>Confidence Score: 5/5</h3>

pure metadata version bump with no logic, dependency, or config changes — safe to merge

all three version-carrying files are mutually consistent at 6.1.10, the lock file's two version fields are both updated, and no source code, dependencies, or auth/token handling is touched

no files require special attention

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| package.json | version field bumped from 6.1.9 to 6.1.10 — no other changes |
| package-lock.json | both root-level and packages[""] version entries updated to 6.1.10, consistent with package.json |
| .codex-plugin/plugin.json | plugin manifest version bumped to 6.1.10, consistent with npm package version |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[package.json\nversion: 6.1.9 → 6.1.10] -->|npm version bump| B[package-lock.json\nroot + packages version: 6.1.10]
    A -->|plugin manifest sync| C[.codex-plugin/plugin.json\nversion: 6.1.10]
    B --> D[npm pack\noc-codex-multi-auth-6.1.10.tgz]
    C --> E[Codex marketplace\nplugin discovery at 6.1.10]
```

<sub>Reviews (1): Last reviewed commit: ["chore: bump version to 6.1.10"](https://github.com/ndycode/oc-codex-multi-auth/commit/02d153c01fc93785d91ee7909f63cc93520caa94) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33149116)</sub>

<!-- /greptile_comment -->