### PR TITLE
feat(privacy): mask account emails across all display surfaces

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -159,7 +159,7 @@ The sample above intentionally sets `"retryAllAccountsMaxRetries": 3` as a bound
 | `codexTuiV2` | `true` | enables codex-style terminal ui output (set `false` to keep legacy output) |
 | `codexTuiColorProfile` | `truecolor` | terminal color profile for codex ui (`truecolor`, `ansi256`, `ansi16`) |
 | `codexTuiGlyphMode` | `ascii` | glyph set for codex ui (`ascii`, `unicode`, `auto`) |
-| `maskEmail` | `false` | masks the active account email in the TUI prompt quota status only |
+| `maskEmail` | `false` | masks account emails across account-display surfaces: the TUI prompt quota status, command output (`codex-list`, `codex-status`, `codex-limits`, `codex-health`, `codex-dashboard`, `codex-switch`, `codex-label`, `codex-tag`, `codex-note`, `codex-remove`), the interactive account menu, and the standalone login menu. Account labels (set via `codex-label`) are preferred and always shown; emails are reduced to a masked form such as `us***@example.com`. Raw emails are still emitted in `--includeSensitive` JSON output, which is opt-in. |
 | `maskEmailInQuotaDetails` | `false` | also masks the active account email in the quota details dialog when `maskEmail` is enabled |
 | `beginnerSafeMode` | `false` | enables conservative beginner-safe runtime behavior for retries and recovery |
 | `fastSession` | `false` | forces low-latency settings per request (`reasoningEffort=none/low`, `reasoningSummary=auto`, `textVerbosity=low`) |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -159,7 +159,7 @@ The sample above intentionally sets `"retryAllAccountsMaxRetries": 3` as a bound
 | `codexTuiV2` | `true` | enables codex-style terminal ui output (set `false` to keep legacy output) |
 | `codexTuiColorProfile` | `truecolor` | terminal color profile for codex ui (`truecolor`, `ansi256`, `ansi16`) |
 | `codexTuiGlyphMode` | `ascii` | glyph set for codex ui (`ascii`, `unicode`, `auto`) |
-| `maskEmail` | `false` | masks account emails across account-display surfaces: the TUI prompt quota status, command output (`codex-list`, `codex-status`, `codex-limits`, `codex-health`, `codex-dashboard`, `codex-switch`, `codex-label`, `codex-tag`, `codex-note`, `codex-remove`), the interactive account menu, and the standalone login menu. Account labels (set via `codex-label`) are preferred and always shown; emails are reduced to a masked form such as `us***@example.com`. Raw emails are still emitted in `--includeSensitive` JSON output, which is opt-in. |
+| `maskEmail` | `false` | masks account emails across account-display surfaces: the TUI prompt quota status, command output (`codex-list`, `codex-status`, `codex-limits`, `codex-health`, `codex-dashboard`, `codex-refresh`, `codex-switch`, `codex-label`, `codex-tag`, `codex-note`, `codex-remove`), the interactive account menu, and the standalone login menu. Account labels (set via `codex-label`) are preferred and always shown; emails are reduced to a masked form such as `us***@example.com`. Raw emails are still emitted in `--includeSensitive` JSON output, which is opt-in. |
 | `maskEmailInQuotaDetails` | `false` | also masks the active account email in the quota details dialog when `maskEmail` is enabled |
 | `beginnerSafeMode` | `false` | enables conservative beginner-safe runtime behavior for retries and recovery |
 | `fastSession` | `false` | forces low-latency settings per request (`reasoningEffort=none/low`, `reasoningSummary=auto`, `textVerbosity=low`) |
@@ -245,7 +245,7 @@ override any config with env vars:
 | `CODEX_TUI_V2=0` | disable codex-style ui (use legacy output) |
 | `CODEX_TUI_COLOR_PROFILE=ansi16` | force color profile for codex ui |
 | `CODEX_TUI_GLYPHS=unicode` | override glyph mode (`ascii`, `unicode`, `auto`) |
-| `CODEX_TUI_MASK_EMAIL=1` | mask the active account email in the TUI prompt quota status only |
+| `CODEX_TUI_MASK_EMAIL=1` | mask account emails across account-display surfaces (TUI prompt quota status, command output, interactive account menu, and standalone login menu) |
 | `CODEX_TUI_MASK_EMAIL_DETAILS=1` | also mask the active account email in quota details when prompt masking is enabled |
 | `CODEX_AUTH_PREWARM=0` | disable startup prewarm (prompt/instruction cache warmup) |
 | `CODEX_AUTH_FAST_SESSION=1` | enable fast-session defaults |

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -145,6 +145,12 @@ All network communication uses HTTPS:
 - API requests: Encrypted
 - Token refresh: Encrypted
 
+### Email Masking in Account Displays
+Account emails are personally identifying and can be exposed in screenshots, screen sharing, and terminal recordings during pair programming or shared OpenCode TUI sessions. To avoid this:
+- Set a stable, non-identifying label for each account with `codex-label` (for example `plus-1`, `plus-2`, `pro-1`). Labels are always preferred over emails in account displays.
+- Enable `maskEmail` in `~/.opencode/openai-codex-auth-config.json` to reduce any remaining emails to a masked form such as `us***@example.com` across the account menu, command output, and TUI quota status.
+- Raw emails are only emitted in `--includeSensitive` JSON output, which is opt-in and never shown by default.
+
 ---
 
 ## Compliance

--- a/index.ts
+++ b/index.ts
@@ -944,9 +944,10 @@ export const OpenAIOAuthPlugin: Plugin = async ({ client }: PluginInput) => {
 			if (!supportsInteractiveMenus()) return null;
 			try {
 				const { select } = await import("./lib/ui/select.js");
+				const maskEmail = resolveMaskEmail();
 				const selected = await select<number>(
 					storage.accounts.map((account, index) => ({
-						label: formatCommandAccountLabel(account, index),
+						label: formatCommandAccountLabel(account, index, { maskEmail }),
 						value: index,
 					})),
 					{
@@ -3418,9 +3419,10 @@ while (attempted.size < Math.max(1, accountCount)) {
 										};
 									});
 
+									const maskEmailEnabled = getCodexTuiMaskEmail(loadPluginConfig());
 									const menuResult = await promptLoginMode(existingAccounts, {
 										flaggedCount: flaggedStorage.accounts.length,
-										maskEmail: getCodexTuiMaskEmail(loadPluginConfig()),
+										maskEmail: maskEmailEnabled,
 									});
 
 									if (menuResult.mode === "cancel") {
@@ -3466,7 +3468,7 @@ while (attempted.size < Math.max(1, accountCount)) {
 													),
 												});
 												invalidateAccountManagerCache();
-												console.log(`\nDeleted ${target.email ?? `Account ${menuResult.deleteAccountIndex + 1}`}.\n`);
+												console.log(`\nDeleted ${resolveDisplayEmail(target.email, maskEmailEnabled) ?? `Account ${menuResult.deleteAccountIndex + 1}`}.\n`);
 											}
 											continue;
 										}
@@ -3478,7 +3480,7 @@ while (attempted.size < Math.max(1, accountCount)) {
 												await saveAccounts(workingStorage);
 												invalidateAccountManagerCache();
 												console.log(
-													`\n${target.email ?? `Account ${menuResult.toggleAccountIndex + 1}`} ${target.enabled === false ? "disabled" : "enabled"}.\n`,
+													`\n${resolveDisplayEmail(target.email, maskEmailEnabled) ?? `Account ${menuResult.toggleAccountIndex + 1}`} ${target.enabled === false ? "disabled" : "enabled"}.\n`,
 												);
 											}
 											continue;

--- a/index.ts
+++ b/index.ts
@@ -82,6 +82,7 @@ import {
 	getCodexTuiColorProfile,
 	getCodexTuiGlyphMode,
 	getBeginnerSafeMode,
+	getCodexTuiMaskEmail,
 	loadPluginConfig,
 } from "./lib/config.js";
 import {
@@ -118,6 +119,7 @@ import {
         parseRateLimitReason,
 	lookupCodexCliTokensByEmail,
 } from "./lib/accounts.js";
+import { resolveDisplayEmail } from "./lib/account-display.js";
 import {
 	getStoragePath,
 	loadAccounts,
@@ -856,6 +858,10 @@ export const OpenAIOAuthPlugin: Plugin = async ({ client }: PluginInput) => {
 			return applyUiRuntimeFromConfig(loadPluginConfig());
 		};
 
+		const resolveMaskEmail = (): boolean => {
+			return getCodexTuiMaskEmail(loadPluginConfig());
+		};
+
 		const getStatusMarker = (
 			ui: UiRuntimeOptions,
 			status: "ok" | "warning" | "error",
@@ -886,8 +892,9 @@ export const OpenAIOAuthPlugin: Plugin = async ({ client }: PluginInput) => {
 				accountNote?: string;
 			} | undefined,
 			index: number,
+			options: { maskEmail?: boolean } = {},
 		): string => {
-			const email = account?.email?.trim();
+			const email = resolveDisplayEmail(account?.email, options.maskEmail ?? false);
 			const workspace = account?.accountLabel?.trim();
 			const accountId = formatAccountIdForDisplay(account?.accountId);
 			const tags =
@@ -1386,6 +1393,7 @@ export const OpenAIOAuthPlugin: Plugin = async ({ client }: PluginInput) => {
 			resolveUiRuntime,
 			getStatusMarker,
 			formatCommandAccountLabel,
+			resolveMaskEmail,
 			normalizeAccountTags,
 			supportsInteractiveMenus,
 			promptAccountIndexSelection,
@@ -1513,6 +1521,7 @@ export const OpenAIOAuthPlugin: Plugin = async ({ client }: PluginInput) => {
 				const fastSessionMaxInputItems = getFastSessionMaxInputItems(pluginConfig);
 				const beginnerSafeMode = getBeginnerSafeMode(pluginConfig);
 				beginnerSafeModeEnabled = beginnerSafeMode;
+				const maskEmailEnabled = getCodexTuiMaskEmail(pluginConfig);
 				const retryProfile = beginnerSafeMode
 					? "conservative"
 					: getRetryProfile(pluginConfig);
@@ -1920,7 +1929,9 @@ while (attempted.size < Math.max(1, accountCount)) {
 				runtimeMetrics.lastError = (err as Error)?.message ?? String(err);
 				runtimeMetrics.lastErrorCategory = "auth-refresh";
 				const failures = await accountManager.incrementAuthFailures(account);
-				const accountLabel = formatAccountLabel(account, account.index);
+				const accountLabel = formatAccountLabel(account, account.index, {
+					maskEmail: maskEmailEnabled,
+				});
 				
 				if (failures >= ACCOUNT_LIMITS.MAX_AUTH_FAILURES_BEFORE_REMOVAL) {
 					const removedCount = accountManager.removeAccountsWithSameRefreshToken(account);
@@ -1999,7 +2010,9 @@ while (attempted.size < Math.max(1, accountCount)) {
 													rateLimitToastDebounceMs,
 												)
 											) {
-												const accountLabel = formatAccountLabel(account, account.index);
+												const accountLabel = formatAccountLabel(account, account.index, {
+													maskEmail: maskEmailEnabled,
+												});
 												await showToast(
 													`Using ${accountLabel} (${account.index + 1}/${accountCount})`,
 													"info",
@@ -2167,7 +2180,9 @@ while (attempted.size < Math.max(1, accountCount)) {
 
 			const workspaceDeactivated = isDeactivatedWorkspaceError(errorBody, response.status);
 				if (workspaceDeactivated) {
-					const accountLabel = formatAccountLabel(account, account.index);
+					const accountLabel = formatAccountLabel(account, account.index, {
+						maskEmail: maskEmailEnabled,
+					});
 					accountManager.refundToken(account, modelFamily, model);
 					accountManager.recordFailure(account, modelFamily, model);
 				account.lastSwitchReason = "rotation";
@@ -2986,6 +3001,7 @@ while (attempted.size < Math.max(1, accountCount)) {
 								let ok = 0;
 								let disabled = 0;
 								let errors = 0;
+								const maskEmailEnabled = getCodexTuiMaskEmail(loadPluginConfig());
 
 								console.log(
 									`\nChecking ${deepProbe ? "full account health" : "quotas"} for all accounts...\n`,
@@ -2994,7 +3010,10 @@ while (attempted.size < Math.max(1, accountCount)) {
 								for (let i = 0; i < total; i += 1) {
 									const account = workingStorage.accounts[i];
 									if (!account) continue;
-									const label = account.email ?? account.accountLabel ?? `Account ${i + 1}`;
+									const label =
+										account.accountLabel?.trim() ||
+										resolveDisplayEmail(account.email, maskEmailEnabled) ||
+										`Account ${i + 1}`;
 									if (account.enabled === false) {
 										disabled += 1;
 										console.log(`[${i + 1}/${total}] ${label}: DISABLED`);
@@ -3250,13 +3269,17 @@ while (attempted.size < Math.max(1, accountCount)) {
 								}
 
 								console.log("\nVerifying flagged accounts...\n");
+								const maskEmailEnabled = getCodexTuiMaskEmail(loadPluginConfig());
 								const remaining: FlaggedAccountMetadataV1[] = [];
 								const restored: TokenSuccessWithAccount[] = [];
 
 								for (let i = 0; i < flaggedStorage.accounts.length; i += 1) {
 									const flagged = flaggedStorage.accounts[i];
 									if (!flagged) continue;
-									const label = flagged.email ?? flagged.accountLabel ?? `Flagged ${i + 1}`;
+									const label =
+										flagged.accountLabel?.trim() ||
+										resolveDisplayEmail(flagged.email, maskEmailEnabled) ||
+										`Flagged ${i + 1}`;
 									if (flagged.flaggedReason === "workspace-deactivated") {
 										console.log(
 											`[${i + 1}/${flaggedStorage.accounts.length}] ${label}: STILL FLAGGED (workspace deactivated)`,
@@ -3397,6 +3420,7 @@ while (attempted.size < Math.max(1, accountCount)) {
 
 									const menuResult = await promptLoginMode(existingAccounts, {
 										flaggedCount: flaggedStorage.accounts.length,
+										maskEmail: getCodexTuiMaskEmail(loadPluginConfig()),
 									});
 
 									if (menuResult.mode === "cancel") {

--- a/lib/account-display.ts
+++ b/lib/account-display.ts
@@ -1,0 +1,47 @@
+/**
+ * Shared account-display helpers.
+ *
+ * Account identity is rendered across several UI surfaces (interactive auth
+ * menu, command output, runtime/log messages, standalone CLI login menu, TUI
+ * quota status). Historically each surface formatted the email independently
+ * and only the TUI quota path honored the `maskEmail` config, so full emails
+ * could still leak into screenshots, screen shares, and terminal recordings.
+ *
+ * These helpers centralize the privacy behavior so every human-facing surface
+ * masks the email consistently when `maskEmail` is enabled, while preferring a
+ * user-defined account label when one exists.
+ */
+
+/**
+ * Mask an email for display while preserving the domain so collisions between
+ * accounts on the same provider remain distinguishable.
+ *
+ * `user@example.com` -> `us***@example.com`
+ * `a@example.org`    -> `a***@example.org`
+ * `not-an-email`     -> `*****`
+ *
+ * Returns `undefined` for empty/whitespace input so callers can fall back to
+ * other identity fields.
+ */
+export function maskEmailForDisplay(email: string | undefined): string | undefined {
+	const trimmed = email?.trim();
+	if (!trimmed) return undefined;
+	const atIndex = trimmed.indexOf("@");
+	if (atIndex <= 0) return "*****";
+	const prefix = trimmed.slice(0, Math.min(2, atIndex));
+	const domain = trimmed.slice(atIndex);
+	return `${prefix}***${domain}`;
+}
+
+/**
+ * Resolve the email value to display for an account, applying masking when
+ * requested. Returns `undefined` when there is no email to show.
+ */
+export function resolveDisplayEmail(
+	email: string | undefined,
+	maskEmail: boolean,
+): string | undefined {
+	const trimmed = email?.trim();
+	if (!trimmed) return undefined;
+	return maskEmail ? maskEmailForDisplay(trimmed) : trimmed;
+}

--- a/lib/accounts.ts
+++ b/lib/accounts.ts
@@ -29,6 +29,7 @@ import {
 } from "./accounts/state.js";
 import { formatWaitTime, type RateLimitReason } from "./accounts/rate-limits.js";
 import { nowMs } from "./utils.js";
+import { resolveDisplayEmail } from "./account-display.js";
 
 export type { AccountSelectionExplainability, ManagedAccount } from "./accounts/state.js";
 
@@ -332,9 +333,10 @@ export class AccountManager {
 export function formatAccountLabel(
 	account: { email?: string; accountId?: string; accountLabel?: string } | undefined,
 	index: number,
+	options: { maskEmail?: boolean } = {},
 ): string {
 	const accountLabel = account?.accountLabel?.trim();
-	const email = account?.email?.trim();
+	const email = resolveDisplayEmail(account?.email, options.maskEmail ?? false);
 	const accountId = account?.accountId?.trim();
 	const idSuffix = accountId
 		? accountId.length > 6

--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -1,6 +1,7 @@
 import { createInterface } from "node:readline/promises";
 import { stdin as input, stdout as output } from "node:process";
 import type { AccountIdSource } from "./types.js";
+import { resolveDisplayEmail } from "./account-display.js";
 import {
 	showAuthMenu,
 	showAccountDetails,
@@ -62,6 +63,7 @@ export interface ExistingAccountInfo {
 
 export interface LoginMenuOptions {
 	flaggedCount?: number;
+	maskEmail?: boolean;
 }
 
 export interface LoginMenuResult {
@@ -72,10 +74,14 @@ export interface LoginMenuResult {
 	deleteAll?: boolean;
 }
 
-function formatAccountLabel(account: ExistingAccountInfo, index: number): string {
+function formatAccountLabel(
+	account: ExistingAccountInfo,
+	index: number,
+	options: { maskEmail?: boolean } = {},
+): string {
 	const num = index + 1;
 	const label = account.accountLabel?.trim();
-	const email = account.email?.trim();
+	const email = resolveDisplayEmail(account.email, options.maskEmail ?? false);
 	const accountId = account.accountId?.trim();
 	const accountIdDisplay =
 		accountId && accountId.length > 14
@@ -101,13 +107,16 @@ async function promptDeleteAllTypedConfirm(): Promise<boolean> {
 	}
 }
 
-async function promptLoginModeFallback(existingAccounts: ExistingAccountInfo[]): Promise<LoginMenuResult> {
+async function promptLoginModeFallback(
+	existingAccounts: ExistingAccountInfo[],
+	maskEmail = false,
+): Promise<LoginMenuResult> {
 	const rl = createInterface({ input, output });
 	try {
 		if (existingAccounts.length > 0) {
 			console.log(`\n${existingAccounts.length} account(s) saved:`);
 			for (const account of existingAccounts) {
-				console.log(`  ${formatAccountLabel(account, account.index)}`);
+				console.log(`  ${formatAccountLabel(account, account.index, { maskEmail })}`);
 			}
 			console.log("");
 		}
@@ -136,13 +145,16 @@ export async function promptLoginMode(
 		return { mode: "add" };
 	}
 
+	const maskEmail = options.maskEmail ?? false;
+
 	if (!isTTY()) {
-		return promptLoginModeFallback(existingAccounts);
+		return promptLoginModeFallback(existingAccounts, maskEmail);
 	}
 
 	while (true) {
 		const action = await showAuthMenu(existingAccounts, {
 			flaggedCount: options.flaggedCount ?? 0,
+			maskEmail,
 		});
 
 		switch (action.type) {
@@ -161,7 +173,7 @@ export async function promptLoginMode(
 			case "verify-flagged":
 				return { mode: "verify-flagged" };
 			case "select-account": {
-				const accountAction = await showAccountDetails(action.account);
+				const accountAction = await showAccountDetails(action.account, { maskEmail });
 				if (accountAction === "delete") {
 					return { mode: "manage", deleteAccountIndex: action.account.index };
 				}

--- a/lib/tools/codex-dashboard.ts
+++ b/lib/tools/codex-dashboard.ts
@@ -23,6 +23,7 @@ export function createCodexDashboardTool(ctx: ToolContext): ToolDefinition {
 		resolveUiRuntime,
 		resolveActiveIndex,
 		formatCommandAccountLabel,
+		resolveMaskEmail,
 		buildJsonAccountIdentity,
 		buildRoutingVisibilitySnapshot,
 		appendRoutingVisibilityText,
@@ -56,6 +57,7 @@ export function createCodexDashboardTool(ctx: ToolContext): ToolDefinition {
 			includeSensitive?: boolean;
 		} = {}) {
 			const ui = resolveUiRuntime();
+			const maskEmail = resolveMaskEmail();
 			const outputFormat = normalizeToolOutputFormat(format);
 			const includeSensitiveOutput = includeSensitive === true;
 			const storage = await loadAccounts();
@@ -194,6 +196,7 @@ export function createCodexDashboardTool(ctx: ToolContext): ToolDefinition {
 					const label = formatCommandAccountLabel(
 						storage.accounts[entry.index],
 						entry.index,
+						{ maskEmail },
 					);
 					const state = entry.eligible
 						? formatUiBadge(ui, "eligible", "success")
@@ -249,6 +252,7 @@ export function createCodexDashboardTool(ctx: ToolContext): ToolDefinition {
 				const label = formatCommandAccountLabel(
 					storage.accounts[entry.index],
 					entry.index,
+					{ maskEmail },
 				);
 				lines.push(
 					`  - ${label}: ${entry.eligible ? "eligible" : "blocked"} | health=${Math.round(entry.healthScore)} | tokens=${entry.tokensAvailable.toFixed(1)} | reasons=${entry.reasons.join(", ")}`,

--- a/lib/tools/codex-health.ts
+++ b/lib/tools/codex-health.ts
@@ -14,6 +14,7 @@ export function createCodexHealthTool(ctx: ToolContext): ToolDefinition {
 	const {
 		resolveUiRuntime,
 		formatCommandAccountLabel,
+		resolveMaskEmail,
 		getStatusMarker,
 		buildJsonAccountIdentity,
 	} = ctx;
@@ -40,6 +41,7 @@ export function createCodexHealthTool(ctx: ToolContext): ToolDefinition {
 			includeSensitive?: boolean;
 		} = {}) {
 			const ui = resolveUiRuntime();
+			const maskEmail = resolveMaskEmail();
 			const outputFormat = normalizeToolOutputFormat(format);
 			const includeSensitiveOutput = includeSensitive === true;
 			const storage = await loadAccounts();
@@ -78,6 +80,7 @@ export function createCodexHealthTool(ctx: ToolContext): ToolDefinition {
 				if (!account) continue;
 
 				const label = formatCommandAccountLabel(account, i);
+				const displayLabel = formatCommandAccountLabel(account, i, { maskEmail });
 				try {
 					const refreshResult = await queuedRefresh(account.refreshToken);
 					if (refreshResult.type === "success") {
@@ -90,7 +93,7 @@ export function createCodexHealthTool(ctx: ToolContext): ToolDefinition {
 							status: "healthy",
 						});
 						results.push(
-							`  ${getStatusMarker(ui, "ok")} ${label}: Healthy`,
+							`  ${getStatusMarker(ui, "ok")} ${displayLabel}: Healthy`,
 						);
 						healthyCount++;
 					} else {
@@ -104,7 +107,7 @@ export function createCodexHealthTool(ctx: ToolContext): ToolDefinition {
 							error: refreshResult.message ?? refreshResult.reason,
 						});
 						results.push(
-							`  ${getStatusMarker(ui, "error")} ${label}: Token refresh failed`,
+							`  ${getStatusMarker(ui, "error")} ${displayLabel}: Token refresh failed`,
 						);
 						unhealthyCount++;
 					}
@@ -121,7 +124,7 @@ export function createCodexHealthTool(ctx: ToolContext): ToolDefinition {
 						error: errorMsg.slice(0, 120),
 					});
 					results.push(
-						`  ${getStatusMarker(ui, "error")} ${label}: Error - ${errorMsg.slice(0, 120)}`,
+						`  ${getStatusMarker(ui, "error")} ${displayLabel}: Error - ${errorMsg.slice(0, 120)}`,
 					);
 					unhealthyCount++;
 				}

--- a/lib/tools/codex-label.ts
+++ b/lib/tools/codex-label.ts
@@ -20,6 +20,7 @@ export function createCodexLabelTool(ctx: ToolContext): ToolDefinition {
 		promptAccountIndexSelection,
 		supportsInteractiveMenus,
 		formatCommandAccountLabel,
+		resolveMaskEmail,
 		getStatusMarker,
 		cachedAccountManagerRef,
 		accountManagerPromiseRef,
@@ -42,6 +43,7 @@ export function createCodexLabelTool(ctx: ToolContext): ToolDefinition {
 		},
 		async execute({ index, label }: { index?: number; label: string }) {
 			const ui = resolveUiRuntime();
+			const maskEmail = resolveMaskEmail();
 			const storage = await loadAccounts();
 			if (!storage || storage.accounts.length === 0) {
 				if (ui.v2Enabled) {
@@ -175,7 +177,7 @@ export function createCodexLabelTool(ctx: ToolContext): ToolDefinition {
 				accountManagerPromiseRef.current = Promise.resolve(reloadedManager);
 			}
 
-			const accountLabel = formatCommandAccountLabel(account, targetIndex);
+			const accountLabel = formatCommandAccountLabel(account, targetIndex, { maskEmail });
 			if (ui.v2Enabled) {
 				const statusText =
 					normalizedLabel.length === 0

--- a/lib/tools/codex-limits.ts
+++ b/lib/tools/codex-limits.ts
@@ -44,6 +44,7 @@ export function createCodexLimitsTool(ctx: ToolContext): ToolDefinition {
 		resolveUiRuntime,
 		resolveActiveIndex,
 		formatCommandAccountLabel,
+		resolveMaskEmail,
 		buildJsonAccountIdentity,
 		invalidateAccountManagerCache,
 	} = ctx;
@@ -70,6 +71,7 @@ export function createCodexLimitsTool(ctx: ToolContext): ToolDefinition {
 			includeSensitive?: boolean;
 		} = {}) {
 			const ui = resolveUiRuntime();
+			const maskEmail = resolveMaskEmail();
 			const outputFormat = normalizeToolOutputFormat(format);
 			const includeSensitiveOutput = includeSensitive === true;
 			const storage = await loadAccounts();
@@ -166,6 +168,11 @@ export function createCodexLimitsTool(ctx: ToolContext): ToolDefinition {
 					effectiveDisplayAccount,
 					displayIndex,
 				);
+				const displayLabel = formatCommandAccountLabel(
+					effectiveDisplayAccount,
+					displayIndex,
+					{ maskEmail },
+				);
 				const isActive = i === activeIndex || sharesActiveCredential;
 				const activeSuffix = isActive
 					? ui.v2Enabled
@@ -210,7 +217,7 @@ export function createCodexLimitsTool(ctx: ToolContext): ToolDefinition {
 					});
 
 					if (ui.v2Enabled) {
-						lines.push(formatUiItem(ui, `${label}${activeSuffix}`));
+						lines.push(formatUiItem(ui, `${displayLabel}${activeSuffix}`));
 						lines.push(
 							`  ${formatUiKeyValue(ui, formatUsageLimitTitle(usage.primary.windowMinutes), formatUsageLimitSummary(usage.primary), "muted")}`,
 						);
@@ -238,7 +245,7 @@ export function createCodexLimitsTool(ctx: ToolContext): ToolDefinition {
 							);
 						}
 					} else {
-						lines.push(`${label}${activeSuffix}:`);
+						lines.push(`${displayLabel}${activeSuffix}:`);
 						lines.push(
 							`  ${formatUsageLimitTitle(usage.primary.windowMinutes)}: ${formatUsageLimitSummary(usage.primary)}`,
 						);
@@ -276,12 +283,12 @@ export function createCodexLimitsTool(ctx: ToolContext): ToolDefinition {
 						error: message.slice(0, 160),
 					});
 					if (ui.v2Enabled) {
-						lines.push(formatUiItem(ui, `${label}${activeSuffix}`));
+						lines.push(formatUiItem(ui, `${displayLabel}${activeSuffix}`));
 						lines.push(
 							`  ${formatUiKeyValue(ui, "Error", message.slice(0, 160), "danger")}`,
 						);
 					} else {
-						lines.push(`${label}${activeSuffix}:`);
+						lines.push(`${displayLabel}${activeSuffix}:`);
 						lines.push(`  Error: ${message.slice(0, 160)}`);
 					}
 				}

--- a/lib/tools/codex-list.ts
+++ b/lib/tools/codex-list.ts
@@ -23,6 +23,7 @@ export function createCodexListTool(ctx: ToolContext): ToolDefinition {
 		resolveUiRuntime,
 		resolveActiveIndex,
 		formatCommandAccountLabel,
+		resolveMaskEmail,
 		formatRateLimitEntry,
 		buildJsonAccountIdentity,
 	} = ctx;
@@ -55,6 +56,7 @@ export function createCodexListTool(ctx: ToolContext): ToolDefinition {
 			includeSensitive?: boolean;
 		} = {}) {
 			const ui = resolveUiRuntime();
+			const maskEmail = resolveMaskEmail();
 			const storage = await loadAccounts();
 			const storePath = getStoragePath();
 			const outputFormat = normalizeToolOutputFormat(format);
@@ -201,7 +203,7 @@ export function createCodexListTool(ctx: ToolContext): ToolDefinition {
 				];
 
 				filteredEntries.forEach(({ account, index }) => {
-					const label = formatCommandAccountLabel(account, index);
+					const label = formatCommandAccountLabel(account, index, { maskEmail });
 					const badges: string[] = [];
 					if (index === activeIndex)
 						badges.push(formatUiBadge(ui, "current", "accent"));
@@ -282,7 +284,7 @@ export function createCodexListTool(ctx: ToolContext): ToolDefinition {
 			];
 
 			filteredEntries.forEach(({ account, index }) => {
-				const label = formatCommandAccountLabel(account, index);
+				const label = formatCommandAccountLabel(account, index, { maskEmail });
 				const statuses: string[] = [];
 				const rateLimit = formatRateLimitEntry(account, now);
 				if (index === activeIndex) statuses.push("active");

--- a/lib/tools/codex-note.ts
+++ b/lib/tools/codex-note.ts
@@ -15,6 +15,7 @@ export function createCodexNoteTool(ctx: ToolContext): ToolDefinition {
 		promptAccountIndexSelection,
 		supportsInteractiveMenus,
 		formatCommandAccountLabel,
+		resolveMaskEmail,
 		cachedAccountManagerRef,
 		accountManagerPromiseRef,
 	} = ctx;
@@ -33,6 +34,7 @@ export function createCodexNoteTool(ctx: ToolContext): ToolDefinition {
 		},
 		async execute({ index, note }: { index?: number; note: string }) {
 			const ui = resolveUiRuntime();
+			const maskEmail = resolveMaskEmail();
 			const storage = await loadAccounts();
 			if (!storage || storage.accounts.length === 0) {
 				return "No Codex accounts configured. Run: opencode auth login";
@@ -90,7 +92,7 @@ export function createCodexNoteTool(ctx: ToolContext): ToolDefinition {
 				accountManagerPromiseRef.current = Promise.resolve(reloadedManager);
 			}
 
-			const accountLabel = formatCommandAccountLabel(account, targetIndex);
+			const accountLabel = formatCommandAccountLabel(account, targetIndex, { maskEmail });
 			if (normalizedNote.length === 0) {
 				return `Cleared note for ${accountLabel}`;
 			}

--- a/lib/tools/codex-refresh.ts
+++ b/lib/tools/codex-refresh.ts
@@ -14,6 +14,7 @@ export function createCodexRefreshTool(ctx: ToolContext): ToolDefinition {
 	const {
 		resolveUiRuntime,
 		formatCommandAccountLabel,
+		resolveMaskEmail,
 		getStatusMarker,
 		cachedAccountManagerRef,
 		accountManagerPromiseRef,
@@ -24,6 +25,7 @@ export function createCodexRefreshTool(ctx: ToolContext): ToolDefinition {
 		args: {},
 		async execute() {
 			const ui = resolveUiRuntime();
+			const maskEmail = resolveMaskEmail();
 			const storage = await loadAccounts();
 			if (!storage || storage.accounts.length === 0) {
 				if (ui.v2Enabled) {
@@ -47,7 +49,7 @@ export function createCodexRefreshTool(ctx: ToolContext): ToolDefinition {
 			for (let i = 0; i < storage.accounts.length; i++) {
 				const account = storage.accounts[i];
 				if (!account) continue;
-				const label = formatCommandAccountLabel(account, i);
+				const label = formatCommandAccountLabel(account, i, { maskEmail });
 
 				try {
 					const refreshResult = await queuedRefresh(account.refreshToken);

--- a/lib/tools/codex-remove.ts
+++ b/lib/tools/codex-remove.ts
@@ -6,6 +6,7 @@
 import { tool, type ToolDefinition } from "@opencode-ai/plugin/tool";
 import { loadAccounts, saveAccounts } from "../storage.js";
 import { AccountManager } from "../accounts.js";
+import { resolveDisplayEmail } from "../account-display.js";
 import { logWarn } from "../logger.js";
 import { MODEL_FAMILIES } from "../prompts/codex.js";
 import {
@@ -208,12 +209,13 @@ export function createCodexRemoveTool(ctx: ToolContext): ToolDefinition {
 				? storage.accounts.filter((entry) => entry.email === account.email)
 						.length
 				: 0;
+			const displayEmail = resolveDisplayEmail(account.email, maskEmail);
 			if (ui.v2Enabled) {
 				const postRemoveHint =
-					matchingEmailRemaining > 0 && account.email
+					matchingEmailRemaining > 0 && displayEmail
 						? formatUiItem(
 								ui,
-								`Other entries for ${account.email} remain: ${matchingEmailRemaining}`,
+								`Other entries for ${displayEmail} remain: ${matchingEmailRemaining}`,
 								"muted",
 							)
 						: formatUiItem(
@@ -240,8 +242,8 @@ export function createCodexRemoveTool(ctx: ToolContext): ToolDefinition {
 				].join("\n");
 			}
 			const postRemoveHint =
-				matchingEmailRemaining > 0 && account.email
-					? `Other entries for ${account.email} remain: ${matchingEmailRemaining}`
+				matchingEmailRemaining > 0 && displayEmail
+					? `Other entries for ${displayEmail} remain: ${matchingEmailRemaining}`
 					: "Only the selected entry was removed.";
 			return [
 				`Removed selected entry: ${label}`,

--- a/lib/tools/codex-remove.ts
+++ b/lib/tools/codex-remove.ts
@@ -21,6 +21,7 @@ export function createCodexRemoveTool(ctx: ToolContext): ToolDefinition {
 		promptAccountIndexSelection,
 		supportsInteractiveMenus,
 		formatCommandAccountLabel,
+		resolveMaskEmail,
 		getStatusMarker,
 		cachedAccountManagerRef,
 		accountManagerPromiseRef,
@@ -50,6 +51,7 @@ export function createCodexRemoveTool(ctx: ToolContext): ToolDefinition {
 			confirm,
 		}: { index?: number; confirm?: boolean } = {}) {
 			const ui = resolveUiRuntime();
+			const maskEmail = resolveMaskEmail();
 			if (confirm !== true) {
 				const guidance =
 					"codex-remove requires confirm=true to proceed. " +
@@ -145,7 +147,7 @@ export function createCodexRemoveTool(ctx: ToolContext): ToolDefinition {
 				return `Account ${resolvedIndex} not found.`;
 			}
 
-			const label = formatCommandAccountLabel(account, targetIndex);
+			const label = formatCommandAccountLabel(account, targetIndex, { maskEmail });
 
 			storage.accounts.splice(targetIndex, 1);
 

--- a/lib/tools/codex-status.ts
+++ b/lib/tools/codex-status.ts
@@ -28,6 +28,7 @@ export function createCodexStatusTool(ctx: ToolContext): ToolDefinition {
 		resolveUiRuntime,
 		resolveActiveIndex,
 		formatCommandAccountLabel,
+		resolveMaskEmail,
 		formatRateLimitEntry,
 		getRateLimitResetTimeForFamily,
 		buildJsonAccountIdentity,
@@ -62,6 +63,7 @@ export function createCodexStatusTool(ctx: ToolContext): ToolDefinition {
 			includeSensitive?: boolean;
 		} = {}) {
 			const ui = resolveUiRuntime();
+			const maskEmail = resolveMaskEmail();
 			const outputFormat = normalizeToolOutputFormat(format);
 			const includeSensitiveOutput = includeSensitive === true;
 			const storage = await loadAccounts();
@@ -200,7 +202,7 @@ export function createCodexStatusTool(ctx: ToolContext): ToolDefinition {
 				];
 
 				storage.accounts.forEach((account, index) => {
-					const label = formatCommandAccountLabel(account, index);
+					const label = formatCommandAccountLabel(account, index, { maskEmail });
 					const badges: string[] = [];
 					if (index === activeIndex)
 						badges.push(formatUiBadge(ui, "active", "accent"));
@@ -303,7 +305,7 @@ export function createCodexStatusTool(ctx: ToolContext): ToolDefinition {
 			];
 
 			storage.accounts.forEach((account, index) => {
-				const label = formatCommandAccountLabel(account, index);
+				const label = formatCommandAccountLabel(account, index, { maskEmail });
 				const active = index === activeIndex ? "Yes" : "No";
 				const rateLimit = formatRateLimitEntry(account, now) ?? "None";
 				const cooldown = formatCooldown(account, now) ?? "No";

--- a/lib/tools/codex-switch.ts
+++ b/lib/tools/codex-switch.ts
@@ -22,6 +22,7 @@ export function createCodexSwitchTool(ctx: ToolContext): ToolDefinition {
 		promptAccountIndexSelection,
 		supportsInteractiveMenus,
 		formatCommandAccountLabel,
+		resolveMaskEmail,
 		getStatusMarker,
 		cachedAccountManagerRef,
 		accountManagerPromiseRef,
@@ -39,6 +40,7 @@ export function createCodexSwitchTool(ctx: ToolContext): ToolDefinition {
 		},
 		async execute({ index }: { index?: number } = {}) {
 			const ui = resolveUiRuntime();
+			const maskEmail = resolveMaskEmail();
 			const storage = await loadAccounts();
 			if (!storage || storage.accounts.length === 0) {
 				if (ui.v2Enabled) {
@@ -132,7 +134,7 @@ export function createCodexSwitchTool(ctx: ToolContext): ToolDefinition {
 				logWarn("Failed to save account switch", {
 					error: String(saveError),
 				});
-				const label = formatCommandAccountLabel(account, targetIndex);
+				const label = formatCommandAccountLabel(account, targetIndex, { maskEmail });
 				if (ui.v2Enabled) {
 					return [
 						...formatUiHeader(ui, "Switch account"),
@@ -161,7 +163,7 @@ export function createCodexSwitchTool(ctx: ToolContext): ToolDefinition {
 				accountManagerPromiseRef.current = Promise.resolve(reloadedManager);
 			}
 
-			const label = formatCommandAccountLabel(account, targetIndex);
+			const label = formatCommandAccountLabel(account, targetIndex, { maskEmail });
 			if (ui.v2Enabled) {
 				return [
 					...formatUiHeader(ui, "Switch account"),

--- a/lib/tools/codex-tag.ts
+++ b/lib/tools/codex-tag.ts
@@ -20,6 +20,7 @@ export function createCodexTagTool(ctx: ToolContext): ToolDefinition {
 		promptAccountIndexSelection,
 		supportsInteractiveMenus,
 		formatCommandAccountLabel,
+		resolveMaskEmail,
 		getStatusMarker,
 		normalizeAccountTags,
 		cachedAccountManagerRef,
@@ -42,6 +43,7 @@ export function createCodexTagTool(ctx: ToolContext): ToolDefinition {
 		},
 		async execute({ index, tags }: { index?: number; tags: string }) {
 			const ui = resolveUiRuntime();
+			const maskEmail = resolveMaskEmail();
 			const storage = await loadAccounts();
 			if (!storage || storage.accounts.length === 0) {
 				if (ui.v2Enabled) {
@@ -111,7 +113,7 @@ export function createCodexTagTool(ctx: ToolContext): ToolDefinition {
 				accountManagerPromiseRef.current = Promise.resolve(reloadedManager);
 			}
 
-			const accountLabel = formatCommandAccountLabel(account, targetIndex);
+			const accountLabel = formatCommandAccountLabel(account, targetIndex, { maskEmail });
 			const previousText =
 				previousTags.length > 0 ? previousTags.join(", ") : "none";
 			const nextText =

--- a/lib/tools/index.ts
+++ b/lib/tools/index.ts
@@ -111,7 +111,9 @@ export interface ToolContext {
 			  }
 			| undefined,
 		index: number,
+		options?: { maskEmail?: boolean },
 	) => string;
+	resolveMaskEmail: () => boolean;
 	normalizeAccountTags: (raw: string) => string[];
 	supportsInteractiveMenus: () => boolean;
 	promptAccountIndexSelection: (

--- a/lib/ui/auth-menu.ts
+++ b/lib/ui/auth-menu.ts
@@ -3,6 +3,7 @@ import { confirm } from "./confirm.js";
 import { getUiRuntimeOptions } from "./runtime.js";
 import { select, type MenuItem } from "./select.js";
 import { paintUiText, formatUiBadge } from "./format.js";
+import { resolveDisplayEmail } from "../account-display.js";
 
 export type AccountStatus =
 	| "active"
@@ -28,6 +29,7 @@ export interface AccountInfo {
 
 export interface AuthMenuOptions {
 	flaggedCount?: number;
+	maskEmail?: boolean;
 }
 
 export type AuthMenuAction =
@@ -108,8 +110,8 @@ function formatAccountIdSuffix(accountId: string | undefined): string | undefine
 		: trimmed;
 }
 
-function accountTitle(account: AccountInfo): string {
-	const email = account.email?.trim();
+function accountTitle(account: AccountInfo, maskEmail = false): string {
+	const email = resolveDisplayEmail(account.email, maskEmail);
 	const label = account.accountLabel?.trim();
 	const accountIdSuffix = formatAccountIdSuffix(account.accountId);
 
@@ -132,6 +134,7 @@ export async function showAuthMenu(
 ): Promise<AuthMenuAction> {
 	const ui = getUiRuntimeOptions();
 	const flaggedCount = options.flaggedCount ?? 0;
+	const maskEmail = options.maskEmail ?? false;
 	const verifyLabel =
 		flaggedCount > 0
 			? `Verify flagged accounts (${flaggedCount})`
@@ -156,7 +159,7 @@ export async function showAuthMenu(
 					? (ui.v2Enabled ? ` ${formatUiBadge(ui, "disabled", "danger")}` : ` ${ANSI.red}[disabled]${ANSI.reset}`)
 					: "";
 			const statusSuffix = badge ? ` ${badge}` : "";
-			const label = `${accountTitle(account)}${currentBadge}${statusSuffix}${disabledBadge}`;
+			const label = `${accountTitle(account, maskEmail)}${currentBadge}${statusSuffix}${disabledBadge}`;
 			return {
 				label: ui.v2Enabled ? paintUiText(ui, label, "heading") : label,
 				hint: `used ${formatRelativeTime(account.lastUsed)}`,
@@ -186,10 +189,14 @@ export async function showAuthMenu(
 	}
 }
 
-export async function showAccountDetails(account: AccountInfo): Promise<AccountAction> {
+export async function showAccountDetails(
+	account: AccountInfo,
+	options: { maskEmail?: boolean } = {},
+): Promise<AccountAction> {
 	const ui = getUiRuntimeOptions();
+	const maskEmail = options.maskEmail ?? false;
 	const header =
-		`${accountTitle(account)} ${statusBadge(account.status)}` +
+		`${accountTitle(account, maskEmail)} ${statusBadge(account.status)}` +
 		(account.enabled === false
 			? (ui.v2Enabled
 				? ` ${formatUiBadge(ui, "disabled", "danger")}`
@@ -220,11 +227,11 @@ export async function showAccountDetails(account: AccountInfo): Promise<AccountA
 
 		if (!action) return "cancel";
 		if (action === "delete") {
-			const confirmed = await confirm(`Delete ${accountTitle(account)}?`);
+			const confirmed = await confirm(`Delete ${accountTitle(account, maskEmail)}?`);
 			if (!confirmed) continue;
 		}
 		if (action === "refresh") {
-			const confirmed = await confirm(`Re-authenticate ${accountTitle(account)}?`);
+			const confirmed = await confirm(`Re-authenticate ${accountTitle(account, maskEmail)}?`);
 			if (!confirmed) continue;
 		}
 		return action;

--- a/test/account-display.test.ts
+++ b/test/account-display.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import {
+	maskEmailForDisplay,
+	resolveDisplayEmail,
+} from "../lib/account-display.js";
+
+describe("account-display", () => {
+	describe("maskEmailForDisplay", () => {
+		it("preserves the domain and first two local characters", () => {
+			expect(maskEmailForDisplay("user@example.com")).toBe("us***@example.com");
+		});
+
+		it("keeps a single-character local part", () => {
+			expect(maskEmailForDisplay("a@example.org")).toBe("a***@example.org");
+		});
+
+		it("preserves multi-part domains", () => {
+			expect(maskEmailForDisplay("user@mail.company.co.uk")).toBe(
+				"us***@mail.company.co.uk",
+			);
+		});
+
+		it("falls back to a fully masked token for non-emails", () => {
+			expect(maskEmailForDisplay("not-an-email")).toBe("*****");
+		});
+
+		it("returns undefined for empty or whitespace input", () => {
+			expect(maskEmailForDisplay(undefined)).toBeUndefined();
+			expect(maskEmailForDisplay("")).toBeUndefined();
+			expect(maskEmailForDisplay("   ")).toBeUndefined();
+		});
+
+		it("trims surrounding whitespace before masking", () => {
+			expect(maskEmailForDisplay("  user@example.com  ")).toBe(
+				"us***@example.com",
+			);
+		});
+	});
+
+	describe("resolveDisplayEmail", () => {
+		it("returns the raw email when masking is disabled", () => {
+			expect(resolveDisplayEmail("user@example.com", false)).toBe(
+				"user@example.com",
+			);
+		});
+
+		it("returns a masked email when masking is enabled", () => {
+			expect(resolveDisplayEmail("user@example.com", true)).toBe(
+				"us***@example.com",
+			);
+		});
+
+		it("returns undefined when there is no email", () => {
+			expect(resolveDisplayEmail(undefined, true)).toBeUndefined();
+			expect(resolveDisplayEmail("", false)).toBeUndefined();
+		});
+	});
+});

--- a/test/account-display.test.ts
+++ b/test/account-display.test.ts
@@ -1,4 +1,3 @@
-import { describe, expect, it } from "vitest";
 import {
 	maskEmailForDisplay,
 	resolveDisplayEmail,

--- a/test/accounts.test.ts
+++ b/test/accounts.test.ts
@@ -414,6 +414,28 @@ describe("AccountManager", () => {
     expect(formatAccountLabel({ accountLabel: "Work", email: "work@co.com", accountId: "abcdef123456" }, 0)).toBe("Account 1 (Work, work@co.com, id:123456)");
   });
 
+  it("masks the email when maskEmail is enabled", () => {
+    expect(
+      formatAccountLabel({ email: "user@example.com" }, 0, { maskEmail: true }),
+    ).toBe("Account 1 (us***@example.com)");
+    expect(
+      formatAccountLabel(
+        { accountLabel: "Work", email: "work@co.com" },
+        0,
+        { maskEmail: true },
+      ),
+    ).toBe("Account 1 (Work, wo***@co.com)");
+  });
+
+  it("leaves the email raw when maskEmail is disabled or omitted", () => {
+    expect(
+      formatAccountLabel({ email: "user@example.com" }, 0, { maskEmail: false }),
+    ).toBe("Account 1 (user@example.com)");
+    expect(formatAccountLabel({ email: "user@example.com" }, 0)).toBe(
+      "Account 1 (user@example.com)",
+    );
+  });
+
   it("formats account label with short accountId", () => {
     expect(formatAccountLabel({ accountId: "abc" }, 0)).toBe("Account 1 (abc)");
     expect(formatAccountLabel({ accountId: "123456" }, 0)).toBe("Account 1 (123456)");

--- a/test/auth-menu.test.ts
+++ b/test/auth-menu.test.ts
@@ -72,4 +72,49 @@ describe("auth-menu", () => {
 			expect.stringContaining("shared@example.com | workspace:Workspace A | id:org-aaaa...bb2222"),
 		);
 	});
+
+	it("masks emails in the account menu when maskEmail is enabled", async () => {
+		vi.mocked(select).mockResolvedValueOnce({ type: "cancel" });
+
+		const accounts: AccountInfo[] = [
+			{
+				index: 0,
+				email: "shared@example.com",
+				accountLabel: "Workspace A",
+				accountId: "org-aaaa1111bbbb2222",
+			},
+		];
+
+		await showAuthMenu(accounts, { maskEmail: true });
+
+		const firstCall = vi.mocked(select).mock.calls[0];
+		const items = firstCall?.[0] as Array<{ label: string; value?: { type?: string } }>;
+		const accountRows = items.filter((item) => item.value?.type === "select-account");
+		expect(accountRows[0]?.label).toContain("sh***@example.com");
+		expect(accountRows[0]?.label).not.toContain("shared@example.com");
+		expect(accountRows[0]?.label).toContain("workspace:Workspace A");
+	});
+
+	it("masks the email in the delete confirmation when maskEmail is enabled", async () => {
+		vi.mocked(select).mockResolvedValueOnce("delete");
+		vi.mocked(confirm).mockResolvedValueOnce(true);
+
+		const action = await showAccountDetails(
+			{
+				index: 0,
+				email: "shared@example.com",
+				accountLabel: "Workspace A",
+				accountId: "org-aaaa1111bbbb2222",
+			},
+			{ maskEmail: true },
+		);
+
+		expect(action).toBe("delete");
+		expect(vi.mocked(confirm)).toHaveBeenCalledWith(
+			expect.stringContaining("sh***@example.com | workspace:Workspace A"),
+		);
+		expect(vi.mocked(confirm)).not.toHaveBeenCalledWith(
+			expect.stringContaining("shared@example.com"),
+		);
+	});
 });

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -214,11 +214,29 @@ describe("CLI Module", () => {
 		it("displays only label when no email", async () => {
 			mockRl.question.mockResolvedValueOnce("a");
 			const consoleSpy = vi.spyOn(console, "log");
-			
+
 			const { promptLoginMode } = await import("../lib/cli.js");
 			await promptLoginMode([{ index: 0, accountLabel: "Personal" }]);
-			
+
 			expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("1. workspace:Personal"));
+		});
+
+		it("masks the email when maskEmail is enabled", async () => {
+			mockRl.question.mockResolvedValueOnce("a");
+			const consoleSpy = vi.spyOn(console, "log");
+
+			const { promptLoginMode } = await import("../lib/cli.js");
+			await promptLoginMode(
+				[{ index: 0, accountLabel: "Work", email: "work@example.com" }],
+				{ maskEmail: true },
+			);
+
+			expect(consoleSpy).toHaveBeenCalledWith(
+				expect.stringContaining("wo***@example.com | workspace:Work"),
+			);
+			expect(consoleSpy).not.toHaveBeenCalledWith(
+				expect.stringContaining("work@example.com | workspace:Work"),
+			);
 		});
 	});
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -177,6 +177,13 @@ vi.mock("../lib/rotation.js", () => ({
 	addJitter: (ms: number) => ms,
 }));
 
+// The interactive account picker (`promptAccountIndexSelection`) and setup
+// wizard dynamically import this; mocking it lets us capture the menu items
+// (account labels) without a real TTY. Only active when a test stubs isTTY.
+vi.mock("../lib/ui/select.js", () => ({
+	select: vi.fn(async () => null),
+}));
+
 vi.mock("../lib/prompts/codex.js", () => ({
 	getModelFamily: (model: string) => {
 		if (model.includes("codex-max")) return "codex-max";
@@ -2284,6 +2291,217 @@ describe("OpenAIOAuthPlugin", () => {
 				backupMode: "required",
 			});
 			expect(observedSnapshots).toEqual(["s1", "s2"]);
+		});
+	});
+
+	// Regression suite for #163: when `maskEmail` is enabled, no human-facing
+	// account-display surface may render a raw email. These drive the REAL
+	// plugin tools (and thus the real `formatCommandAccountLabel` closure), so a
+	// regression that drops `{ maskEmail }` at any call site fails here.
+	describe("issue #163: email masking across all display surfaces", () => {
+		const RAW_EMAIL = "alice.example@example.com";
+		const MASKED_EMAIL = "al***@example.com";
+
+		const enableMasking = async () => {
+			const configModule = await import("../lib/config.js");
+			vi.mocked(configModule.getCodexTuiMaskEmail).mockReturnValue(true);
+		};
+		const disableMasking = async () => {
+			const configModule = await import("../lib/config.js");
+			vi.mocked(configModule.getCodexTuiMaskEmail).mockReturnValue(false);
+		};
+
+		const seedSingleAccount = () => {
+			mockStorage.accounts = [
+				{ refreshToken: "r1", email: RAW_EMAIL, accountId: "acc-1" },
+			];
+		};
+
+		// Each entry: a label and a thunk that returns the tool's rendered TEXT
+		// output for a single seeded account. Index-bearing tools target index 1.
+		const textSurfaces: Array<{
+			name: string;
+			run: () => Promise<string>;
+		}> = [
+			{
+				name: "codex-list",
+				run: async () =>
+					(await plugin.tool["codex-list"].execute()) as string,
+			},
+			{
+				name: "codex-status",
+				run: async () =>
+					(await plugin.tool["codex-status"].execute()) as string,
+			},
+			{
+				name: "codex-health",
+				run: async () =>
+					(await plugin.tool["codex-health"].execute()) as string,
+			},
+			{
+				name: "codex-switch",
+				run: async () =>
+					(await plugin.tool["codex-switch"].execute({ index: 1 })) as string,
+			},
+			{
+				name: "codex-label",
+				run: async () =>
+					(await plugin.tool["codex-label"].execute({
+						index: 1,
+						label: "Work",
+					})) as string,
+			},
+			{
+				name: "codex-tag",
+				run: async () =>
+					(await plugin.tool["codex-tag"].execute({
+						index: 1,
+						tags: "work",
+					})) as string,
+			},
+			{
+				name: "codex-note",
+				run: async () =>
+					(await plugin.tool["codex-note"].execute({
+						index: 1,
+						note: "primary",
+					})) as string,
+			},
+			{
+				name: "codex-remove",
+				run: async () =>
+					(await plugin.tool["codex-remove"].execute({
+						index: 1,
+						confirm: true,
+					})) as string,
+			},
+		];
+
+		// PLACEHOLDER_163_TESTS
+		for (const surface of textSurfaces) {
+			it(`${surface.name}: never renders the raw email when maskEmail is enabled`, async () => {
+				await enableMasking();
+				seedSingleAccount();
+
+				const output = await surface.run();
+
+				expect(output).toContain(MASKED_EMAIL);
+				expect(output).not.toContain(RAW_EMAIL);
+			});
+
+			it(`${surface.name}: renders the raw email when maskEmail is disabled (backward compatible)`, async () => {
+				await disableMasking();
+				seedSingleAccount();
+
+				const output = await surface.run();
+
+				expect(output).toContain(RAW_EMAIL);
+				expect(output).not.toContain(MASKED_EMAIL);
+			});
+		}
+
+		it("codex-list: masks every email when multiple accounts are listed", async () => {
+			await enableMasking();
+			mockStorage.accounts = [
+				{ refreshToken: "r1", email: "alice@example.com", accountId: "acc-1" },
+				{ refreshToken: "r2", email: "bob@other.org", accountId: "acc-2" },
+			];
+
+			const output = (await plugin.tool["codex-list"].execute()) as string;
+
+			expect(output).toContain("al***@example.com");
+			expect(output).toContain("bo***@other.org");
+			expect(output).not.toContain("alice@example.com");
+			expect(output).not.toContain("bob@other.org");
+		});
+
+		it("codex-remove: masks the email in the duplicate-entries hint when maskEmail is enabled", async () => {
+			await enableMasking();
+			// Two entries share the same email so the post-remove duplicate hint fires.
+			mockStorage.accounts = [
+				{ refreshToken: "r1", email: RAW_EMAIL, accountId: "acc-1" },
+				{ refreshToken: "r2", email: RAW_EMAIL, accountId: "acc-2" },
+			];
+
+			const output = (await plugin.tool["codex-remove"].execute({
+				index: 1,
+				confirm: true,
+			})) as string;
+
+			expect(output).toContain("Other entries for");
+			expect(output).toContain(MASKED_EMAIL);
+			expect(output).not.toContain(RAW_EMAIL);
+		});
+
+		it("codex-remove: shows the raw email in the duplicate-entries hint when maskEmail is disabled", async () => {
+			await disableMasking();
+			mockStorage.accounts = [
+				{ refreshToken: "r1", email: RAW_EMAIL, accountId: "acc-1" },
+				{ refreshToken: "r2", email: RAW_EMAIL, accountId: "acc-2" },
+			];
+
+			const output = (await plugin.tool["codex-remove"].execute({
+				index: 1,
+				confirm: true,
+			})) as string;
+
+			expect(output).toContain(`Other entries for ${RAW_EMAIL} remain`);
+		});
+
+		it("codex-list --includeSensitive: still emits the raw email in opt-in JSON even when masking is enabled", async () => {
+			await enableMasking();
+			seedSingleAccount();
+
+			const result = parseJsonOutput<{
+				accounts: Array<{ label: string; email: string | null }>;
+			}>(
+				(await plugin.tool["codex-list"].execute({
+					format: "json",
+					includeSensitive: true,
+				})) as string,
+			);
+
+			// The privacy boundary: --includeSensitive is the one opt-in surface
+			// where raw identity is intentionally preserved for tooling.
+			expect(result.accounts[0]?.email).toBe(RAW_EMAIL);
+			expect(result.accounts[0]?.label).toContain(RAW_EMAIL);
+		});
+
+		it("interactive account picker: masks emails in the selection menu when maskEmail is enabled", async () => {
+			await enableMasking();
+			mockStorage.accounts = [
+				{ refreshToken: "r1", email: RAW_EMAIL, accountId: "acc-1" },
+				{ refreshToken: "r2", email: "bob@other.org", accountId: "acc-2" },
+			];
+
+			const { select } = await import("../lib/ui/select.js");
+			vi.mocked(select).mockResolvedValueOnce(null);
+
+			// promptAccountIndexSelection only runs when an interactive TTY is
+			// available; stub both streams for the duration of this test.
+			const stdinDesc = Object.getOwnPropertyDescriptor(process.stdin, "isTTY");
+			const stdoutDesc = Object.getOwnPropertyDescriptor(process.stdout, "isTTY");
+			Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true });
+			Object.defineProperty(process.stdout, "isTTY", { value: true, configurable: true });
+
+			try {
+				// No index => falls through to the interactive picker.
+				await plugin.tool["codex-switch"].execute({});
+
+				expect(vi.mocked(select)).toHaveBeenCalled();
+				const items = vi.mocked(select).mock.calls[0]?.[0] as Array<{
+					label: string;
+				}>;
+				const labels = items.map((item) => item.label).join("\n");
+
+				expect(labels).toContain("al***@example.com");
+				expect(labels).toContain("bo***@other.org");
+				expect(labels).not.toContain(RAW_EMAIL);
+				expect(labels).not.toContain("bob@other.org");
+			} finally {
+				if (stdinDesc) Object.defineProperty(process.stdin, "isTTY", stdinDesc);
+				if (stdoutDesc) Object.defineProperty(process.stdout, "isTTY", stdoutDesc);
+			}
 		});
 	});
 });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -136,6 +136,7 @@ vi.mock("../lib/config.js", () => ({
 	getCodexTuiV2: () => false,
 	getCodexTuiColorProfile: () => "ansi16",
 	getCodexTuiGlyphMode: () => "ascii",
+	getCodexTuiMaskEmail: () => false,
 	getBeginnerSafeMode: () => false,
 	loadPluginConfig: () => ({}),
 }));

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -4689,6 +4689,76 @@ describe("OpenAIOAuthPlugin persistAccountPool", () => {
 		});
 	});
 
+	it("masks the email in the interactive delete confirmation when maskEmail is enabled", async () => {
+		const cliModule = await import("../lib/cli.js");
+		const configModule = await import("../lib/config.js");
+
+		vi.mocked(configModule.getCodexTuiMaskEmail).mockReturnValue(true);
+
+		mockStorage.accounts = [
+			{ refreshToken: "r1", email: "user@example.com", accountId: "acc-1" },
+		];
+
+		vi.mocked(cliModule.promptLoginMode)
+			.mockReset()
+			.mockResolvedValueOnce({ mode: "manage", deleteAccountIndex: 0 })
+			.mockResolvedValue({ mode: "cancel" });
+
+		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+		const mockClient = createMockClient();
+		const { OpenAIOAuthPlugin } = await import("../index.js");
+		const plugin = (await OpenAIOAuthPlugin({
+			client: mockClient,
+		} as never)) as unknown as PluginType;
+		const autoMethod = plugin.auth.methods[0] as unknown as {
+			authorize: (inputs?: Record<string, string>) => Promise<{ instructions: string }>;
+		};
+
+		await autoMethod.authorize();
+
+		const logged = logSpy.mock.calls.map((call) => String(call[0])).join("\n");
+		expect(logged).toContain("Deleted us***@example.com");
+		expect(logged).not.toContain("user@example.com");
+
+		logSpy.mockRestore();
+	});
+
+	it("masks the email in the interactive enable/disable confirmation when maskEmail is enabled", async () => {
+		const cliModule = await import("../lib/cli.js");
+		const configModule = await import("../lib/config.js");
+
+		vi.mocked(configModule.getCodexTuiMaskEmail).mockReturnValue(true);
+
+		mockStorage.accounts = [
+			{ refreshToken: "r1", email: "user@example.com", accountId: "acc-1" },
+		];
+
+		vi.mocked(cliModule.promptLoginMode)
+			.mockReset()
+			.mockResolvedValueOnce({ mode: "manage", toggleAccountIndex: 0 })
+			.mockResolvedValue({ mode: "cancel" });
+
+		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+		const mockClient = createMockClient();
+		const { OpenAIOAuthPlugin } = await import("../index.js");
+		const plugin = (await OpenAIOAuthPlugin({
+			client: mockClient,
+		} as never)) as unknown as PluginType;
+		const autoMethod = plugin.auth.methods[0] as unknown as {
+			authorize: (inputs?: Record<string, string>) => Promise<{ instructions: string }>;
+		};
+
+		await autoMethod.authorize();
+
+		const logged = logSpy.mock.calls.map((call) => String(call[0])).join("\n");
+		expect(logged).toContain("us***@example.com");
+		expect(logged).not.toContain("user@example.com");
+
+		logSpy.mockRestore();
+	});
+
 	it("keeps workspace-deactivated flagged entries out of verify-flagged restore", async () => {
 		const cliModule = await import("../lib/cli.js");
 		const storageModule = await import("../lib/storage.js");

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -136,7 +136,7 @@ vi.mock("../lib/config.js", () => ({
 	getCodexTuiV2: () => false,
 	getCodexTuiColorProfile: () => "ansi16",
 	getCodexTuiGlyphMode: () => "ascii",
-	getCodexTuiMaskEmail: () => false,
+	getCodexTuiMaskEmail: vi.fn(() => false),
 	getBeginnerSafeMode: () => false,
 	loadPluginConfig: () => ({}),
 }));
@@ -479,7 +479,9 @@ vi.mock("../lib/accounts.js", () => {
 			(_storedId: string | undefined, _source: string | undefined, tokenId: string | undefined) =>
 				tokenId,
 		),
-		formatAccountLabel: (_account: unknown, index: number) => `Account ${index + 1}`,
+		formatAccountLabel: vi.fn(
+			(_account: unknown, index: number) => `Account ${index + 1}`,
+		),
 		formatCooldown: () => null,
 		formatWaitTime: (ms: number) => `${Math.round(ms / 1000)}s`,
 		sanitizeEmail: (email: string) => email,
@@ -2882,6 +2884,47 @@ describe("OpenAIOAuthPlugin fetch handler", () => {
 			"refresh-1",
 			ACCOUNT_LIMITS.AUTH_FAILURE_COOLDOWN_MS,
 			"auth-failure",
+		);
+	});
+
+	it("passes maskEmail to the account label on the auth-failure removal path", async () => {
+		const fetchHelpers = await import("../lib/request/fetch-helpers.js");
+		const accountsModule = await import("../lib/accounts.js");
+		const configModule = await import("../lib/config.js");
+		const { AccountManager } = accountsModule;
+		const { ACCOUNT_LIMITS } = await import("../lib/constants.js");
+
+		vi.mocked(configModule.getCodexTuiMaskEmail).mockReturnValue(true);
+		vi.spyOn(fetchHelpers, "shouldRefreshToken").mockReturnValue(true);
+		vi.mocked(fetchHelpers.refreshAndUpdateToken).mockRejectedValue(
+			new Error("Token expired"),
+		);
+		vi.spyOn(AccountManager.prototype, "incrementAuthFailures").mockReturnValue(
+			ACCOUNT_LIMITS.MAX_AUTH_FAILURES_BEFORE_REMOVAL,
+		);
+		// Returning 1 drives the single-account removal branch that renders the
+		// account label in the user-facing removal toast.
+		vi.spyOn(
+			AccountManager.prototype,
+			"removeAccountsWithSameRefreshToken",
+		).mockReturnValue(1);
+
+		globalThis.fetch = vi.fn().mockResolvedValue(
+			new Response(JSON.stringify({ content: "should-not-fetch" }), { status: 200 }),
+		);
+
+		const { sdk } = await setupPlugin();
+		await sdk.fetch!("https://api.openai.com/v1/chat", {
+			method: "POST",
+			body: JSON.stringify({ model: "gpt-5.1" }),
+		});
+
+		// The runtime label must be built with masking enabled. If the
+		// `{ maskEmail }` option is dropped from this call site, this fails.
+		expect(vi.mocked(accountsModule.formatAccountLabel)).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.any(Number),
+			{ maskEmail: true },
 		);
 	});
 

--- a/test/tools-codex-refresh.test.ts
+++ b/test/tools-codex-refresh.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { ToolContext } from "../lib/tools/index.js";
+import { createCodexRefreshTool } from "../lib/tools/codex-refresh.js";
+import { resolveDisplayEmail } from "../lib/account-display.js";
+
+vi.mock("../lib/storage.js", () => ({
+	loadAccounts: vi.fn(),
+	saveAccounts: vi.fn(async () => undefined),
+}));
+
+vi.mock("../lib/refresh-queue.js", () => ({
+	queuedRefresh: vi.fn(async () => ({
+		type: "success",
+		access: "new-access",
+		refresh: "new-refresh",
+		expires: Date.now() + 3_600_000,
+	})),
+}));
+
+vi.mock("../lib/accounts.js", () => ({
+	AccountManager: { loadFromDisk: vi.fn(async () => ({})) },
+}));
+
+import { loadAccounts } from "../lib/storage.js";
+
+/**
+ * Faithful stand-in for the `formatCommandAccountLabel` closure defined in
+ * `index.ts`: it honors the `maskEmail` option through the shared helper, so a
+ * regression that drops `{ maskEmail }` at the call site yields an unmasked
+ * string and fails the assertions below.
+ */
+function formatCommandAccountLabel(
+	account: { email?: string; accountLabel?: string } | undefined,
+	index: number,
+	options: { maskEmail?: boolean } = {},
+): string {
+	const email = resolveDisplayEmail(account?.email, options.maskEmail ?? false);
+	const workspace = account?.accountLabel?.trim();
+	const details: string[] = [];
+	if (email) details.push(email);
+	if (workspace) details.push(`workspace:${workspace}`);
+	if (details.length === 0) return `Account ${index + 1}`;
+	return `Account ${index + 1} (${details.join(", ")})`;
+}
+
+function buildCtx(maskEmail: boolean): ToolContext {
+	const ctx = {
+		resolveUiRuntime: () => ({
+			v2Enabled: false,
+			colorProfile: "ansi16",
+			glyphMode: "ascii",
+			theme: undefined,
+		}),
+		resolveMaskEmail: () => maskEmail,
+		formatCommandAccountLabel,
+		getStatusMarker: () => "[ok]",
+		cachedAccountManagerRef: { current: null },
+		accountManagerPromiseRef: { current: null },
+	};
+	return ctx as unknown as ToolContext;
+}
+
+describe("codex-refresh tool masking", () => {
+	beforeEach(() => {
+		vi.mocked(loadAccounts).mockReset();
+	});
+
+	it("masks the account email when maskEmail is enabled", async () => {
+		vi.mocked(loadAccounts).mockResolvedValue({
+			version: 3,
+			activeIndex: 0,
+			accounts: [{ email: "user@example.com", refreshToken: "r1" }],
+		} as never);
+
+		const tool = createCodexRefreshTool(buildCtx(true));
+		const output = (await tool.execute({}, {} as never)) as string;
+
+		expect(output).toContain("us***@example.com");
+		expect(output).not.toContain("user@example.com");
+	});
+
+	it("shows the raw email when maskEmail is disabled", async () => {
+		vi.mocked(loadAccounts).mockResolvedValue({
+			version: 3,
+			activeIndex: 0,
+			accounts: [{ email: "user@example.com", refreshToken: "r1" }],
+		} as never);
+
+		const tool = createCodexRefreshTool(buildCtx(false));
+		const output = (await tool.execute({}, {} as never)) as string;
+
+		expect(output).toContain("user@example.com");
+	});
+});

--- a/test/tools-codex-remove.test.ts
+++ b/test/tools-codex-remove.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { ToolContext } from "../lib/tools/index.js";
+import { createCodexRemoveTool } from "../lib/tools/codex-remove.js";
+import { resolveDisplayEmail } from "../lib/account-display.js";
+
+vi.mock("../lib/storage.js", () => ({
+	loadAccounts: vi.fn(),
+	saveAccounts: vi.fn(async () => undefined),
+}));
+
+vi.mock("../lib/accounts.js", () => ({
+	AccountManager: { loadFromDisk: vi.fn(async () => ({})) },
+}));
+
+import { loadAccounts } from "../lib/storage.js";
+
+/**
+ * Faithful stand-in for the `formatCommandAccountLabel` closure defined in
+ * `index.ts`: it honors the `maskEmail` option through the shared helper.
+ */
+function formatCommandAccountLabel(
+	account: { email?: string; accountLabel?: string } | undefined,
+	index: number,
+	options: { maskEmail?: boolean } = {},
+): string {
+	const email = resolveDisplayEmail(account?.email, options.maskEmail ?? false);
+	const workspace = account?.accountLabel?.trim();
+	const details: string[] = [];
+	if (email) details.push(email);
+	if (workspace) details.push(`workspace:${workspace}`);
+	if (details.length === 0) return `Account ${index + 1}`;
+	return `Account ${index + 1} (${details.join(", ")})`;
+}
+
+function buildCtx(maskEmail: boolean): ToolContext {
+	const ctx = {
+		resolveUiRuntime: () => ({
+			v2Enabled: false,
+			colorProfile: "ansi16",
+			glyphMode: "ascii",
+			theme: undefined,
+		}),
+		resolveMaskEmail: () => maskEmail,
+		formatCommandAccountLabel,
+		getStatusMarker: () => "[ok]",
+		promptAccountIndexSelection: vi.fn(async () => null),
+		supportsInteractiveMenus: () => false,
+		cachedAccountManagerRef: { current: null },
+		accountManagerPromiseRef: { current: null },
+	};
+	return ctx as unknown as ToolContext;
+}
+
+describe("codex-remove tool masking", () => {
+	beforeEach(() => {
+		vi.mocked(loadAccounts).mockReset();
+	});
+
+	it("masks the email in the duplicate-entries hint when maskEmail is enabled", async () => {
+		// Two entries share the same email so the post-remove duplicate hint fires.
+		vi.mocked(loadAccounts).mockResolvedValue({
+			version: 3,
+			activeIndex: 0,
+			accounts: [
+				{ email: "user@example.com", refreshToken: "r1" },
+				{ email: "user@example.com", refreshToken: "r2" },
+			],
+		} as never);
+
+		const tool = createCodexRemoveTool(buildCtx(true));
+		const output = (await tool.execute(
+			{ index: 1, confirm: true },
+			{} as never,
+		)) as string;
+
+		expect(output).toContain("us***@example.com");
+		expect(output).not.toContain("user@example.com");
+	});
+
+	it("shows the raw email in the duplicate-entries hint when maskEmail is disabled", async () => {
+		vi.mocked(loadAccounts).mockResolvedValue({
+			version: 3,
+			activeIndex: 0,
+			accounts: [
+				{ email: "user@example.com", refreshToken: "r1" },
+				{ email: "user@example.com", refreshToken: "r2" },
+			],
+		} as never);
+
+		const tool = createCodexRemoveTool(buildCtx(false));
+		const output = (await tool.execute(
+			{ index: 1, confirm: true },
+			{} as never,
+		)) as string;
+
+		expect(output).toContain("user@example.com");
+	});
+});


### PR DESCRIPTION
## Summary

Closes #163.

`maskEmail` previously only reached the TUI prompt quota status. Every other account-display surface (account menu, command output, runtime messages, standalone login menu) still rendered full emails, so private addresses could leak into screenshots, screen sharing, and terminal recordings.

This change extends the existing `maskEmail` flag so it applies consistently to all human-facing account displays. No new config keys are introduced. When `maskEmail` is enabled, emails are reduced to a domain-preserving masked form (for example `us***@example.com`); account labels set via `codex-label` are always preferred over emails.

## What changed

- New `lib/account-display.ts` with `maskEmailForDisplay` (domain-preserving) and `resolveDisplayEmail` helpers as a single source of truth.
- Threaded `maskEmail` through the account-display formatters:
  - `formatAccountLabel` (`lib/accounts.ts`) used by runtime and rotation messages.
  - `formatCommandAccountLabel` (`index.ts`) and its tool call sites: `codex-list`, `codex-status`, `codex-limits`, `codex-health`, `codex-dashboard`, `codex-switch`, `codex-label`, `codex-tag`, `codex-note`, `codex-remove`.
  - `accountTitle` in the interactive auth menu (`lib/ui/auth-menu.ts`) plus its detail and delete/refresh confirmation prompts.
  - `formatAccountLabel` in the standalone CLI login menu (`lib/cli.ts`).
  - The check-all and verify-flagged command output in `index.ts`, now label-first with a masked email fallback.
- Added `resolveMaskEmail` to `ToolContext` so each tool resolves the flag once per invocation rather than per account.
- Documentation updated in `docs/configuration.md` and `docs/privacy.md`.

## Privacy boundary

- Raw emails are still emitted only in opt-in `--includeSensitive` JSON output. In `codex-health` and `codex-limits` the sensitive JSON `label` field keeps the raw value while the rendered text uses the masked label, so `--includeSensitive` behavior is unchanged.
- Default behavior is unchanged: `maskEmail` defaults to `false`, so emails render exactly as before unless a user opts in.

## Verification

- `npm run typecheck`: clean.
- `npm run lint`: clean.
- `npm test`: 86 files, 2412 passed, 1 skipped.
- `npm run build`: succeeds.
- New tests: `test/account-display.test.ts`, plus masking cases in `test/accounts.test.ts`, `test/auth-menu.test.ts`, and `test/cli.test.ts`.

## Notes

- No version bump in this PR; release is handled separately.
- The TUI quota masking path from #160 is intentionally untouched; this PR brings the remaining surfaces to parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Account email masking now applies consistently across status screens, command output, interactive menus, and login flows; configured stable labels remain visible and raw emails appear only in opt-in machine-readable outputs.

* **Documentation**
  * Expanded docs and privacy guidance on configuring email masking and reducing email exposure in screenshots/TUI sessions; environment variable/docs updated to reflect broader masking behavior.

* **Tests**
  * Added tests verifying masked vs. unmasked account label behavior across interfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

this pr extends the existing `maskEmail` flag from the tui quota status to every human-facing account-display surface — command output, interactive menus, standalone login menu, and runtime rotation/failure messages — by centralizing masking logic in a new `lib/account-display.ts` module and threading `resolveMaskEmail()` through the `ToolContext`.

- **new `lib/account-display.ts`**: `maskEmailForDisplay` (domain-preserving, handles single-char local parts and invalid emails) and `resolveDisplayEmail` as the single source of truth; all call sites now delegate here instead of rolling their own email trimming.
- **coverage**: `test/tools-codex-refresh.test.ts` and `test/tools-codex-remove.test.ts` added; `test/index.test.ts` gains a full `textSurfaces` regression matrix plus interactive-picker and runtime-path guard tests; `codex-limits` and `codex-dashboard` masking paths are not yet in the matrix.
- **privacy boundary preserved**: raw email still flows through to `--includeSensitive` json output via a separate unmasked `label` variable in `codex-health` and `codex-limits`; default behavior unchanged (`maskEmail` remains `false`).

<h3>Confidence Score: 5/5</h3>

safe to merge — masking is display-only and defaults to false, so existing behavior is unchanged unless the user opts in.

the change is well-scoped: a single new helper module, a consistent option threaded through every call site, and the privacy boundary preserved by keeping a separate unmasked label variable in the tools that need it. the regression suite is comprehensive for all but two tool surfaces.

test/index.test.ts — `codex-limits` and `codex-dashboard` are not in the `textSurfaces` masking matrix.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/account-display.ts | new shared masking helpers — `maskEmailForDisplay` and `resolveDisplayEmail` — clean, well-tested, correct edge-case handling for single-char locals, missing @, and empty input. |
| index.ts | `resolveMaskEmail` closure added to `ToolContext`; `promptAccountIndexSelection` now masks the interactive picker labels; runtime paths (auth-failure, rate-limit toast, workspace-deactivated) wired through `maskEmailEnabled`. |
| lib/tools/codex-health.ts | dual-label approach correct — raw `label` kept for `--includeSensitive` JSON, `displayLabel` used for all rendered text output. |
| lib/tools/codex-limits.ts | same dual-label pattern as `codex-health` — raw label for JSON, `displayLabel` for text; masking test coverage not yet added to the surface matrix in `test/index.test.ts`. |
| lib/tools/codex-dashboard.ts | `resolveMaskEmail` destructured and `{ maskEmail }` passed to both `formatCommandAccountLabel` calls; no dedicated masking test yet. |
| lib/tools/codex-refresh.ts | masking threaded correctly; `test/tools-codex-refresh.test.ts` added with masked and raw cases using a faithful `formatCommandAccountLabel` stand-in. |
| lib/tools/codex-remove.ts | `displayEmail` used for the duplicate-entries hint guard and message; semantics preserved — falsy only when original `account.email` was empty/undefined. |
| test/index.test.ts | comprehensive masking regression suite added; `textSurfaces` matrix missing `codex-limits` and `codex-dashboard`; runtime auth-failure path now has a spy-based guard test. |
| test/account-display.test.ts | thorough unit tests for `maskEmailForDisplay` and `resolveDisplayEmail`, covering single-char local, multi-part domain, non-email fallback, empty/whitespace, and whitespace trimming. |

</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Foc-codex-multi-auth%22%20on%20the%20existing%20branch%20%22feat%2F163-consistent-account-email-masking%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2F163-consistent-account-email-masking%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atest%2Findex.test.ts%3A1166-1227%0A**masking%20coverage%20gap%20for%20%60codex-limits%60%20and%20%60codex-dashboard%60**%0A%0Athe%20%60textSurfaces%60%20matrix%20covers%20%60codex-list%60%2C%20%60codex-status%60%2C%20%60codex-health%60%2C%20%60codex-switch%60%2C%20%60codex-label%60%2C%20%60codex-tag%60%2C%20%60codex-note%60%2C%20and%20%60codex-remove%60%20%E2%80%94%20but%20not%20%60codex-limits%60%20or%20%60codex-dashboard%60%2C%20both%20of%20which%20received%20%60%7B%20maskEmail%20%7D%60%20threading%20in%20this%20pr.%20if%20the%20%60resolveMaskEmail%28%29%60%20call%20or%20the%20%60%7B%20maskEmail%20%7D%60%20option%20is%20accidentally%20dropped%20from%20either%20tool's%20execute%20body%2C%20no%20test%20will%20catch%20it.%20%60codex-health%60%20is%20already%20in%20the%20matrix%20and%20needed%20the%20same%20pattern%2C%20so%20adding%20both%20tools%20here%20is%20straightforward.%0A%0A&repo=ndycode%2Foc-codex-multi-auth&pr=164&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
test/index.test.ts:1166-1227
**masking coverage gap for `codex-limits` and `codex-dashboard`**

the `textSurfaces` matrix covers `codex-list`, `codex-status`, `codex-health`, `codex-switch`, `codex-label`, `codex-tag`, `codex-note`, and `codex-remove` — but not `codex-limits` or `codex-dashboard`, both of which received `{ maskEmail }` threading in this pr. if the `resolveMaskEmail()` call or the `{ maskEmail }` option is accidentally dropped from either tool's execute body, no test will catch it. `codex-health` is already in the matrix and needed the same pattern, so adding both tools here is straightforward.

`````

</details>

<sub>Reviews (5): Last reviewed commit: ["test(privacy): broaden #163 coverage acr..."](https://github.com/ndycode/oc-codex-multi-auth/commit/82f37a37b7786c3f788e79dc89885c7f50aff5dd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35610859)</sub>

<!-- /greptile_comment -->