### PR TITLE
fix: preserve workspace-specific usage quotas + harden test isolation

### DIFF
--- a/lib/codex-usage.ts
+++ b/lib/codex-usage.ts
@@ -535,28 +535,32 @@ export function getUsageAccountDedupeKey(
  * Disabled accounts are skipped. Accounts with no usable identity — no
  * `accountId`, no `organizationId`, and no `refreshToken`, i.e. those for which
  * {@link getUsageAccountDedupeKey} returns `undefined` — are also dropped, since
- * they cannot be attributed to a quota and have no token to query. Remaining
- * entries sharing the same dedupe key are collapsed to their first occurrence
- * so the same workspace/credential is only queried once.
+ * they cannot be attributed to a quota and have no token to query. Entries
+ * sharing the same dedupe key are collapsed to a single index.
+ *
+ * When a workspace key appears more than once (e.g. an account re-added after a
+ * token re-issue), the *last* (most recently added) occurrence is kept so the
+ * freshest credential is queried — keeping the first occurrence could surface
+ * an invalidated refresh token after re-auth. First-appearance order is still
+ * used for display stability.
  *
  * @param storage - The account storage to scan.
  * @returns Storage indices of unique, enabled, identifiable usage accounts in
- *   original order.
+ *   first-appearance order, each pointing at its freshest occurrence.
  */
 export function deduplicateUsageAccountIndices(storage: AccountStorageV3): number[] {
-	const seenIdentities = new Set<string>();
-	const uniqueIndices: number[] = [];
+	const indexByIdentity = new Map<string, number>();
 	for (let i = 0; i < storage.accounts.length; i += 1) {
 		const account = storage.accounts[i];
 		if (!account) continue;
 		if (account.enabled === false) continue;
 		const key = getUsageAccountDedupeKey(account);
 		if (!key) continue;
-		if (seenIdentities.has(key)) continue;
-		seenIdentities.add(key);
-		uniqueIndices.push(i);
+		// Map keeps first-insertion key order (stable display) while overwriting
+		// the value so the latest occurrence's index wins (freshest credential).
+		indexByIdentity.set(key, i);
 	}
-	return uniqueIndices;
+	return [...indexByIdentity.values()];
 }
 
 /**

--- a/lib/codex-usage.ts
+++ b/lib/codex-usage.ts
@@ -532,12 +532,16 @@ export function getUsageAccountDedupeKey(
 /**
  * Collect the indices of accounts that represent distinct usage quotas.
  *
- * Disabled accounts are skipped, and entries sharing the same
- * {@link getUsageAccountDedupeKey} identity are collapsed to their first
- * occurrence so the same workspace/credential is only queried once.
+ * Disabled accounts are skipped. Accounts with no usable identity — no
+ * `accountId`, no `organizationId`, and no `refreshToken`, i.e. those for which
+ * {@link getUsageAccountDedupeKey} returns `undefined` — are also dropped, since
+ * they cannot be attributed to a quota and have no token to query. Remaining
+ * entries sharing the same dedupe key are collapsed to their first occurrence
+ * so the same workspace/credential is only queried once.
  *
  * @param storage - The account storage to scan.
- * @returns Storage indices of unique, enabled usage accounts in original order.
+ * @returns Storage indices of unique, enabled, identifiable usage accounts in
+ *   original order.
  */
 export function deduplicateUsageAccountIndices(storage: AccountStorageV3): number[] {
 	const seenIdentities = new Set<string>();
@@ -587,12 +591,20 @@ export function resolveCodexUsageActiveAccount(
 		return null;
 	}
 
+	// An enabled active account with a missing/invalid `lastUsed` must fall back
+	// to 0 (same as every other enabled account), not -1. Using -1 would let a
+	// lower-index enabled account with `lastUsed` 0 win the `0 > -1` comparison
+	// and steal the active marker before the active account's own iteration.
+	const activeEnabled = !!activeAccount && activeAccount.enabled !== false;
 	const activeLastUsed =
-		activeAccount?.enabled !== false &&
-		typeof activeAccount?.lastUsed === "number" && Number.isFinite(activeAccount.lastUsed)
+		activeEnabled &&
+		typeof activeAccount?.lastUsed === "number" &&
+		Number.isFinite(activeAccount.lastUsed)
 			? activeAccount.lastUsed
-			: -1;
-	let newestIndex = activeAccount?.enabled === false ? -1 : index;
+			: activeEnabled
+				? 0
+				: -1;
+	let newestIndex = activeEnabled ? index : -1;
 	let newestLastUsed = activeLastUsed;
 	for (let i = 0; i < storage.accounts.length; i += 1) {
 		const account = storage.accounts[i];

--- a/lib/codex-usage.ts
+++ b/lib/codex-usage.ts
@@ -490,18 +490,34 @@ export async function ensureCodexUsageAccessToken(params: {
 	return { accessToken, refreshed: true, persisted };
 }
 
+function normalizeUsageIdentityPart(value: string | undefined): string {
+	return typeof value === "string" ? value.trim() : "";
+}
+
+export function getUsageAccountDedupeKey(
+	account: AccountMetadataV3,
+): string | undefined {
+	const accountId = normalizeUsageIdentityPart(account.accountId);
+	const organizationId = normalizeUsageIdentityPart(account.organizationId);
+	if (accountId || organizationId) {
+		return JSON.stringify(["workspace", accountId, organizationId]);
+	}
+
+	const refreshToken = normalizeUsageIdentityPart(account.refreshToken);
+	return refreshToken ? JSON.stringify(["refresh", refreshToken]) : undefined;
+}
+
 export function deduplicateUsageAccountIndices(storage: AccountStorageV3): number[] {
-	const seenTokens = new Set<string>();
+	const seenIdentities = new Set<string>();
 	const uniqueIndices: number[] = [];
 	for (let i = 0; i < storage.accounts.length; i += 1) {
 		const account = storage.accounts[i];
 		if (!account) continue;
-		const refreshToken =
-			typeof account.refreshToken === "string"
-				? account.refreshToken.trim()
-				: "";
-		if (refreshToken && seenTokens.has(refreshToken)) continue;
-		if (refreshToken) seenTokens.add(refreshToken);
+		if (account.enabled === false) continue;
+		const key = getUsageAccountDedupeKey(account);
+		if (!key) continue;
+		if (seenIdentities.has(key)) continue;
+		seenIdentities.add(key);
 		uniqueIndices.push(i);
 	}
 	return uniqueIndices;
@@ -519,25 +535,28 @@ export function resolveCodexUsageActiveAccount(
 		Math.min(storage.accounts.length - 1, Math.trunc(numericIndex)),
 	);
 	const activeAccount = storage.accounts[index];
-	if (!activeAccount) return null;
+	if (!activeAccount && storage.accounts.every((account) => account.enabled === false)) return null;
 
 	const activeLastUsed =
-		typeof activeAccount.lastUsed === "number" && Number.isFinite(activeAccount.lastUsed)
+		activeAccount?.enabled !== false &&
+		typeof activeAccount?.lastUsed === "number" && Number.isFinite(activeAccount.lastUsed)
 			? activeAccount.lastUsed
-			: 0;
-	let newestIndex = index;
+			: -1;
+	let newestIndex = activeAccount?.enabled === false ? -1 : index;
 	let newestLastUsed = activeLastUsed;
 	for (let i = 0; i < storage.accounts.length; i += 1) {
 		const account = storage.accounts[i];
+		if (!account || account.enabled === false) continue;
 		const lastUsed =
-			typeof account?.lastUsed === "number" && Number.isFinite(account.lastUsed)
+			typeof account.lastUsed === "number" && Number.isFinite(account.lastUsed)
 				? account.lastUsed
 				: 0;
-		if (account && lastUsed > newestLastUsed) {
+		if (lastUsed > newestLastUsed) {
 			newestIndex = i;
 			newestLastUsed = lastUsed;
 		}
 	}
+	if (newestIndex < 0) return null;
 
 	const account = storage.accounts[newestIndex];
 	return account ? { index: newestIndex, account } : null;

--- a/lib/codex-usage.ts
+++ b/lib/codex-usage.ts
@@ -490,10 +490,32 @@ export async function ensureCodexUsageAccessToken(params: {
 	return { accessToken, refreshed: true, persisted };
 }
 
+/**
+ * Normalize an account identity field to a trimmed string.
+ *
+ * Non-string values collapse to an empty string so callers can treat
+ * "missing" and "blank" identity parts uniformly when building dedupe keys.
+ */
 function normalizeUsageIdentityPart(value: string | undefined): string {
 	return typeof value === "string" ? value.trim() : "";
 }
 
+/**
+ * Derive a stable usage-quota dedupe key for an account.
+ *
+ * A single OAuth credential can authorize multiple ChatGPT workspaces, each
+ * exposing distinct `accountId` / `organizationId` values while sharing one
+ * refresh token. Quota deduplication must therefore key on workspace identity
+ * first so separate workspaces are not collapsed into one row, falling back to
+ * the refresh token only when no workspace identity is available.
+ *
+ * Keys are emitted as `JSON.stringify` arrays (tagged `"workspace"` or
+ * `"refresh"`) so values containing delimiter characters cannot collide.
+ *
+ * @param account - Stored account metadata to derive the key from.
+ * @returns A unique identity key, or `undefined` when the account carries no
+ *   workspace identity and no refresh token.
+ */
 export function getUsageAccountDedupeKey(
 	account: AccountMetadataV3,
 ): string | undefined {
@@ -507,6 +529,16 @@ export function getUsageAccountDedupeKey(
 	return refreshToken ? JSON.stringify(["refresh", refreshToken]) : undefined;
 }
 
+/**
+ * Collect the indices of accounts that represent distinct usage quotas.
+ *
+ * Disabled accounts are skipped, and entries sharing the same
+ * {@link getUsageAccountDedupeKey} identity are collapsed to their first
+ * occurrence so the same workspace/credential is only queried once.
+ *
+ * @param storage - The account storage to scan.
+ * @returns Storage indices of unique, enabled usage accounts in original order.
+ */
 export function deduplicateUsageAccountIndices(storage: AccountStorageV3): number[] {
 	const seenIdentities = new Set<string>();
 	const uniqueIndices: number[] = [];
@@ -523,6 +555,19 @@ export function deduplicateUsageAccountIndices(storage: AccountStorageV3): numbe
 	return uniqueIndices;
 }
 
+/**
+ * Resolve which account's usage quota should be shown as active.
+ *
+ * Starts from the persisted active index (preferring the Codex family index)
+ * and then prefers the most-recently-used enabled account by `lastUsed`, so the
+ * displayed quota tracks the credential actually serving requests. Disabled
+ * accounts are ignored, and invalid/missing `lastUsed` values are treated as
+ * oldest.
+ *
+ * @param storage - The account storage to inspect.
+ * @returns The selected account and its index, or `null` when no enabled
+ *   account is available.
+ */
 export function resolveCodexUsageActiveAccount(
 	storage: AccountStorageV3,
 ): UsageAccountSelection | null {

--- a/lib/codex-usage.ts
+++ b/lib/codex-usage.ts
@@ -535,7 +535,12 @@ export function resolveCodexUsageActiveAccount(
 		Math.min(storage.accounts.length - 1, Math.trunc(numericIndex)),
 	);
 	const activeAccount = storage.accounts[index];
-	if (!activeAccount && storage.accounts.every((account) => account.enabled === false)) return null;
+	if (
+		!activeAccount &&
+		storage.accounts.every((account) => !account || account.enabled === false)
+	) {
+		return null;
+	}
 
 	const activeLastUsed =
 		activeAccount?.enabled !== false &&

--- a/lib/tools/codex-limits.ts
+++ b/lib/tools/codex-limits.ts
@@ -119,6 +119,20 @@ export function createCodexLimitsTool(ctx: ToolContext): ToolDefinition {
 			const activeUsageKey = activeAccount
 				? getUsageAccountDedupeKey(activeAccount)
 				: undefined;
+			// If the active account was deduplicated out of uniqueIndices (e.g. it
+			// is a later occurrence of a workspace whose first occurrence carries a
+			// re-issued refresh token), warn so the missing `[active]` marker is
+			// diagnosable. The key-based match below still recovers the marker.
+			if (
+				typeof activeIndex === "number" &&
+				activeIndex >= 0 &&
+				activeIndex < storage.accounts.length &&
+				!uniqueIndices.includes(activeIndex)
+			) {
+				logWarn(
+					`[${PLUGIN_NAME}] active account index ${activeIndex} was deduplicated out of the usage list; matching the active workspace by identity instead.`,
+				);
+			}
 			let storageChanged = false;
 			const jsonAccounts: Array<Record<string, unknown>> = [];
 
@@ -126,11 +140,15 @@ export function createCodexLimitsTool(ctx: ToolContext): ToolDefinition {
 				const account = storage.accounts[i];
 				if (!account) continue;
 				const accountUsageKey = getUsageAccountDedupeKey(account);
-				const sharesActiveCredential =
-					!!activeRefreshToken &&
-					account.refreshToken === activeRefreshToken &&
-					!!activeUsageKey &&
-					accountUsageKey === activeUsageKey;
+				// Match the active account by workspace identity first: two entries
+				// for the same workspace can carry different refresh tokens (e.g. a
+				// re-issued token after re-add), so an exact token match alone would
+				// drop the `[active]` marker. Fall back to refresh-token equality for
+				// accounts that have no workspace identity (token-only dedupe key).
+				const sharesActiveCredential = activeUsageKey
+					? accountUsageKey === activeUsageKey
+					: !!activeRefreshToken &&
+						account.refreshToken === activeRefreshToken;
 				const displayIndex =
 					sharesActiveCredential && typeof activeIndex === "number"
 						? activeIndex

--- a/lib/tools/codex-limits.ts
+++ b/lib/tools/codex-limits.ts
@@ -11,6 +11,7 @@ import {
 	fetchCodexUsage,
 	formatUsageLimitSummary,
 	formatUsageLimitTitle,
+	getUsageAccountDedupeKey,
 	hasUsageWindow,
 	parseCodexUsagePayload,
 	resolveCodexUsageAccountId,
@@ -97,14 +98,27 @@ export function createCodexLimitsTool(ctx: ToolContext): ToolDefinition {
 				activeIndex < storage.accounts.length
 					? storage.accounts[activeIndex]?.refreshToken?.trim() || undefined
 					: undefined;
+			const activeAccount =
+				typeof activeIndex === "number" &&
+				activeIndex >= 0 &&
+				activeIndex < storage.accounts.length
+					? storage.accounts[activeIndex]
+					: undefined;
+			const activeUsageKey = activeAccount
+				? getUsageAccountDedupeKey(activeAccount)
+				: undefined;
 			let storageChanged = false;
 			const jsonAccounts: Array<Record<string, unknown>> = [];
 
 			for (const i of uniqueIndices) {
 				const account = storage.accounts[i];
 				if (!account) continue;
+				const accountUsageKey = getUsageAccountDedupeKey(account);
 				const sharesActiveCredential =
-					!!activeRefreshToken && account.refreshToken === activeRefreshToken;
+					!!activeRefreshToken &&
+					account.refreshToken === activeRefreshToken &&
+					!!activeUsageKey &&
+					accountUsageKey === activeUsageKey;
 				const displayIndex =
 					sharesActiveCredential && typeof activeIndex === "number"
 						? activeIndex

--- a/lib/tools/codex-limits.ts
+++ b/lib/tools/codex-limits.ts
@@ -27,6 +27,18 @@ import {
 import { normalizeToolOutputFormat, renderJsonOutput } from "../runtime.js";
 import type { ToolContext } from "./index.js";
 
+/**
+ * Build the `codex-limits` tool.
+ *
+ * The tool fetches and renders Codex usage quotas for each unique account.
+ * Accounts are deduplicated by workspace identity via
+ * {@link getUsageAccountDedupeKey} so distinct workspaces are shown separately,
+ * while the active-account marker is only applied when an account matches both
+ * the active refresh token and the active workspace dedupe key.
+ *
+ * @param ctx - Shared {@link ToolContext} providing UI runtime and account helpers.
+ * @returns The `codex-limits` {@link ToolDefinition}.
+ */
 export function createCodexLimitsTool(ctx: ToolContext): ToolDefinition {
 	const {
 		resolveUiRuntime,

--- a/test/codex-usage.test.ts
+++ b/test/codex-usage.test.ts
@@ -94,6 +94,38 @@ describe("codex usage helpers", () => {
 		});
 	});
 
+	it("keeps same-token workspace entries distinct and skips disabled usage accounts", () => {
+		const storage: AccountStorageV3 = {
+			version: 3,
+			activeIndex: 0,
+			accounts: [
+				{ refreshToken: "r1", accountId: "acc-1", organizationId: "org-1", addedAt: 0, lastUsed: 0 },
+				{ refreshToken: "r1", accountId: "acc-2", organizationId: "org-2", addedAt: 0, lastUsed: 0 },
+				{ refreshToken: "r2", accountId: "acc-3", enabled: false, addedAt: 0, lastUsed: 50 },
+				{ refreshToken: "r3", accountId: "acc-1", organizationId: "org-1", addedAt: 0, lastUsed: 0 },
+			],
+		};
+
+		expect(deduplicateUsageAccountIndices(storage)).toEqual([0, 1]);
+		expect(resolveCodexUsageActiveAccount(storage)).toMatchObject({
+			index: 0,
+			account: { accountId: "acc-1" },
+		});
+	});
+
+	it("deduplicates workspace identities without delimiter collisions", () => {
+		const storage: AccountStorageV3 = {
+			version: 3,
+			activeIndex: 0,
+			accounts: [
+				{ refreshToken: "r1", accountId: "acc:1", organizationId: "org", addedAt: 0, lastUsed: 0 },
+				{ refreshToken: "r2", accountId: "acc", organizationId: "1:org", addedAt: 0, lastUsed: 0 },
+			],
+		};
+
+		expect(deduplicateUsageAccountIndices(storage)).toEqual([0, 1]);
+	});
+
 	it("uses the most recently persisted request account for usage display", () => {
 		const storage: AccountStorageV3 = {
 			version: 3,

--- a/test/codex-usage.test.ts
+++ b/test/codex-usage.test.ts
@@ -126,6 +126,36 @@ describe("codex usage helpers", () => {
 		expect(deduplicateUsageAccountIndices(storage)).toEqual([0, 1]);
 	});
 
+	it("handles sparse/undefined account slots without throwing", () => {
+		const storage = {
+			version: 3,
+			activeIndex: 5,
+			accounts: [
+				undefined,
+				{ refreshToken: "r1", accountId: "acc-1", organizationId: "org-1", addedAt: 0, lastUsed: 10 },
+			],
+		} as unknown as AccountStorageV3;
+
+		expect(() => resolveCodexUsageActiveAccount(storage)).not.toThrow();
+		expect(resolveCodexUsageActiveAccount(storage)).toMatchObject({
+			index: 1,
+			account: { accountId: "acc-1" },
+		});
+	});
+
+	it("returns null when every account slot is empty or disabled", () => {
+		const storage = {
+			version: 3,
+			activeIndex: 0,
+			accounts: [
+				undefined,
+				{ refreshToken: "r2", accountId: "acc-2", enabled: false, addedAt: 0, lastUsed: 0 },
+			],
+		} as unknown as AccountStorageV3;
+
+		expect(resolveCodexUsageActiveAccount(storage)).toBeNull();
+	});
+
 	it("uses the most recently persisted request account for usage display", () => {
 		const storage: AccountStorageV3 = {
 			version: 3,

--- a/test/codex-usage.test.ts
+++ b/test/codex-usage.test.ts
@@ -87,14 +87,14 @@ describe("codex usage helpers", () => {
 			],
 		};
 
-		expect(deduplicateUsageAccountIndices(storage)).toEqual([0, 2]);
+		expect(deduplicateUsageAccountIndices(storage)).toEqual([1, 2]);
 		expect(resolveCodexUsageActiveAccount(storage)).toMatchObject({
 			index: 2,
 			account: { accountId: "acc-2" },
 		});
 	});
 
-	it("keeps same-token workspace entries distinct and skips disabled usage accounts", () => {
+	it("keeps same-token workspace entries distinct, skips disabled, and prefers the freshest duplicate", () => {
 		const storage: AccountStorageV3 = {
 			version: 3,
 			activeIndex: 0,
@@ -106,7 +106,11 @@ describe("codex usage helpers", () => {
 			],
 		};
 
-		expect(deduplicateUsageAccountIndices(storage)).toEqual([0, 1]);
+		// org-1 (key W) appears at index 0 and again at index 3 (re-added with a
+		// fresh token r3); org-2 (key X) at index 1; index 2 disabled. Display
+		// order follows first appearance (W then X), but W resolves to its
+		// freshest occurrence (index 3, token r3), not the stale index 0.
+		expect(deduplicateUsageAccountIndices(storage)).toEqual([3, 1]);
 		expect(resolveCodexUsageActiveAccount(storage)).toMatchObject({
 			index: 0,
 			account: { accountId: "acc-1" },

--- a/test/codex-usage.test.ts
+++ b/test/codex-usage.test.ts
@@ -156,6 +156,38 @@ describe("codex usage helpers", () => {
 		expect(resolveCodexUsageActiveAccount(storage)).toBeNull();
 	});
 
+	it("keeps the active account when its lastUsed is missing", () => {
+		const storage = {
+			version: 3,
+			activeIndex: 1,
+			accounts: [
+				{ refreshToken: "r1", accountId: "acc-1", organizationId: "org-1", addedAt: 0, lastUsed: 0 },
+				{ refreshToken: "r2", accountId: "acc-2", organizationId: "org-2", addedAt: 0 },
+			],
+		} as unknown as AccountStorageV3;
+
+		// The active account (index 1) has no lastUsed. It must not lose the
+		// marker to index 0's lastUsed:0 via a 0 > -1 comparison.
+		expect(resolveCodexUsageActiveAccount(storage)).toMatchObject({
+			index: 1,
+			account: { accountId: "acc-2" },
+		});
+	});
+
+	it("drops accounts that have no workspace identity and no refresh token", () => {
+		const storage: AccountStorageV3 = {
+			version: 3,
+			activeIndex: 0,
+			accounts: [
+				{ addedAt: 0, lastUsed: 0 },
+				{ refreshToken: "r1", accountId: "acc-1", organizationId: "org-1", addedAt: 0, lastUsed: 0 },
+			],
+		};
+
+		// The identity-less entry (index 0) yields no dedupe key and is excluded.
+		expect(deduplicateUsageAccountIndices(storage)).toEqual([1]);
+	});
+
 	it("uses the most recently persisted request account for usage display", () => {
 		const storage: AccountStorageV3 = {
 			version: 3,

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1090,7 +1090,7 @@ describe("OpenAIOAuthPlugin", () => {
 			expect(mockStorage.accounts[0]?.accessToken).toBe("refreshed-access");
 		});
 
-		it("deduplicates accounts with same refreshToken and keeps the active marker", async () => {
+		it("keeps same-token workspace accounts separate and keeps the active marker", async () => {
 			const { createCodexHeaders } = await import("../lib/request/fetch-helpers.js");
 			mockStorage.accounts = [
 				{
@@ -1134,13 +1134,19 @@ describe("OpenAIOAuthPlugin", () => {
 
 			const result = await plugin.tool["codex-limits"].execute();
 
-			expect(result).toContain("2 account");
-			expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+			expect(result).toContain("3 account");
+			expect(globalThis.fetch).toHaveBeenCalledTimes(3);
+			expect(result).toContain("Account 1 (a@test.com, id:acc-1):");
 			expect(result).toContain("Account 2 (a@test.com, id:acc-2) [active]:");
 			expect(result.match(/Account 2 \(a@test\.com, id:acc-2\)/g)).toHaveLength(1);
-			expect(result).not.toContain("Account 1 (a@test.com, id:acc-1):");
 			expect(result).toContain("Account 3 (b@test.com, id:acc-3):");
 			expect(result).not.toContain("Account 2 (a@test.com, id:acc-2):");
+			expect(vi.mocked(createCodexHeaders)).toHaveBeenCalledWith(
+				undefined,
+				"acc-1",
+				"shared-access",
+				expect.objectContaining({ organizationId: "org-1" }),
+			);
 			expect(vi.mocked(createCodexHeaders)).toHaveBeenCalledWith(
 				undefined,
 				"acc-2",

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1155,6 +1155,50 @@ describe("OpenAIOAuthPlugin", () => {
 			);
 		});
 
+		it("keeps the active marker when the active account was deduped out by a re-issued token", async () => {
+			// Two entries for the same workspace (acc-1/org-1). The active entry is
+			// the later duplicate carrying a re-issued refresh token, so dedupe keeps
+			// the first occurrence (older token). The active marker must still attach
+			// to that surviving entry via workspace-identity match, not token match.
+			mockStorage.accounts = [
+				{
+					refreshToken: "rt_old",
+					accountId: "acc-1",
+					organizationId: "org-1",
+					email: "a@test.com",
+					accessToken: "access-old",
+					expiresAt: Date.now() + 3600_000,
+				},
+				{
+					refreshToken: "rt_reissued",
+					accountId: "acc-1",
+					organizationId: "org-1",
+					email: "a@test.com",
+					accessToken: "access-reissued",
+					expiresAt: Date.now() + 3600_000,
+				},
+			];
+			mockStorage.activeIndex = 1;
+			mockStorage.activeIndexByFamily = { codex: 1 };
+			globalThis.fetch = vi.fn().mockImplementation(async () =>
+				new Response(
+					JSON.stringify({
+						rate_limit: {
+							primary_window: { used_percent: 50, limit_window_seconds: 18000, reset_at: Math.floor(Date.now() / 1000) + 1800 },
+							secondary_window: { used_percent: 50, limit_window_seconds: 604800, reset_at: Math.floor(Date.now() / 1000) + 86400 },
+						},
+					}),
+					{ status: 200, headers: { "content-type": "application/json" } },
+				),
+			);
+
+			const result = await plugin.tool["codex-limits"].execute();
+
+			// Only the first occurrence survives dedupe, and it still shows [active].
+			expect(result).toContain("1 account");
+			expect(result).toContain("[active]");
+		});
+
 		it("does not deduplicate accounts that are missing refreshToken", async () => {
 			mockStorage.activeIndex = 0;
 			mockStorage.activeIndexByFamily = {};

--- a/test/rotation-integration.test.ts
+++ b/test/rotation-integration.test.ts
@@ -10,6 +10,7 @@ import {
   type AccountStorageV3,
 } from "../lib/storage.js";
 import type { ModelFamily } from "../lib/prompts/codex.js";
+import { runCleanup } from "../lib/shutdown.js";
 
 const TEST_ACCOUNTS = [
   { email: "account1@example.com", refresh_token: "fake_refresh_token_1_for_testing_only" },
@@ -65,6 +66,12 @@ describe("Multi-Account Rotation Integration", () => {
   });
 
   afterAll(async () => {
+    // Drain any pending debounced saves while TEST_STORAGE_PATH is still the
+    // active target. runCleanup() awaits every registered shutdown-flush
+    // handler (AccountManager.flushPendingSave), so a timer that resolves after
+    // this point has nothing left to write. Without this, a leaked debounced
+    // save would land in the real user store once the path is reset to null.
+    await runCleanup();
     try {
       await fs.unlink(TEST_STORAGE_PATH);
     } catch (error) {
@@ -265,12 +272,18 @@ describe("Multi-Account Rotation Integration", () => {
   });
 
   describe("Debounced save", () => {
-    it("saveToDiskDebounced does not throw", () => {
+    it("saveToDiskDebounced does not throw", async () => {
       const storage = createStorageFromTestAccounts(TEST_ACCOUNTS.slice(0, 3));
       const manager = new AccountManager(undefined, storage);
 
       expect(() => manager.saveToDiskDebounced()).not.toThrow();
       expect(() => manager.saveToDiskDebounced(100)).not.toThrow();
+
+      // Flush the pending debounced write while TEST_STORAGE_PATH is still
+      // active. Without this, the 100ms timer resolves after afterAll() resets
+      // the storage path to null and the save lands in the real user store.
+      await manager.flushPendingSave();
+      manager.disposeShutdownHandler();
     });
 
     it("flushPendingSave completes pending save", async () => {
@@ -279,6 +292,7 @@ describe("Multi-Account Rotation Integration", () => {
 
       manager.saveToDiskDebounced(1000);
       await manager.flushPendingSave();
+      manager.disposeShutdownHandler();
     });
   });
 

--- a/test/rotation-integration.test.ts
+++ b/test/rotation-integration.test.ts
@@ -10,7 +10,6 @@ import {
   type AccountStorageV3,
 } from "../lib/storage.js";
 import type { ModelFamily } from "../lib/prompts/codex.js";
-import { runCleanup } from "../lib/shutdown.js";
 
 const TEST_ACCOUNTS = [
   { email: "account1@example.com", refresh_token: "fake_refresh_token_1_for_testing_only" },
@@ -66,12 +65,13 @@ describe("Multi-Account Rotation Integration", () => {
   });
 
   afterAll(async () => {
-    // Drain any pending debounced saves while TEST_STORAGE_PATH is still the
-    // active target. runCleanup() awaits every registered shutdown-flush
-    // handler (AccountManager.flushPendingSave), so a timer that resolves after
-    // this point has nothing left to write. Without this, a leaked debounced
-    // save would land in the real user store once the path is reset to null.
-    await runCleanup();
+    // Tests that schedule debounced saves (see "Debounced save") flush and
+    // dispose their own managers while TEST_STORAGE_PATH is still active, so
+    // no pending write can outlive this teardown. We deliberately do NOT call
+    // the global runCleanup() here: it drains the shared shutdown-flush queue
+    // in lib/shutdown.ts, which under non-default vitest pools (singleThread /
+    // vmForks) would also flush AccountManager handlers registered by other
+    // test files in the same process against the wrong storage path.
     try {
       await fs.unlink(TEST_STORAGE_PATH);
     } catch (error) {


### PR DESCRIPTION
## Summary

- **What changed?**
  - **Workspace-aware usage dedupe.** `codex-limits` and TUI usage discovery deduplicated accounts purely by refresh token. Multiple ChatGPT workspaces under one login share a single refresh token while exposing distinct `accountId`/`organizationId`, so same-token workspaces collapsed into one row. Usage accounts are now deduplicated by workspace identity (`accountId` + `organizationId`) when available, falling back to refresh token only when no workspace identity exists. Dedupe keys are `JSON.stringify` arrays so delimiter characters can't cause collisions. Disabled accounts are skipped, and the active-account marker tracks the active workspace identity rather than the shared refresh token alone.
  - **Sparse-slot guard.** `resolveCodexUsageActiveAccount` no longer throws on an undefined account slot; empty slots are treated as disabled, matching the selection loop.
  - **Test isolation fix.** `test/rotation-integration.test.ts` could leak fixture accounts into the real account store (`~/.opencode/oc-codex-multi-auth-accounts.json`): it redirects storage with `setStoragePathDirect(TEST_STORAGE_PATH)` and resets to `null` in `afterAll`, but a pending `saveToDiskDebounced()` timer could fire after the reset. The suite now drains shutdown-flush handlers via `runCleanup()` before resetting, and flushes/disposes managers in the debounce tests while the test path is still active.
  - **Docstrings** for the new/changed usage helpers and the `codex-limits` tool factory.

- **Why is this needed?** Users running multiple workspaces under one login saw only one workspace's quota in `codex-limits`/TUI. This restores correct per-workspace visibility. The test leak is a safety issue: running the suite could overwrite a developer's real local account store.

  > Workspaces that share one ChatGPT login still share one server-side Codex quota. This fixes how distinct workspace entries are displayed and deduplicated; it does not create independent quotas.

## Testing

- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm test`

Local results on this branch: lint clean, typecheck clean, `npm test` 85 files / 2386 tests passing. Added regression tests for distinct same-token workspaces, skipped disabled accounts, delimiter-collision safety, sparse/undefined slots, and all-empty/disabled storage returning `null`. Verified the live account store checksum/mtime is unchanged before/after the full suite.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved account deduplication to prefer workspace identity, skip accounts lacking a derived key, keep first-seen ordering, and retain the most recent record per identity.
  * Refined active-account selection: ignores disabled/missing slots, treats absent timestamps consistently, returns null only when all accounts are missing/disabled, and preserves the active marker when an active entry is deduplicated.

* **Tests**
  * Expanded coverage for deduplication, delimiter-safe keys, sparse storage, active-selection edge cases, and teardown flushing of debounced saves.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

fixes workspace-aware dedupe so multiple chatgpt workspaces sharing one refresh token are shown as separate rows in `codex-limits`/tui, and hardens test isolation so the debounced-save tests can't leak fixture data into the developer's real account store.

- `deduplicateUsageAccountIndices` now keys on `accountId`+`organizationId` first, falling back to refresh token, using json-serialised tagged arrays to prevent delimiter collisions; per-key it keeps the **last** occurrence so a re-issued refresh token wins over the stale original.
- `resolveCodexUsageActiveAccount` no longer throws on sparse account slots; disabled accounts are skipped throughout both helpers.
- `rotation-integration.test.ts` debounced-save tests now flush and dispose their own `AccountManager` instances before `afterAll` resets the storage path, removing the `runCleanup()` call that could have drained shutdown handlers from other workers.

<h3>Confidence Score: 5/5</h3>

the dedup and active-marker changes are correct and well-tested; no data loss or token-leak paths introduced

core logic in `deduplicateUsageAccountIndices` and `resolveCodexUsageActiveAccount` is sound — last-occurrence preference correctly surfaces the freshest credential, the workspace-identity key prevents delimiter collisions, and the sparse-slot guard behaves correctly. the two stale inline comments are documentation noise and do not affect runtime behaviour. test isolation fix is clean.

the `logWarn` comment in `lib/tools/codex-limits.ts` and the test comment in `test/index.test.ts` both describe the old first-occurrence dedup direction; worth correcting before this ships to avoid future confusion

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/codex-usage.ts | adds `getUsageAccountDedupeKey` and rewrites `deduplicateUsageAccountIndices` to key on workspace identity first, keep the last (freshest) occurrence per key, and skip disabled accounts; `resolveCodexUsageActiveAccount` hardened against sparse slots and disabled active accounts — logic is sound and well-tested |
| lib/tools/codex-limits.ts | active-marker matching upgraded to workspace-identity key comparison with token-match fallback; `logWarn` on deduped-out active index added, but the prose explanation above the warn describes the inverted (old first-occurrence) scenario |
| test/codex-usage.test.ts | new regression tests cover distinct same-token workspaces, disabled-skip, delimiter-collision safety, sparse slots, all-empty/disabled null return, and missing lastUsed — good coverage of the changed paths |
| test/index.test.ts | integration test updated for 3-account distinct-workspace display; new re-issued-token test is correct but the inline comment describes old first-occurrence dedupe direction (now inverted) |
| test/rotation-integration.test.ts | debounced-save tests now flush and dispose their own managers before afterAll resets the storage path; `runCleanup()` correctly removed to avoid draining the global shutdown queue across workers |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[storage.accounts] --> B[deduplicateUsageAccountIndices]
    B --> C{account exists?}
    C -- no --> D[skip sparse slot]
    C -- yes --> E{enabled === false?}
    E -- yes --> F[skip disabled]
    E -- no --> G[getUsageAccountDedupeKey]
    G --> H{accountId or organizationId?}
    H -- yes --> I["key = JSON.stringify(['workspace', accountId, orgId])"]
    H -- no --> J{refreshToken?}
    J -- yes --> K["key = JSON.stringify(['refresh', token])"]
    J -- no --> L[skip: no identity]
    I --> M["indexByIdentity.set(key, i) - overwrites → last occurrence wins"]
    K --> M
    M --> N["[...indexByIdentity.values()] - first-appearance order"]
    N --> O[uniqueIndices for codex-limits display]
    O --> P{i === activeIndex or accountUsageKey === activeUsageKey?}
    P -- yes --> Q[show active marker]
    P -- no --> R[no marker]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
test/index.test.ts:1158-1162
**stale dedup-direction comment**

the inline comment says "dedupe keeps the first occurrence (older token)" and "the active marker must still attach to that surviving entry via workspace-identity match" — both are backwards. `deduplicateUsageAccountIndices` now keeps the **last** occurrence (`indexByIdentity.set(key, i)` overwrites on every pass), so both entries share `acc-1/org-1`, the Map keeps index 1 (`rt_reissued`), and `activeIndex === 1` means the marker lands via a direct `i === activeIndex` hit, not via workspace-identity recovery. the comment describes the old first-occurrence behaviour that was explicitly replaced by this PR; a future engineer reading it would come away with the wrong mental model of the dedup direction.

### Issue 2 of 2
lib/tools/codex-limits.ts:122-135
**`logWarn` comment describes inverted scenario**

the explanation above the `logWarn` says the warn fires when "the active account is a later occurrence of a workspace whose first occurrence carries a re-issued refresh token" — but that's the old first-occurrence world. with last-occurrence preference, the **last** occurrence is the one kept in `uniqueIndices`. the warn therefore fires when `activeIndex` points at an **earlier** occurrence while a newer duplicate at a higher index has taken its place, or when the active account is excluded due to `enabled === false`. the written rationale is inverted; a developer chasing this log line will look for the wrong thing.

`````

</details>

<sub>Reviews (3): Last reviewed commit: ["fix: prefer freshest occurrence in usage..."](https://github.com/ndycode/oc-codex-multi-auth/commit/a2280346a8d8f0fcc51c5895e2bbf1a3d31ecc83) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34672850)</sub>

<!-- /greptile_comment -->