### PR TITLE
feat: add TUI email masking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,23 +1,79 @@
+# Dependencies
 node_modules/
 bun.lockb
 pnpm-lock.yaml
+
+# Environment / secrets
+.env
+.env.local
+credentials.json
+state.json
+
+# Build artifacts
 dist/
-.DS_Store
-.history/
-opencode.json
-.opencode/
-tmp
-tmp*
+build/
 *.tgz
 *.patched
-*first_fail*
-Heap-*.heapsnapshot
+
+# macOS / Apple sidecar files
+._*
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# OpenCode local config and cache
+opencode.json
+.opencode/
 .codex-cache
 .sisyphus/
-coverage/
-winston/
+
+# Skills
+.agents/
+skills-lock.json
+
+# IDE
+.history/
+.vscode/
+.idea/
+.shard/
+
+# Local Docker Compose overrides
+docker-compose.yaml
+docker-compose.local.yml
+docker-compose.local.yaml
+compose.local.yml
+compose.local.yaml
+
+# Temporary files
+tmp
+tmp*
 .tmp-plugin-test/
 .tmp-release-*.md
+
+# Debug logs
+debug_logs*/
+debug*.json
+winston/
+Heap-*.heapsnapshot
+*first_fail*
+
+# Project-specific notes and scratch files
+_notes/
+requests/
 task_plan.md
 findings.md
 progress.md
+
+# Testing and coverage
+coverage/
+.pytest_cache/
+.coverage
+htmlcov/
+
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+*.egg-info/

--- a/README.md
+++ b/README.md
@@ -249,7 +249,8 @@ Selected runtime/environment overrides:
 | `CODEX_TUI_V2=0/1` | Disable/enable codex-style tool output |
 | `CODEX_TUI_COLOR_PROFILE=truecolor|ansi256|ansi16` | Force terminal color profile |
 | `CODEX_TUI_GLYPHS=ascii|unicode|auto` | Force terminal glyph style |
-| `CODEX_TUI_MASK_EMAIL=0/1` | Hide account email in TUI quota status |
+| `CODEX_TUI_MASK_EMAIL=0/1` | Hide account email in TUI quota status only |
+| `CODEX_TUI_MASK_EMAIL_DETAILS=0/1` | Also hide account email in quota details when prompt masking is enabled |
 | `CODEX_AUTH_PER_PROJECT_ACCOUNTS=0/1` | Disable/enable per-project account pools |
 | `CODEX_AUTH_AUTO_UPDATE=0/1` | Disable/enable daily npm update check and cache refresh |
 | `CODEX_AUTH_UNSUPPORTED_MODEL_POLICY=strict|fallback` | Control unsupported-model retry behavior |

--- a/README.md
+++ b/README.md
@@ -249,6 +249,7 @@ Selected runtime/environment overrides:
 | `CODEX_TUI_V2=0/1` | Disable/enable codex-style tool output |
 | `CODEX_TUI_COLOR_PROFILE=truecolor|ansi256|ansi16` | Force terminal color profile |
 | `CODEX_TUI_GLYPHS=ascii|unicode|auto` | Force terminal glyph style |
+| `CODEX_TUI_MASK_EMAIL=0/1` | Hide account email in TUI quota status |
 | `CODEX_AUTH_PER_PROJECT_ACCOUNTS=0/1` | Disable/enable per-project account pools |
 | `CODEX_AUTH_AUTO_UPDATE=0/1` | Disable/enable daily npm update check and cache refresh |
 | `CODEX_AUTH_UNSUPPORTED_MODEL_POLICY=strict|fallback` | Control unsupported-model retry behavior |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -122,6 +122,7 @@ advanced settings go in `~/.opencode/openai-codex-auth-config.json`:
   "codexTuiColorProfile": "truecolor",
   "codexTuiGlyphMode": "ascii",
   "maskEmail": false,
+  "maskEmailInQuotaDetails": false,
   "beginnerSafeMode": false,
   "fastSession": false,
   "fastSessionStrategy": "hybrid",
@@ -158,7 +159,8 @@ The sample above intentionally sets `"retryAllAccountsMaxRetries": 3` as a bound
 | `codexTuiV2` | `true` | enables codex-style terminal ui output (set `false` to keep legacy output) |
 | `codexTuiColorProfile` | `truecolor` | terminal color profile for codex ui (`truecolor`, `ansi256`, `ansi16`) |
 | `codexTuiGlyphMode` | `ascii` | glyph set for codex ui (`ascii`, `unicode`, `auto`) |
-| `maskEmail` | `false` | masks the active account email in the TUI prompt quota status and quota details |
+| `maskEmail` | `false` | masks the active account email in the TUI prompt quota status only |
+| `maskEmailInQuotaDetails` | `false` | also masks the active account email in the quota details dialog when `maskEmail` is enabled |
 | `beginnerSafeMode` | `false` | enables conservative beginner-safe runtime behavior for retries and recovery |
 | `fastSession` | `false` | forces low-latency settings per request (`reasoningEffort=none/low`, `reasoningSummary=auto`, `textVerbosity=low`) |
 | `fastSessionStrategy` | `hybrid` | `hybrid` speeds simple turns and keeps full-depth for complex prompts; `always` forces fast mode every turn |
@@ -243,7 +245,8 @@ override any config with env vars:
 | `CODEX_TUI_V2=0` | disable codex-style ui (use legacy output) |
 | `CODEX_TUI_COLOR_PROFILE=ansi16` | force color profile for codex ui |
 | `CODEX_TUI_GLYPHS=unicode` | override glyph mode (`ascii`, `unicode`, `auto`) |
-| `CODEX_TUI_MASK_EMAIL=1` | mask the active account email in TUI quota status |
+| `CODEX_TUI_MASK_EMAIL=1` | mask the active account email in the TUI prompt quota status only |
+| `CODEX_TUI_MASK_EMAIL_DETAILS=1` | also mask the active account email in quota details when prompt masking is enabled |
 | `CODEX_AUTH_PREWARM=0` | disable startup prewarm (prompt/instruction cache warmup) |
 | `CODEX_AUTH_FAST_SESSION=1` | enable fast-session defaults |
 | `CODEX_AUTH_FAST_SESSION_STRATEGY=always` | force fast mode on every prompt |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -121,6 +121,7 @@ advanced settings go in `~/.opencode/openai-codex-auth-config.json`:
   "codexTuiV2": true,
   "codexTuiColorProfile": "truecolor",
   "codexTuiGlyphMode": "ascii",
+  "maskEmail": false,
   "beginnerSafeMode": false,
   "fastSession": false,
   "fastSessionStrategy": "hybrid",
@@ -157,6 +158,7 @@ The sample above intentionally sets `"retryAllAccountsMaxRetries": 3` as a bound
 | `codexTuiV2` | `true` | enables codex-style terminal ui output (set `false` to keep legacy output) |
 | `codexTuiColorProfile` | `truecolor` | terminal color profile for codex ui (`truecolor`, `ansi256`, `ansi16`) |
 | `codexTuiGlyphMode` | `ascii` | glyph set for codex ui (`ascii`, `unicode`, `auto`) |
+| `maskEmail` | `false` | masks the active account email in the TUI prompt quota status and quota details |
 | `beginnerSafeMode` | `false` | enables conservative beginner-safe runtime behavior for retries and recovery |
 | `fastSession` | `false` | forces low-latency settings per request (`reasoningEffort=none/low`, `reasoningSummary=auto`, `textVerbosity=low`) |
 | `fastSessionStrategy` | `hybrid` | `hybrid` speeds simple turns and keeps full-depth for complex prompts; `always` forces fast mode every turn |
@@ -241,6 +243,7 @@ override any config with env vars:
 | `CODEX_TUI_V2=0` | disable codex-style ui (use legacy output) |
 | `CODEX_TUI_COLOR_PROFILE=ansi16` | force color profile for codex ui |
 | `CODEX_TUI_GLYPHS=unicode` | override glyph mode (`ascii`, `unicode`, `auto`) |
+| `CODEX_TUI_MASK_EMAIL=1` | mask the active account email in TUI quota status |
 | `CODEX_AUTH_PREWARM=0` | disable startup prewarm (prompt/instruction cache warmup) |
 | `CODEX_AUTH_FAST_SESSION=1` | enable fast-session defaults |
 | `CODEX_AUTH_FAST_SESSION_STRATEGY=always` | force fast mode on every prompt |

--- a/docs/development/TUI_PARITY_CHECKLIST.md
+++ b/docs/development/TUI_PARITY_CHECKLIST.md
@@ -78,7 +78,7 @@ Use this checklist to keep `oc-codex-multi-auth` aligned with the Antigravity-st
 - Visual controls:
   - `codexTuiColorProfile`: `truecolor` / `ansi256` / `ansi16`
   - `codexTuiGlyphMode`: `ascii` / `unicode` / `auto`
-- Privacy control: `maskEmail: true` or `CODEX_TUI_MASK_EMAIL=1` hides account email in prompt quota status and quota details.
+- Privacy controls: `maskEmail: true` or `CODEX_TUI_MASK_EMAIL=1` hides account email in prompt quota status only; `maskEmailInQuotaDetails: true` or `CODEX_TUI_MASK_EMAIL_DETAILS=1` extends masking to quota details.
 
 ## Tooling Parity
 

--- a/docs/development/TUI_PARITY_CHECKLIST.md
+++ b/docs/development/TUI_PARITY_CHECKLIST.md
@@ -78,6 +78,7 @@ Use this checklist to keep `oc-codex-multi-auth` aligned with the Antigravity-st
 - Visual controls:
   - `codexTuiColorProfile`: `truecolor` / `ansi256` / `ansi16`
   - `codexTuiGlyphMode`: `ascii` / `unicode` / `auto`
+- Privacy control: `maskEmail: true` or `CODEX_TUI_MASK_EMAIL=1` hides account email in prompt quota status and quota details.
 
 ## Tooling Parity
 

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -36,6 +36,7 @@ const DEFAULT_CONFIG: PluginConfig = {
 	codexTuiColorProfile: "truecolor",
 	codexTuiGlyphMode: "ascii",
 	maskEmail: false,
+	maskEmailInQuotaDetails: false,
 	beginnerSafeMode: false,
 	fastSession: false,
 	fastSessionStrategy: "hybrid",
@@ -288,6 +289,16 @@ export function getCodexTuiMaskEmail(pluginConfig: PluginConfig): boolean {
 	return resolveBooleanSetting(
 		"CODEX_TUI_MASK_EMAIL",
 		pluginConfig.maskEmail,
+		false,
+	);
+}
+
+export function getCodexTuiMaskEmailInQuotaDetails(
+	pluginConfig: PluginConfig,
+): boolean {
+	return resolveBooleanSetting(
+		"CODEX_TUI_MASK_EMAIL_DETAILS",
+		pluginConfig.maskEmailInQuotaDetails,
 		false,
 	);
 }

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -35,6 +35,7 @@ const DEFAULT_CONFIG: PluginConfig = {
 	codexTuiV2: true,
 	codexTuiColorProfile: "truecolor",
 	codexTuiGlyphMode: "ascii",
+	maskEmail: false,
 	beginnerSafeMode: false,
 	fastSession: false,
 	fastSessionStrategy: "hybrid",
@@ -280,6 +281,14 @@ export function getCodexTuiGlyphMode(
 		pluginConfig.codexTuiGlyphMode,
 		"ascii",
 		TUI_GLYPH_MODES,
+	);
+}
+
+export function getCodexTuiMaskEmail(pluginConfig: PluginConfig): boolean {
+	return resolveBooleanSetting(
+		"CODEX_TUI_MASK_EMAIL",
+		pluginConfig.maskEmail,
+		false,
 	);
 }
 

--- a/lib/schemas.ts
+++ b/lib/schemas.ts
@@ -17,6 +17,7 @@ export const PluginConfigSchema = z.object({
 	codexTuiColorProfile: z.enum(["truecolor", "ansi16", "ansi256"]).optional(),
 	codexTuiGlyphMode: z.enum(["ascii", "unicode", "auto"]).optional(),
 	maskEmail: z.boolean().optional(),
+	maskEmailInQuotaDetails: z.boolean().optional(),
 	beginnerSafeMode: z.boolean().optional(),
 	fastSession: z.boolean().optional(),
 	fastSessionStrategy: z.enum(["hybrid", "always"]).optional(),

--- a/lib/schemas.ts
+++ b/lib/schemas.ts
@@ -16,6 +16,7 @@ export const PluginConfigSchema = z.object({
 	codexTuiV2: z.boolean().optional(),
 	codexTuiColorProfile: z.enum(["truecolor", "ansi16", "ansi256"]).optional(),
 	codexTuiGlyphMode: z.enum(["ascii", "unicode", "auto"]).optional(),
+	maskEmail: z.boolean().optional(),
 	beginnerSafeMode: z.boolean().optional(),
 	fastSession: z.boolean().optional(),
 	fastSessionStrategy: z.enum(["hybrid", "always"]).optional(),

--- a/lib/tui-status.ts
+++ b/lib/tui-status.ts
@@ -57,7 +57,8 @@ const STATUS_SEPARATOR = ` ${String.fromCharCode(183)} `;
 const WARNING_LIMIT_LEFT_PERCENT = 25;
 const DANGER_LIMIT_LEFT_PERCENT = 10;
 const MASKED_EMAIL = "*****";
-const EMAIL_PATTERN = /[^\s(),<>]+@[^\s(),<>]+/g;
+const EMAIL_PATTERN = /[^\s(),<>]+@[^\s(),<>]+/;
+const EMAIL_PATTERN_GLOBAL = /[^\s(),<>]+@[^\s(),<>]+/g;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return value !== null && typeof value === "object" && !Array.isArray(value);
@@ -209,7 +210,7 @@ function maskEmailsInText(
 	maskEmail: boolean,
 ): string | undefined {
 	if (!value) return undefined;
-	return maskEmail ? value.replace(EMAIL_PATTERN, MASKED_EMAIL) : value;
+	return maskEmail ? value.replace(EMAIL_PATTERN_GLOBAL, MASKED_EMAIL) : value;
 }
 
 function formatQuotaLimit(

--- a/lib/tui-status.ts
+++ b/lib/tui-status.ts
@@ -56,6 +56,8 @@ const variantSuffixes: ReasoningVariant[] = [
 const STATUS_SEPARATOR = ` ${String.fromCharCode(183)} `;
 const WARNING_LIMIT_LEFT_PERCENT = 25;
 const DANGER_LIMIT_LEFT_PERCENT = 10;
+const MASKED_EMAIL = "*****";
+const EMAIL_PATTERN = /[^\s(),<>]+@[^\s(),<>]+/g;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return value !== null && typeof value === "object" && !Array.isArray(value);
@@ -190,13 +192,24 @@ function isPercent(value: number | null): value is number {
 }
 
 function extractEmailFromLabel(label: string | undefined): string | undefined {
-	const match = label?.match(/[^\s(),<>]+@[^\s(),<>]+/);
+	const match = label?.match(EMAIL_PATTERN);
 	return match?.[0];
 }
 
-function formatAccountEmail(email: string | undefined): string | undefined {
+function formatAccountEmail(
+	email: string | undefined,
+	maskEmail: boolean,
+): string | undefined {
 	const trimmed = email?.trim() || undefined;
-	return trimmed ? `[${trimmed}]` : undefined;
+	return trimmed ? `[${maskEmail ? MASKED_EMAIL : trimmed}]` : undefined;
+}
+
+function maskEmailsInText(
+	value: string | undefined,
+	maskEmail: boolean,
+): string | undefined {
+	if (!value) return undefined;
+	return maskEmail ? value.replace(EMAIL_PATTERN, MASKED_EMAIL) : value;
 }
 
 function formatQuotaLimit(
@@ -212,7 +225,10 @@ function formatQuotaLimit(
 	return reset ? `${base} resets ${reset}` : base;
 }
 
-function formatAccountHint(quota: CompactQuotaStatus): string | undefined {
+function formatAccountHint(
+	quota: CompactQuotaStatus,
+	maskEmail = false,
+): string | undefined {
 	if (quota.type !== "ready") return undefined;
 	if (
 		typeof quota.accountIndex !== "number" ||
@@ -228,8 +244,8 @@ function formatAccountHint(quota: CompactQuotaStatus): string | undefined {
 		return undefined;
 	}
 	const email =
-		formatAccountEmail(quota.accountEmail) ??
-		formatAccountEmail(extractEmailFromLabel(quota.accountLabel));
+		formatAccountEmail(quota.accountEmail, maskEmail) ??
+		formatAccountEmail(extractEmailFromLabel(quota.accountLabel), maskEmail);
 	if (email) return email;
 	return `A${quota.accountIndex}`;
 }
@@ -286,9 +302,10 @@ export function formatPromptStatusText(params: {
 	variant?: ReasoningVariant;
 	quota: CompactQuotaStatus;
 	width?: number;
+	maskEmail?: boolean;
 }): string {
 	const variant = params.variant;
-	const account = formatAccountHint(params.quota);
+	const account = formatAccountHint(params.quota, params.maskEmail);
 	const quotaParts = formatQuotaParts(params.quota, true);
 	const quotaPartsWithoutReset = formatQuotaParts(params.quota, false);
 	const quota = quotaParts.length > 0
@@ -403,17 +420,19 @@ function formatDetailsLimit(limit: CompactQuotaLimit): string {
 export function formatQuotaDetailsText(
 	quota: CompactQuotaStatus,
 	now = Date.now(),
+	options: { maskEmail?: boolean } = {},
 ): string {
 	if (quota.type === "loading") return "Quota is loading.";
 	if (quota.type === "missing") return "No Codex OAuth account is configured.";
 	if (quota.type === "unavailable") return "Quota is unavailable.";
 
 	const lines: string[] = [];
-	const accountHint = formatAccountHint(quota);
-	if (quota.accountLabel && accountHint) {
-		lines.push(`Account: ${accountHint} (${quota.accountLabel})`);
-	} else if (quota.accountLabel) {
-		lines.push(`Account: ${quota.accountLabel}`);
+	const accountHint = formatAccountHint(quota, options.maskEmail);
+	const accountLabel = maskEmailsInText(quota.accountLabel, Boolean(options.maskEmail));
+	if (accountLabel && accountHint) {
+		lines.push(`Account: ${accountHint} (${accountLabel})`);
+	} else if (accountLabel) {
+		lines.push(`Account: ${accountLabel}`);
 	} else if (accountHint) {
 		lines.push(`Account: ${accountHint}`);
 	}

--- a/test/plugin-config.test.ts
+++ b/test/plugin-config.test.ts
@@ -6,6 +6,7 @@ import {
 	getCodexTuiColorProfile,
 	getCodexTuiGlyphMode,
 	getCodexTuiMaskEmail,
+	getCodexTuiMaskEmailInQuotaDetails,
 	getBeginnerSafeMode,
 	getFastSession,
 	getFastSessionStrategy,
@@ -57,6 +58,7 @@ describe('Plugin Configuration', () => {
 		'CODEX_TUI_COLOR_PROFILE',
 		'CODEX_TUI_GLYPHS',
 		'CODEX_TUI_MASK_EMAIL',
+		'CODEX_TUI_MASK_EMAIL_DETAILS',
 		'CODEX_AUTH_FAST_SESSION',
 		'CODEX_AUTH_BEGINNER_SAFE_MODE',
 		'CODEX_AUTH_FAST_SESSION_STRATEGY',
@@ -101,6 +103,7 @@ describe('Plugin Configuration', () => {
 				codexTuiColorProfile: 'truecolor',
 				codexTuiGlyphMode: 'ascii',
 				maskEmail: false,
+				maskEmailInQuotaDetails: false,
 				beginnerSafeMode: false,
 				fastSession: false,
 				fastSessionStrategy: 'hybrid',
@@ -147,6 +150,7 @@ describe('Plugin Configuration', () => {
 				codexTuiColorProfile: 'truecolor',
 				codexTuiGlyphMode: 'ascii',
 				maskEmail: false,
+				maskEmailInQuotaDetails: false,
 				beginnerSafeMode: false,
 				fastSession: false,
 				fastSessionStrategy: 'hybrid',
@@ -190,6 +194,7 @@ describe('Plugin Configuration', () => {
 				codexTuiColorProfile: 'truecolor',
 				codexTuiGlyphMode: 'ascii',
 				maskEmail: false,
+				maskEmailInQuotaDetails: false,
 				beginnerSafeMode: false,
 				fastSession: false,
 				fastSessionStrategy: 'hybrid',
@@ -244,6 +249,7 @@ describe('Plugin Configuration', () => {
 		codexTuiColorProfile: 'truecolor',
 		codexTuiGlyphMode: 'ascii',
 		maskEmail: false,
+		maskEmailInQuotaDetails: false,
 		beginnerSafeMode: false,
 		fastSession: false,
 		fastSessionStrategy: 'hybrid',
@@ -292,6 +298,7 @@ describe('Plugin Configuration', () => {
 			codexTuiColorProfile: 'truecolor',
 			codexTuiGlyphMode: 'ascii',
 			maskEmail: false,
+			maskEmailInQuotaDetails: false,
 			beginnerSafeMode: false,
 			fastSession: false,
 			fastSessionStrategy: 'hybrid',
@@ -461,6 +468,31 @@ describe('Plugin Configuration', () => {
 			expect(getCodexTuiMaskEmail({ maskEmail: true })).toBe(false);
 			process.env.CODEX_TUI_MASK_EMAIL = '1';
 			expect(getCodexTuiMaskEmail({ maskEmail: false })).toBe(true);
+		});
+	});
+
+	describe('getCodexTuiMaskEmailInQuotaDetails', () => {
+		it('should default to false', () => {
+			delete process.env.CODEX_TUI_MASK_EMAIL_DETAILS;
+			expect(getCodexTuiMaskEmailInQuotaDetails({})).toBe(false);
+		});
+
+		it('should use config value when env var not set', () => {
+			delete process.env.CODEX_TUI_MASK_EMAIL_DETAILS;
+			expect(
+				getCodexTuiMaskEmailInQuotaDetails({ maskEmailInQuotaDetails: true }),
+			).toBe(true);
+		});
+
+		it('should prioritize env value over config', () => {
+			process.env.CODEX_TUI_MASK_EMAIL_DETAILS = '0';
+			expect(
+				getCodexTuiMaskEmailInQuotaDetails({ maskEmailInQuotaDetails: true }),
+			).toBe(false);
+			process.env.CODEX_TUI_MASK_EMAIL_DETAILS = '1';
+			expect(
+				getCodexTuiMaskEmailInQuotaDetails({ maskEmailInQuotaDetails: false }),
+			).toBe(true);
 		});
 	});
 

--- a/test/plugin-config.test.ts
+++ b/test/plugin-config.test.ts
@@ -5,6 +5,7 @@ import {
 	getCodexTuiV2,
 	getCodexTuiColorProfile,
 	getCodexTuiGlyphMode,
+	getCodexTuiMaskEmail,
 	getBeginnerSafeMode,
 	getFastSession,
 	getFastSessionStrategy,
@@ -55,6 +56,7 @@ describe('Plugin Configuration', () => {
 		'CODEX_TUI_V2',
 		'CODEX_TUI_COLOR_PROFILE',
 		'CODEX_TUI_GLYPHS',
+		'CODEX_TUI_MASK_EMAIL',
 		'CODEX_AUTH_FAST_SESSION',
 		'CODEX_AUTH_BEGINNER_SAFE_MODE',
 		'CODEX_AUTH_FAST_SESSION_STRATEGY',
@@ -98,6 +100,7 @@ describe('Plugin Configuration', () => {
 				codexTuiV2: true,
 				codexTuiColorProfile: 'truecolor',
 				codexTuiGlyphMode: 'ascii',
+				maskEmail: false,
 				beginnerSafeMode: false,
 				fastSession: false,
 				fastSessionStrategy: 'hybrid',
@@ -143,6 +146,7 @@ describe('Plugin Configuration', () => {
 				codexTuiV2: true,
 				codexTuiColorProfile: 'truecolor',
 				codexTuiGlyphMode: 'ascii',
+				maskEmail: false,
 				beginnerSafeMode: false,
 				fastSession: false,
 				fastSessionStrategy: 'hybrid',
@@ -185,6 +189,7 @@ describe('Plugin Configuration', () => {
 				codexTuiV2: true,
 				codexTuiColorProfile: 'truecolor',
 				codexTuiGlyphMode: 'ascii',
+				maskEmail: false,
 				beginnerSafeMode: false,
 				fastSession: false,
 				fastSessionStrategy: 'hybrid',
@@ -238,6 +243,7 @@ describe('Plugin Configuration', () => {
 		codexTuiV2: true,
 		codexTuiColorProfile: 'truecolor',
 		codexTuiGlyphMode: 'ascii',
+		maskEmail: false,
 		beginnerSafeMode: false,
 		fastSession: false,
 		fastSessionStrategy: 'hybrid',
@@ -285,6 +291,7 @@ describe('Plugin Configuration', () => {
 			codexTuiV2: true,
 			codexTuiColorProfile: 'truecolor',
 			codexTuiGlyphMode: 'ascii',
+			maskEmail: false,
 			beginnerSafeMode: false,
 			fastSession: false,
 			fastSessionStrategy: 'hybrid',
@@ -435,6 +442,25 @@ describe('Plugin Configuration', () => {
 			process.env.CODEX_TUI_GLYPHS = 'invalid';
 			expect(getCodexTuiGlyphMode({ codexTuiGlyphMode: 'unicode' })).toBe('unicode');
 			expect(getCodexTuiGlyphMode({})).toBe('ascii');
+		});
+	});
+
+	describe('getCodexTuiMaskEmail', () => {
+		it('should default to false', () => {
+			delete process.env.CODEX_TUI_MASK_EMAIL;
+			expect(getCodexTuiMaskEmail({})).toBe(false);
+		});
+
+		it('should use config value when env var not set', () => {
+			delete process.env.CODEX_TUI_MASK_EMAIL;
+			expect(getCodexTuiMaskEmail({ maskEmail: true })).toBe(true);
+		});
+
+		it('should prioritize env value over config', () => {
+			process.env.CODEX_TUI_MASK_EMAIL = '0';
+			expect(getCodexTuiMaskEmail({ maskEmail: true })).toBe(false);
+			process.env.CODEX_TUI_MASK_EMAIL = '1';
+			expect(getCodexTuiMaskEmail({ maskEmail: false })).toBe(true);
 		});
 	});
 
@@ -766,4 +792,3 @@ describe('Plugin Configuration', () => {
 		});
 	});
 });
-

--- a/test/tui-status.test.ts
+++ b/test/tui-status.test.ts
@@ -231,6 +231,24 @@ describe("TUI prompt status helpers", () => {
 		expect(details).toContain("5h: 88% left");
 	});
 
+	it("preserves account email in quota details when masking is disabled", () => {
+		const details = formatQuotaDetailsText(
+			{
+				...quota,
+				accountIndex: 2,
+				accountCount: 3,
+				accountEmail: "neil@example.com",
+				accountLabel: "Account 2 (neil@example.com)",
+				source: "usage",
+				fetchedAt: 1_000,
+			},
+			31_000,
+			{ maskEmail: false },
+		);
+
+		expect(details).toContain("Account: [neil@example.com] (Account 2 (neil@example.com))");
+	});
+
 	it("resolves the selected variant from session messages before config defaults", () => {
 		const messages: PromptStatusMessage[] = [
 			{

--- a/test/tui-status.test.ts
+++ b/test/tui-status.test.ts
@@ -105,6 +105,34 @@ describe("TUI prompt status helpers", () => {
 		).toBe(`5h 88%${sep}7d 83%`);
 	});
 
+	it("masks account email in prompt status when requested", () => {
+		expect(
+			formatPromptStatusText({
+				quota: {
+					...quota,
+					accountIndex: 2,
+					accountCount: 3,
+					accountEmail: "user2@example.com",
+				},
+				width: 120,
+				maskEmail: true,
+			}),
+		).toBe(`[*****]${sep}5h 88%${sep}7d 83%`);
+
+		expect(
+			formatPromptStatusText({
+				quota: {
+					...quota,
+					accountIndex: 2,
+					accountCount: 3,
+					accountLabel: "Account 2 (user2@example.com)",
+				},
+				width: 120,
+				maskEmail: true,
+			}),
+		).toBe(`[*****]${sep}5h 88%${sep}7d 83%`);
+	});
+
 	it("prefers quota over variant when status space is tight", () => {
 		expect(
 			formatPromptStatusText({
@@ -181,6 +209,26 @@ describe("TUI prompt status helpers", () => {
 		expect(details).toContain("Active limit: 40");
 		expect(details).toContain("Source: response headers");
 		expect(details).toContain("Updated: just now");
+	});
+
+	it("masks account email in quota details when requested", () => {
+		const details = formatQuotaDetailsText(
+			{
+				...quota,
+				accountIndex: 2,
+				accountCount: 3,
+				accountEmail: "neil@example.com",
+				accountLabel: "Account 2 (neil@example.com)",
+				source: "usage",
+				fetchedAt: 1_000,
+			},
+			31_000,
+			{ maskEmail: true },
+		);
+
+		expect(details).toContain("Account: [*****] (Account 2 (*****))");
+		expect(details).not.toContain("neil@example.com");
+		expect(details).toContain("5h: 88% left");
 	});
 
 	it("resolves the selected variant from session messages before config defaults", () => {

--- a/tui.ts
+++ b/tui.ts
@@ -4,6 +4,7 @@ import type { JSX } from "@opentui/solid";
 
 import {
 	getCodexTuiMaskEmail,
+	getCodexTuiMaskEmailInQuotaDetails,
 	loadPluginConfig,
 } from "./lib/config.js";
 import {
@@ -279,7 +280,7 @@ export function shouldRefreshQuotaForEvent(event: Event): boolean {
 function createPromptStatus(
 	api: TuiPluginApi,
 	solid: SolidRuntime,
-	options: { maskEmail: boolean },
+	options: { maskEmail: boolean; maskEmailInQuotaDetails: boolean },
 ): JSX.Element {
 	const [quota, setQuota] = solid.createSignal<CompactQuotaStatus>({
 		type: "loading",
@@ -403,13 +404,18 @@ function createPromptStatus(
 	return node;
 }
 
-function showQuotaDetails(api: TuiPluginApi, options: { maskEmail: boolean }): void {
+function showQuotaDetails(
+	api: TuiPluginApi,
+	options: { maskEmail: boolean; maskEmailInQuotaDetails: boolean },
+): void {
 	void refreshQuotaStatus(api).then(
 		(status) => {
 			api.ui.dialog.replace(() =>
 				api.ui.DialogAlert({
 					title: "Codex quota",
-					message: formatQuotaDetailsText(status, Date.now(), options),
+					message: formatQuotaDetailsText(status, Date.now(), {
+						maskEmail: options.maskEmail && options.maskEmailInQuotaDetails,
+					}),
 					onConfirm: () => api.ui.dialog.clear(),
 				}),
 			);
@@ -429,8 +435,10 @@ function showQuotaDetails(api: TuiPluginApi, options: { maskEmail: boolean }): v
 const module: TuiPluginModule = {
 	id: "oc-codex-multi-auth.status",
 	async tui(api) {
+		const pluginConfig = loadPluginConfig();
 		const promptOptions = {
-			maskEmail: getCodexTuiMaskEmail(loadPluginConfig()),
+			maskEmail: getCodexTuiMaskEmail(pluginConfig),
+			maskEmailInQuotaDetails: getCodexTuiMaskEmailInQuotaDetails(pluginConfig),
 		};
 		const [{ createElement, spread }, { createSignal, onCleanup }] =
 			await Promise.all([import("@opentui/solid"), import("solid-js")]);

--- a/tui.ts
+++ b/tui.ts
@@ -3,6 +3,10 @@ import type { Event } from "@opencode-ai/sdk/v2";
 import type { JSX } from "@opentui/solid";
 
 import {
+	getCodexTuiMaskEmail,
+	loadPluginConfig,
+} from "./lib/config.js";
+import {
 	createUsageAccountFingerprint,
 	ensureCodexUsageAccessToken,
 	fetchCodexUsage,
@@ -275,6 +279,7 @@ export function shouldRefreshQuotaForEvent(event: Event): boolean {
 function createPromptStatus(
 	api: TuiPluginApi,
 	solid: SolidRuntime,
+	options: { maskEmail: boolean },
 ): JSX.Element {
 	const [quota, setQuota] = solid.createSignal<CompactQuotaStatus>({
 		type: "loading",
@@ -376,6 +381,7 @@ function createPromptStatus(
 				return formatPromptStatusText({
 					quota: quota(),
 					width: api.renderer.width,
+					maskEmail: options.maskEmail,
 				});
 			},
 			get fg() {
@@ -397,13 +403,13 @@ function createPromptStatus(
 	return node;
 }
 
-function showQuotaDetails(api: TuiPluginApi): void {
+function showQuotaDetails(api: TuiPluginApi, options: { maskEmail: boolean }): void {
 	void refreshQuotaStatus(api).then(
 		(status) => {
 			api.ui.dialog.replace(() =>
 				api.ui.DialogAlert({
 					title: "Codex quota",
-					message: formatQuotaDetailsText(status),
+					message: formatQuotaDetailsText(status, Date.now(), options),
 					onConfirm: () => api.ui.dialog.clear(),
 				}),
 			);
@@ -423,6 +429,9 @@ function showQuotaDetails(api: TuiPluginApi): void {
 const module: TuiPluginModule = {
 	id: "oc-codex-multi-auth.status",
 	async tui(api) {
+		const promptOptions = {
+			maskEmail: getCodexTuiMaskEmail(loadPluginConfig()),
+		};
 		const [{ createElement, spread }, { createSignal, onCleanup }] =
 			await Promise.all([import("@opentui/solid"), import("solid-js")]);
 		const solid: SolidRuntime = {
@@ -434,7 +443,7 @@ const module: TuiPluginModule = {
 
 		api.slots.register({
 			slots: {
-				session_prompt_right: () => createPromptStatus(api, solid),
+				session_prompt_right: () => createPromptStatus(api, solid, promptOptions),
 			},
 		});
 		const disposeCommand = api.command.register(() => [
@@ -444,7 +453,7 @@ const module: TuiPluginModule = {
 				description:
 					"Show active account usage, reset times, source, and last refresh.",
 				category: "Codex",
-				onSelect: () => showQuotaDetails(api),
+				onSelect: () => showQuotaDetails(api, promptOptions),
 			},
 		]);
 		api.lifecycle.onDispose(disposeCommand);


### PR DESCRIPTION
## Summary
- add opt-in TUI email masking via maskEmail config and CODEX_TUI_MASK_EMAIL
- mask account hints in prompt quota status and quota details while keeping quota percentages intact
- organize .gitignore sections and make Apple sidecar files recursive with ._*

## Verification
- npx vitest run test/tui-status.test.ts test/plugin-config.test.ts
- npm run typecheck
- npm run lint
- npm run build
- npm test
- coderabbit review --agent -t uncommitted (findings: 0)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added email-masking for TUI quota displays, with an option to also mask emails in quota details.

* **Documentation**
  * Documented maskEmail and maskEmailInQuotaDetails options plus CODEX_TUI_MASK_EMAIL and CODEX_TUI_MASK_EMAIL_DETAILS environment variables and README/docs updates.

* **Tests**
  * Added/extended tests covering masking behavior and env-var precedence.

* **Chores**
  * Expanded .gitignore to cover more env, build, debug, test, and local config artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

adds opt-in email masking for the TUI prompt quota status and quota-details dialog, controlled by `maskEmail` / `maskEmailInQuotaDetails` config keys and their `CODEX_TUI_MASK_EMAIL` / `CODEX_TUI_MASK_EMAIL_DETAILS` env-var equivalents. the implementation is clean and follows existing patterns throughout the codebase.

- `lib/tui-status.ts` introduces `EMAIL_PATTERN_GLOBAL` (separate from the non-global `EMAIL_PATTERN`) and a `maskEmailsInText` helper; both are used correctly and the global regex is only ever called through `String.replace`, so no stateful `lastIndex` hazard exists.
- `tui.ts` reads `promptOptions` once at TUI startup and threads it into `createPromptStatus` and `showQuotaDetails`; quota-details masking correctly requires both flags via `options.maskEmail && options.maskEmailInQuotaDetails`, consistent with documentation.
- `.gitignore` expansion adds `credentials.json` and `state.json` to tracked ignores, reducing the risk of accidentally committing local secrets on windows or any platform.

<h3>Confidence Score: 5/5</h3>

safe to merge — masking is purely additive and defaults to false, so existing behaviour is unchanged for all current users

the change is opt-in with a false default, touches only display-layer string formatting, and introduces no new async paths or shared mutable state. config options follow the established resolveBooleanSetting pattern and are fully covered by unit tests. the only gap is a missing explicit maskEmail:false assertion for formatPromptStatusText, which doesn't affect runtime correctness.

test/tui-status.test.ts — explicit opt-out assertion for formatPromptStatusText is missing

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/tui-status.ts | adds EMAIL_PATTERN / EMAIL_PATTERN_GLOBAL constants, maskEmailsInText helper, and threads maskEmail param through formatAccountHint, formatPromptStatusText, and formatQuotaDetailsText — logic is correct and well-scoped |
| tui.ts | reads config once at startup into promptOptions and passes it into createPromptStatus and showQuotaDetails; quota-details masking correctly requires both maskEmail && maskEmailInQuotaDetails |
| lib/config.ts | adds getCodexTuiMaskEmail and getCodexTuiMaskEmailInQuotaDetails following the existing resolveBooleanSetting pattern; defaults and env-var names are consistent with docs |
| lib/schemas.ts | adds maskEmail and maskEmailInQuotaDetails as optional booleans in PluginConfigSchema — straightforward and consistent |
| test/tui-status.test.ts | adds maskEmail:true cases for both formatPromptStatusText and formatQuotaDetailsText, plus explicit maskEmail:false for formatQuotaDetailsText; maskEmail:false path for formatPromptStatusText is not explicitly tested |
| test/plugin-config.test.ts | full env-var / config priority tests for both new getter functions; default-config snapshot rows updated throughout |
| .gitignore | reorganizes and expands entries: adds credentials.json, state.json, .env*, IDE dirs, docker-compose variants, and python artifacts; no removals that would accidentally track secrets |
| README.md | documents CODEX_TUI_MASK_EMAIL and CODEX_TUI_MASK_EMAIL_DETAILS env vars in the env-overrides table |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[TUI startup] --> B[loadPluginConfig]
    B --> C{getCodexTuiMaskEmail}
    B --> D{getCodexTuiMaskEmailInQuotaDetails}
    C -->|env CODEX_TUI_MASK_EMAIL wins| E[promptOptions.maskEmail]
    D -->|env CODEX_TUI_MASK_EMAIL_DETAILS wins| F[promptOptions.maskEmailInQuotaDetails]

    E --> G[createPromptStatus]
    G --> H[formatPromptStatusText\nmaskEmail=promptOptions.maskEmail]
    H --> I[formatAccountHint\nmaskEmail]
    I --> J[formatAccountEmail\nmask or show email]

    E --> K[showQuotaDetails]
    F --> K
    K --> L{maskEmail AND\nmaskEmailInQuotaDetails?}
    L -->|true| M[formatQuotaDetailsText\nmaskEmail=true]
    L -->|false| N[formatQuotaDetailsText\nmaskEmail=false]
    M --> O[maskEmailsInText\naccountLabel]
    M --> I
    N --> P[raw accountLabel\nno masking]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
test/tui-status.test.ts:138
**missing explicit `maskEmail: false` case for `formatPromptStatusText`**

the new suite adds `maskEmail: true` coverage for `formatPromptStatusText` and both `true` and `false` for `formatQuotaDetailsText`, but there's no test that explicitly passes `{ maskEmail: false }` to `formatPromptStatusText` and asserts the raw email survives. pre-existing tests omit the param (which defaults to `undefined → false`) but that's not the same as explicitly asserting the opt-out contract. a regression that treats `false` as `true` would go undetected for this path.

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: scope TUI email masking"](https://github.com/ndycode/oc-codex-multi-auth/commit/204f76b5ebfd26df4b0a97992c10432e5f5fc526) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34609353)</sub>

**Context used:**

- Context used - speak in lowercase, concise sentences. act like th... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->