### PR TITLE
fix: preserve gpt-5.3-codex-spark, gpt-5.3-codex, gpt-5.2-codex as distinct canonical model IDs

### DIFF
--- a/lib/request/helpers/model-map.ts
+++ b/lib/request/helpers/model-map.ts
@@ -42,22 +42,24 @@ export const MODEL_MAP: Record<string, string> = {
 	"gpt-5-codex-xhigh": "gpt-5-codex",
 
 	// ============================================================================
-	// GPT-5.3 Codex Spark Models (legacy aliases)
+	// GPT-5.3 Codex Spark Models (distinct backend model; does NOT support "none")
 	// ============================================================================
-	"gpt-5.3-codex-spark": "gpt-5-codex",
-	"gpt-5.3-codex-spark-low": "gpt-5-codex",
-	"gpt-5.3-codex-spark-medium": "gpt-5-codex",
-	"gpt-5.3-codex-spark-high": "gpt-5-codex",
-	"gpt-5.3-codex-spark-xhigh": "gpt-5-codex",
+	"gpt-5.3-codex-spark": "gpt-5.3-codex-spark",
+	"gpt-5.3-codex-spark-low": "gpt-5.3-codex-spark",
+	"gpt-5.3-codex-spark-medium": "gpt-5.3-codex-spark",
+	"gpt-5.3-codex-spark-high": "gpt-5.3-codex-spark",
+	"gpt-5.3-codex-spark-xhigh": "gpt-5.3-codex-spark",
+	// "-none" is intentionally absent: gpt-5.3-codex-spark rejects reasoning effort "none"
 
 	// ============================================================================
-	// GPT-5.3 Codex Models (legacy aliases)
+	// GPT-5.3 Codex Models (distinct backend model; does NOT support "none")
 	// ============================================================================
-	"gpt-5.3-codex": "gpt-5-codex",
-	"gpt-5.3-codex-low": "gpt-5-codex",
-	"gpt-5.3-codex-medium": "gpt-5-codex",
-	"gpt-5.3-codex-high": "gpt-5-codex",
-	"gpt-5.3-codex-xhigh": "gpt-5-codex",
+	"gpt-5.3-codex": "gpt-5.3-codex",
+	"gpt-5.3-codex-low": "gpt-5.3-codex",
+	"gpt-5.3-codex-medium": "gpt-5.3-codex",
+	"gpt-5.3-codex-high": "gpt-5.3-codex",
+	"gpt-5.3-codex-xhigh": "gpt-5.3-codex",
+	// "-none" is intentionally absent: gpt-5.3-codex rejects reasoning effort "none"
 
 	// ============================================================================
 	// GPT-5.1 Codex Models (legacy aliases)
@@ -107,6 +109,7 @@ export const MODEL_MAP: Record<string, string> = {
 	"gpt-5.4-medium": "gpt-5.4",
 	"gpt-5.4-high": "gpt-5.4",
 	"gpt-5.4-xhigh": "gpt-5.4",
+	"gpt-5.4-fast": "gpt-5.4",
 	...expandDatedAliases(`gpt-5.4-${GPT_54_SNAPSHOT_DATE}`, "gpt-5.4"),
 
 	// ============================================================================
@@ -127,6 +130,7 @@ export const MODEL_MAP: Record<string, string> = {
 	"gpt-5.4-mini-medium": "gpt-5.4-mini",
 	"gpt-5.4-mini-high": "gpt-5.4-mini",
 	"gpt-5.4-mini-xhigh": "gpt-5.4-mini",
+	"gpt-5.4-mini-fast": "gpt-5.4-mini",
 	...expandDatedAliases(`gpt-5.4-mini-${GPT_54_SNAPSHOT_DATE}`, "gpt-5.4-mini"),
 
 	// ============================================================================
@@ -151,13 +155,14 @@ export const MODEL_MAP: Record<string, string> = {
 	"gpt-5.2-xhigh": "gpt-5.2",
 
 	// ============================================================================
-	// GPT-5.2 Codex Models (legacy aliases)
+	// GPT-5.2 Codex Models (distinct backend model; does NOT support "none")
 	// ============================================================================
-	"gpt-5.2-codex": "gpt-5-codex",
-	"gpt-5.2-codex-low": "gpt-5-codex",
-	"gpt-5.2-codex-medium": "gpt-5-codex",
-	"gpt-5.2-codex-high": "gpt-5-codex",
-	"gpt-5.2-codex-xhigh": "gpt-5-codex",
+	"gpt-5.2-codex": "gpt-5.2-codex",
+	"gpt-5.2-codex-low": "gpt-5.2-codex",
+	"gpt-5.2-codex-medium": "gpt-5.2-codex",
+	"gpt-5.2-codex-high": "gpt-5.2-codex",
+	"gpt-5.2-codex-xhigh": "gpt-5.2-codex",
+	// "-none" is intentionally absent: gpt-5.2-codex rejects reasoning effort "none"
 
 	// ============================================================================
 	// GPT-5.1 Codex Mini Models

--- a/lib/request/request-transformer.ts
+++ b/lib/request/request-transformer.ts
@@ -60,28 +60,29 @@ export function normalizeModel(model: string | undefined): string {
 	const normalized = modelId.toLowerCase();
 
 	// Priority order for pattern matching (most specific first):
-	// 1. GPT-5.3 Codex Spark (legacy alias -> canonical gpt-5-codex)
+	// 1. GPT-5.3 Codex Spark — distinct backend model, preserved as canonical ID
 	if (
 		normalized.includes("gpt-5.3-codex-spark") ||
 		normalized.includes("gpt 5.3 codex spark")
 	) {
-		return "gpt-5-codex";
+		return "gpt-5.3-codex-spark";
 	}
 
-	// 2. GPT-5.3 Codex (legacy alias -> canonical gpt-5-codex)
+	// 2. GPT-5.3 Codex — distinct backend model, preserved as canonical ID
+	// Must come after the spark check so "gpt-5.3-codex-spark*" isn't swallowed here.
 	if (
 		normalized.includes("gpt-5.3-codex") ||
 		normalized.includes("gpt 5.3 codex")
 	) {
-		return "gpt-5-codex";
+		return "gpt-5.3-codex";
 	}
 
-	// 3. GPT-5.2 Codex (legacy alias -> canonical gpt-5-codex)
+	// 3. GPT-5.2 Codex — distinct backend model, preserved as canonical ID
 	if (
 		normalized.includes("gpt-5.2-codex") ||
 		normalized.includes("gpt 5.2 codex")
 	) {
-		return "gpt-5-codex";
+		return "gpt-5.2-codex";
 	}
 
 	// 4. GPT-5.5 (general purpose release)

--- a/test/edge-cases.test.ts
+++ b/test/edge-cases.test.ts
@@ -433,7 +433,7 @@ describe("Edge Cases and Boundary Conditions", () => {
 		it("should handle concurrent model normalization", () => {
 			const models = ["gpt-5.4", "gpt-5.3-codex", "gpt-5.2", "gpt-5-codex"];
 			const results = models.map(normalizeModel);
-			expect(results).toEqual(["gpt-5.4", "gpt-5-codex", "gpt-5.2", "gpt-5-codex"]);
+			expect(results).toEqual(["gpt-5.4", "gpt-5.3-codex", "gpt-5.2", "gpt-5-codex"]);
 		});
 
 		it("should be consistent across repeated calls", () => {

--- a/test/fetch-helpers.test.ts
+++ b/test/fetch-helpers.test.ts
@@ -1272,9 +1272,9 @@ describe('Fetch Helpers Module', () => {
 				);
 
 				expect(result).toBeDefined();
-				expect(result?.body.model).toBe('gpt-5-codex');
-				expect(result?.body.instructions).toContain('backend as gpt-5-codex');
-				expect(JSON.stringify(result?.body.input?.[0])).toContain('`gpt-5-codex`');
+				expect(result?.body.model).toBe('gpt-5.3-codex');
+				expect(result?.body.instructions).toContain('backend as gpt-5.3-codex');
+				expect(JSON.stringify(result?.body.input?.[0])).toContain('`gpt-5.3-codex`');
 				expect(result?.body.tools).toEqual([{ name: 'apply_patch' }]);
 				expect(getInstructionsSpy).not.toHaveBeenCalled();
 			});
@@ -1367,7 +1367,7 @@ describe('Fetch Helpers Module', () => {
 				);
 
 				expect(result).toBeDefined();
-				expect(result?.body.model).toBe('gpt-5-codex');
+				expect(result?.body.model).toBe('gpt-5.3-codex');
 				expect(typeof result?.updatedInit.body).toBe('string');
 			});
 

--- a/test/gpt54-models.test.ts
+++ b/test/gpt54-models.test.ts
@@ -406,7 +406,7 @@ describe("GPT-5.4 Model Support", () => {
 
 		it("should coexist with gpt-5.3-codex model", () => {
 			expect(normalizeModel("gpt-5.4")).toBe("gpt-5.4");
-			expect(normalizeModel("gpt-5.3-codex")).toBe("gpt-5-codex");
+			expect(normalizeModel("gpt-5.3-codex")).toBe("gpt-5.3-codex");
 			expect(getModelFamily("gpt-5.4")).toBe("gpt-5.4");
 			expect(getModelFamily("gpt-5.3-codex")).toBe("gpt-5-codex");
 		});

--- a/test/model-map.test.ts
+++ b/test/model-map.test.ts
@@ -159,37 +159,95 @@ describe("Model Map Module", () => {
       expect(getNormalizedModel("gpt-5.3-codex")).toBe("gpt-5.3-codex");
       expect(getNormalizedModel("gpt-5.3-codex-spark")).toBe("gpt-5.3-codex-spark");
 
-      // Fallback chain: gpt-5.2-codex → gpt-5-codex → gpt-5.4 on unsupported error
-      const normalizedCodex = getNormalizedModel("gpt-5.2-codex")!;
-      const fallback = resolveUnsupportedCodexFallbackModel({
-        requestedModel: normalizedCodex,
+      // ── gpt-5.2-codex → gpt-5-codex → gpt-5.4 ──────────────────────────────
+      const normalized52 = getNormalizedModel("gpt-5.2-codex")!;
+      const fallback52 = resolveUnsupportedCodexFallbackModel({
+        requestedModel: normalized52,
         errorBody: {
           error: {
             code: "model_not_supported_with_chatgpt_account",
-            message:
-              "The 'gpt-5.2-codex' model is not supported when using Codex with a ChatGPT account.",
+            message: "The 'gpt-5.2-codex' model is not supported when using Codex with a ChatGPT account.",
           },
         },
-        attemptedModels: [normalizedCodex],
+        attemptedModels: [normalized52],
         fallbackOnUnsupportedCodexModel: true,
         fallbackToGpt52OnUnsupportedGpt53: true,
       });
-      expect(fallback).toBe("gpt-5-codex");
+      expect(fallback52).toBe("gpt-5-codex");
 
-      const secondStepFallback = resolveUnsupportedCodexFallbackModel({
-        requestedModel: fallback,
+      const fallback52step2 = resolveUnsupportedCodexFallbackModel({
+        requestedModel: fallback52,
         errorBody: {
           error: {
             code: "model_not_supported_with_chatgpt_account",
-            message:
-              "The 'gpt-5-codex' model is not supported when using Codex with a ChatGPT account.",
+            message: "The 'gpt-5-codex' model is not supported when using Codex with a ChatGPT account.",
           },
         },
-        attemptedModels: [normalizedCodex, fallback],
+        attemptedModels: [normalized52, fallback52!],
         fallbackOnUnsupportedCodexModel: true,
         fallbackToGpt52OnUnsupportedGpt53: true,
       });
-      expect(secondStepFallback).toBe("gpt-5.4");
+      expect(fallback52step2).toBe("gpt-5.4");
+
+      // ── gpt-5.3-codex → gpt-5-codex ─────────────────────────────────────────
+      const normalized53 = getNormalizedModel("gpt-5.3-codex")!;
+      const fallback53 = resolveUnsupportedCodexFallbackModel({
+        requestedModel: normalized53,
+        errorBody: {
+          error: {
+            code: "model_not_supported_with_chatgpt_account",
+            message: "The 'gpt-5.3-codex' model is not supported when using Codex with a ChatGPT account.",
+          },
+        },
+        attemptedModels: [normalized53],
+        fallbackOnUnsupportedCodexModel: true,
+        fallbackToGpt52OnUnsupportedGpt53: true,
+      });
+      expect(fallback53).toBe("gpt-5-codex");
+
+      // ── gpt-5.3-codex-spark → gpt-5-codex → gpt-5.3-codex → gpt-5.2-codex ──
+      const normalizedSpark = getNormalizedModel("gpt-5.3-codex-spark")!;
+      const fallbackSpark1 = resolveUnsupportedCodexFallbackModel({
+        requestedModel: normalizedSpark,
+        errorBody: {
+          error: {
+            code: "model_not_supported_with_chatgpt_account",
+            message: "The 'gpt-5.3-codex-spark' model is not supported when using Codex with a ChatGPT account.",
+          },
+        },
+        attemptedModels: [normalizedSpark],
+        fallbackOnUnsupportedCodexModel: true,
+        fallbackToGpt52OnUnsupportedGpt53: true,
+      });
+      expect(fallbackSpark1).toBe("gpt-5-codex");
+
+      const fallbackSpark2 = resolveUnsupportedCodexFallbackModel({
+        requestedModel: normalizedSpark,
+        errorBody: {
+          error: {
+            code: "model_not_supported_with_chatgpt_account",
+            message: "The 'gpt-5.3-codex-spark' model is not supported when using Codex with a ChatGPT account.",
+          },
+        },
+        attemptedModels: [normalizedSpark, fallbackSpark1!],
+        fallbackOnUnsupportedCodexModel: true,
+        fallbackToGpt52OnUnsupportedGpt53: true,
+      });
+      expect(fallbackSpark2).toBe("gpt-5.3-codex");
+
+      const fallbackSpark3 = resolveUnsupportedCodexFallbackModel({
+        requestedModel: normalizedSpark,
+        errorBody: {
+          error: {
+            code: "model_not_supported_with_chatgpt_account",
+            message: "The 'gpt-5.3-codex-spark' model is not supported when using Codex with a ChatGPT account.",
+          },
+        },
+        attemptedModels: [normalizedSpark, fallbackSpark1!, fallbackSpark2!],
+        fallbackOnUnsupportedCodexModel: true,
+        fallbackToGpt52OnUnsupportedGpt53: true,
+      });
+      expect(fallbackSpark3).toBe("gpt-5.2-codex");
     });
 
     it("contains GPT-5.1 codex-mini models", () => {

--- a/test/model-map.test.ts
+++ b/test/model-map.test.ts
@@ -123,49 +123,58 @@ describe("Model Map Module", () => {
       expect(MODEL_MAP["gpt-5.4-mini-2026-03-05-high"]).toBe("gpt-5.4-mini");
     });
 
-	    it("contains GPT-5.2 codex models", () => {
-	      expect(MODEL_MAP["gpt-5.2-codex"]).toBe("gpt-5-codex");
-	      expect(MODEL_MAP["gpt-5.2-codex-low"]).toBe("gpt-5-codex");
-	      expect(MODEL_MAP["gpt-5.2-codex-medium"]).toBe("gpt-5-codex");
-	      expect(MODEL_MAP["gpt-5.2-codex-high"]).toBe("gpt-5-codex");
-	      expect(MODEL_MAP["gpt-5.2-codex-xhigh"]).toBe("gpt-5-codex");
+	    it("contains GPT-5.2 codex models (distinct backend model, not collapsed to gpt-5-codex)", () => {
+	      expect(MODEL_MAP["gpt-5.2-codex"]).toBe("gpt-5.2-codex");
+	      expect(MODEL_MAP["gpt-5.2-codex-low"]).toBe("gpt-5.2-codex");
+	      expect(MODEL_MAP["gpt-5.2-codex-medium"]).toBe("gpt-5.2-codex");
+	      expect(MODEL_MAP["gpt-5.2-codex-high"]).toBe("gpt-5.2-codex");
+	      expect(MODEL_MAP["gpt-5.2-codex-xhigh"]).toBe("gpt-5.2-codex");
+	      // "-none" is intentionally absent: this model rejects effort "none"
+	      expect(MODEL_MAP["gpt-5.2-codex-none"]).toBeUndefined();
 	    });
 
-	    it("contains GPT-5.3 codex models", () => {
-	      expect(MODEL_MAP["gpt-5.3-codex"]).toBe("gpt-5-codex");
-	      expect(MODEL_MAP["gpt-5.3-codex-low"]).toBe("gpt-5-codex");
-	      expect(MODEL_MAP["gpt-5.3-codex-medium"]).toBe("gpt-5-codex");
-	      expect(MODEL_MAP["gpt-5.3-codex-high"]).toBe("gpt-5-codex");
-	      expect(MODEL_MAP["gpt-5.3-codex-xhigh"]).toBe("gpt-5-codex");
+	    it("contains GPT-5.3 codex models (distinct backend model, not collapsed to gpt-5-codex)", () => {
+	      expect(MODEL_MAP["gpt-5.3-codex"]).toBe("gpt-5.3-codex");
+	      expect(MODEL_MAP["gpt-5.3-codex-low"]).toBe("gpt-5.3-codex");
+	      expect(MODEL_MAP["gpt-5.3-codex-medium"]).toBe("gpt-5.3-codex");
+	      expect(MODEL_MAP["gpt-5.3-codex-high"]).toBe("gpt-5.3-codex");
+	      expect(MODEL_MAP["gpt-5.3-codex-xhigh"]).toBe("gpt-5.3-codex");
+	      // "-none" is intentionally absent: this model rejects effort "none"
+	      expect(MODEL_MAP["gpt-5.3-codex-none"]).toBeUndefined();
 	    });
 
-    it("contains GPT-5.3 codex spark models", () => {
-      expect(MODEL_MAP["gpt-5.3-codex-spark"]).toBe("gpt-5-codex");
-	      expect(MODEL_MAP["gpt-5.3-codex-spark-low"]).toBe("gpt-5-codex");
-	      expect(MODEL_MAP["gpt-5.3-codex-spark-medium"]).toBe("gpt-5-codex");
-	      expect(MODEL_MAP["gpt-5.3-codex-spark-high"]).toBe("gpt-5-codex");
-      expect(MODEL_MAP["gpt-5.3-codex-spark-xhigh"]).toBe("gpt-5-codex");
+    it("contains GPT-5.3 codex spark models (distinct backend model, not collapsed to gpt-5-codex)", () => {
+      expect(MODEL_MAP["gpt-5.3-codex-spark"]).toBe("gpt-5.3-codex-spark");
+	      expect(MODEL_MAP["gpt-5.3-codex-spark-low"]).toBe("gpt-5.3-codex-spark");
+	      expect(MODEL_MAP["gpt-5.3-codex-spark-medium"]).toBe("gpt-5.3-codex-spark");
+	      expect(MODEL_MAP["gpt-5.3-codex-spark-high"]).toBe("gpt-5.3-codex-spark");
+      expect(MODEL_MAP["gpt-5.3-codex-spark-xhigh"]).toBe("gpt-5.3-codex-spark");
+      // "-none" is intentionally absent: this model rejects effort "none"
+      expect(MODEL_MAP["gpt-5.3-codex-spark-none"]).toBeUndefined();
     });
 
-    it("keeps legacy Codex normalization aligned with canonical fallback", () => {
-      const normalizedCodex = getNormalizedModel("gpt-5.2-codex");
-      expect(normalizedCodex).toBe("gpt-5-codex");
-      expect(getNormalizedModel("gpt-5.3-codex-spark")).toBe("gpt-5-codex");
+    it("keeps Codex normalization aligned with canonical fallback chain", () => {
+      // Each versioned codex family now resolves to its own canonical ID
+      expect(getNormalizedModel("gpt-5.2-codex")).toBe("gpt-5.2-codex");
+      expect(getNormalizedModel("gpt-5.3-codex")).toBe("gpt-5.3-codex");
+      expect(getNormalizedModel("gpt-5.3-codex-spark")).toBe("gpt-5.3-codex-spark");
 
+      // Fallback chain: gpt-5.2-codex → gpt-5-codex → gpt-5.4 on unsupported error
+      const normalizedCodex = getNormalizedModel("gpt-5.2-codex")!;
       const fallback = resolveUnsupportedCodexFallbackModel({
         requestedModel: normalizedCodex,
         errorBody: {
           error: {
             code: "model_not_supported_with_chatgpt_account",
             message:
-              "The 'gpt-5-codex' model is not supported when using Codex with a ChatGPT account.",
+              "The 'gpt-5.2-codex' model is not supported when using Codex with a ChatGPT account.",
           },
         },
-        attemptedModels: [normalizedCodex ?? ""],
+        attemptedModels: [normalizedCodex],
         fallbackOnUnsupportedCodexModel: true,
         fallbackToGpt52OnUnsupportedGpt53: true,
       });
-      expect(fallback).toBe("gpt-5.4");
+      expect(fallback).toBe("gpt-5-codex");
 
       const secondStepFallback = resolveUnsupportedCodexFallbackModel({
         requestedModel: fallback,
@@ -173,14 +182,14 @@ describe("Model Map Module", () => {
           error: {
             code: "model_not_supported_with_chatgpt_account",
             message:
-              "The 'gpt-5.4' model is not supported when using Codex with a ChatGPT account.",
+              "The 'gpt-5-codex' model is not supported when using Codex with a ChatGPT account.",
           },
         },
-        attemptedModels: [normalizedCodex ?? "", fallback],
-        fallbackOnUnsupportedCodexModel: false,
+        attemptedModels: [normalizedCodex, fallback],
+        fallbackOnUnsupportedCodexModel: true,
         fallbackToGpt52OnUnsupportedGpt53: true,
       });
-      expect(secondStepFallback).toBe("gpt-5.4-mini");
+      expect(secondStepFallback).toBe("gpt-5.4");
     });
 
     it("contains GPT-5.1 codex-mini models", () => {
@@ -230,10 +239,12 @@ describe("Model Map Module", () => {
     it("returns normalized model for exact match", () => {
       expect(getNormalizedModel("gpt-5.1-codex")).toBe("gpt-5-codex");
       expect(getNormalizedModel("gpt-5.1-codex-low")).toBe("gpt-5-codex");
-      expect(getNormalizedModel("gpt-5.2-codex-high")).toBe("gpt-5-codex");
-      expect(getNormalizedModel("gpt-5.3-codex-high")).toBe("gpt-5-codex");
-      expect(getNormalizedModel("gpt-5.3-codex-spark-high")).toBe("gpt-5-codex");
+      expect(getNormalizedModel("gpt-5.2-codex-high")).toBe("gpt-5.2-codex");
+      expect(getNormalizedModel("gpt-5.3-codex-high")).toBe("gpt-5.3-codex");
+      expect(getNormalizedModel("gpt-5.3-codex-spark-high")).toBe("gpt-5.3-codex-spark");
       expect(getNormalizedModel("gpt-5.4-high")).toBe("gpt-5.4");
+      expect(getNormalizedModel("gpt-5.4-fast")).toBe("gpt-5.4");
+      expect(getNormalizedModel("gpt-5.4-mini-fast")).toBe("gpt-5.4-mini");
       expect(getNormalizedModel("gpt-5.4-pro-none")).toBeUndefined();
       expect(getNormalizedModel("gpt-5.4-pro-high")).toBe("gpt-5.4-pro");
       expect(getNormalizedModel("gpt-5.4-2026-03-05-medium")).toBe("gpt-5.4");
@@ -245,9 +256,9 @@ describe("Model Map Module", () => {
 
     it("handles case-insensitive lookup", () => {
       expect(getNormalizedModel("GPT-5.1-CODEX")).toBe("gpt-5-codex");
-      expect(getNormalizedModel("Gpt-5.2-Codex-High")).toBe("gpt-5-codex");
-      expect(getNormalizedModel("Gpt-5.3-Codex-High")).toBe("gpt-5-codex");
-      expect(getNormalizedModel("Gpt-5.3-Codex-Spark-High")).toBe("gpt-5-codex");
+      expect(getNormalizedModel("Gpt-5.2-Codex-High")).toBe("gpt-5.2-codex");
+      expect(getNormalizedModel("Gpt-5.3-Codex-High")).toBe("gpt-5.3-codex");
+      expect(getNormalizedModel("Gpt-5.3-Codex-Spark-High")).toBe("gpt-5.3-codex-spark");
       expect(getNormalizedModel("Gpt-5.4-High")).toBe("gpt-5.4");
       expect(getNormalizedModel("Gpt-5.4-Pro-High")).toBe("gpt-5.4-pro");
       expect(getNormalizedModel("Gpt-5.4-Mini-High")).toBe("gpt-5.4-mini");
@@ -297,7 +308,6 @@ describe("Model Map Module", () => {
       expect(isKnownModel("GPT-5.4-MINI-HIGH")).toBe(true);
       expect(isKnownModel("gpt-5.4-mini")).toBe(true);
     });
-
     it("returns false for unknown models", () => {
       expect(isKnownModel("gpt-6")).toBe(false);
       expect(isKnownModel("claude-3")).toBe(false);
@@ -333,6 +343,9 @@ describe("Model Map Module", () => {
         "gpt-5.1-codex-mini",
         "gpt-5.1",
         "gpt-5.2",
+        "gpt-5.2-codex",
+        "gpt-5.3-codex",
+        "gpt-5.3-codex-spark",
         "gpt-5.5",
         "gpt-5.4",
         "gpt-5.4-pro",

--- a/test/request-transformer.test.ts
+++ b/test/request-transformer.test.ts
@@ -37,9 +37,9 @@ describe('Request Transformer Module', () => {
 			['openai/gpt-5.1-codex-mini-high', 'gpt-5.1-codex-mini'],
 			['openai/gpt-5.1-codex-mini-medium', 'gpt-5.1-codex-mini'],
 			['openai/gpt-5.2', 'gpt-5.2'],
-			['openai/gpt-5.2-codex', 'gpt-5-codex'],
-			['openai/gpt-5.3-codex', 'gpt-5-codex'],
-			['openai/gpt-5.3-codex-spark', 'gpt-5-codex'],
+			['openai/gpt-5.2-codex', 'gpt-5.2-codex'],
+			['openai/gpt-5.3-codex', 'gpt-5.3-codex'],
+			['openai/gpt-5.3-codex-spark', 'gpt-5.3-codex-spark'],
 			['openai/gpt-5.4', 'gpt-5.4'],
 			['openai/gpt-5.4-fast', 'gpt-5.4'],
 			['openai/gpt-5.4-mini', 'gpt-5.4-mini'],
@@ -132,12 +132,12 @@ describe('Request Transformer Module', () => {
 			});
 
 			it('should normalize gpt-5.2 codex presets', () => {
-				expect(normalizeModel('gpt-5.2-codex')).toBe('gpt-5-codex');
-				expect(normalizeModel('gpt-5.2-codex-low')).toBe('gpt-5-codex');
-				expect(normalizeModel('gpt-5.2-codex-medium')).toBe('gpt-5-codex');
-				expect(normalizeModel('gpt-5.2-codex-high')).toBe('gpt-5-codex');
-				expect(normalizeModel('gpt-5.2-codex-xhigh')).toBe('gpt-5-codex');
-				expect(normalizeModel('openai/gpt-5.2-codex-xhigh')).toBe('gpt-5-codex');
+				expect(normalizeModel('gpt-5.2-codex')).toBe('gpt-5.2-codex');
+				expect(normalizeModel('gpt-5.2-codex-low')).toBe('gpt-5.2-codex');
+				expect(normalizeModel('gpt-5.2-codex-medium')).toBe('gpt-5.2-codex');
+				expect(normalizeModel('gpt-5.2-codex-high')).toBe('gpt-5.2-codex');
+				expect(normalizeModel('gpt-5.2-codex-xhigh')).toBe('gpt-5.2-codex');
+				expect(normalizeModel('openai/gpt-5.2-codex-xhigh')).toBe('gpt-5.2-codex');
 			});
 
 			it('should normalize gpt-5.4 general presets', () => {
@@ -175,21 +175,23 @@ describe('Request Transformer Module', () => {
 		});
 
 			it('should normalize gpt-5.3 codex presets', () => {
-				expect(normalizeModel('gpt-5.3-codex')).toBe('gpt-5-codex');
-				expect(normalizeModel('gpt-5.3-codex-low')).toBe('gpt-5-codex');
-				expect(normalizeModel('gpt-5.3-codex-medium')).toBe('gpt-5-codex');
-				expect(normalizeModel('gpt-5.3-codex-high')).toBe('gpt-5-codex');
-				expect(normalizeModel('gpt-5.3-codex-xhigh')).toBe('gpt-5-codex');
-				expect(normalizeModel('openai/gpt-5.3-codex-xhigh')).toBe('gpt-5-codex');
+				expect(normalizeModel('gpt-5.3-codex')).toBe('gpt-5.3-codex');
+				expect(normalizeModel('gpt-5.3-codex-low')).toBe('gpt-5.3-codex');
+				expect(normalizeModel('gpt-5.3-codex-medium')).toBe('gpt-5.3-codex');
+				expect(normalizeModel('gpt-5.3-codex-high')).toBe('gpt-5.3-codex');
+				expect(normalizeModel('gpt-5.3-codex-xhigh')).toBe('gpt-5.3-codex');
+				expect(normalizeModel('openai/gpt-5.3-codex-xhigh')).toBe('gpt-5.3-codex');
 			});
 
 			it('should normalize gpt-5.3 codex spark presets', () => {
-				expect(normalizeModel('gpt-5.3-codex-spark')).toBe('gpt-5-codex');
-				expect(normalizeModel('gpt-5.3-codex-spark-low')).toBe('gpt-5-codex');
-				expect(normalizeModel('gpt-5.3-codex-spark-medium')).toBe('gpt-5-codex');
-				expect(normalizeModel('gpt-5.3-codex-spark-high')).toBe('gpt-5-codex');
-				expect(normalizeModel('gpt-5.3-codex-spark-xhigh')).toBe('gpt-5-codex');
-				expect(normalizeModel('openai/gpt-5.3-codex-spark-xhigh')).toBe('gpt-5-codex');
+				expect(normalizeModel('gpt-5.3-codex-spark')).toBe('gpt-5.3-codex-spark');
+				expect(normalizeModel('gpt-5.3-codex-spark-low')).toBe('gpt-5.3-codex-spark');
+				expect(normalizeModel('gpt-5.3-codex-spark-medium')).toBe('gpt-5.3-codex-spark');
+				expect(normalizeModel('gpt-5.3-codex-spark-high')).toBe('gpt-5.3-codex-spark');
+				expect(normalizeModel('gpt-5.3-codex-spark-xhigh')).toBe('gpt-5.3-codex-spark');
+				expect(normalizeModel('openai/gpt-5.3-codex-spark-xhigh')).toBe('gpt-5.3-codex-spark');
+				// regression: spark must not be swallowed by the gpt-5.3-codex pattern
+				expect(normalizeModel('openai/gpt-5.3-codex-spark-high')).toBe('gpt-5.3-codex-spark');
 			});
 
 			it('should normalize gpt-5.1 codex and mini slugs', () => {
@@ -216,7 +218,7 @@ describe('Request Transformer Module', () => {
 				expect(normalizeModel('CODEx-MINI-LATEST')).toBe('gpt-5.1-codex-mini');
 				expect(normalizeModel('GPT-5.4-HIGH')).toBe('gpt-5.4');
 				expect(normalizeModel('GPT-5.4-PRO-HIGH')).toBe('gpt-5.4-pro');
-				expect(normalizeModel('GPT-5.3-CODEX-SPARK')).toBe('gpt-5-codex');
+				expect(normalizeModel('GPT-5.3-CODEX-SPARK')).toBe('gpt-5.3-codex-spark');
 			});
 
 			it('should not misclassify unrelated gpt-5.4x model strings', () => {
@@ -1043,7 +1045,7 @@ describe('Request Transformer Module', () => {
 					'hybrid',
 				);
 
-				expect(result.instructions).toContain('identified to the backend as gpt-5-codex');
+				expect(result.instructions).toContain('identified to the backend as gpt-5.3-codex');
 				expect(result.instructions).toContain(longInstructions);
 			});
 
@@ -1327,7 +1329,7 @@ describe('Request Transformer Module', () => {
 					.reverse()
 					.find((item) => item.role === 'user');
 				expect(lastUser?.content).toBe('hi');
-				expect(result.instructions).toContain('identified to the backend as gpt-5-codex');
+				expect(result.instructions).toContain('identified to the backend as gpt-5.3-codex');
 				expect(result.instructions).toContain(codexInstructions);
 				expect(result.reasoning?.effort).toBe('low');
 				expect(result.text?.verbosity).toBe('low');
@@ -1670,7 +1672,7 @@ describe('Request Transformer Module', () => {
 					input: [],
 				};
 				const result = await transformRequestBody(body, codexInstructions);
-				expect(result.model).toBe('gpt-5-codex');
+				expect(result.model).toBe('gpt-5.2-codex');
 				expect(result.reasoning?.effort).toBe('xhigh');
 			});
 
@@ -1680,7 +1682,7 @@ describe('Request Transformer Module', () => {
 					input: [],
 				};
 				const result = await transformRequestBody(body, codexInstructions);
-				expect(result.model).toBe('gpt-5-codex');
+				expect(result.model).toBe('gpt-5.3-codex');
 				expect(result.reasoning?.effort).toBe('xhigh');
 			});
 
@@ -1690,7 +1692,7 @@ describe('Request Transformer Module', () => {
 					input: [],
 				};
 				const result = await transformRequestBody(body, codexInstructions);
-				expect(result.model).toBe('gpt-5-codex');
+				expect(result.model).toBe('gpt-5.3-codex-spark');
 				expect(result.reasoning?.effort).toBe('xhigh');
 			});
 
@@ -1727,7 +1729,7 @@ describe('Request Transformer Module', () => {
 				},
 			};
 			const result = await transformRequestBody(body, codexInstructions, userConfig);
-			expect(result.model).toBe('gpt-5-codex');
+			expect(result.model).toBe('gpt-5.2-codex');
 				expect(result.reasoning?.effort).toBe('xhigh');
 				expect(result.reasoning?.summary).toBe('detailed');
 			});
@@ -1746,7 +1748,7 @@ describe('Request Transformer Module', () => {
 					},
 				};
 				const result = await transformRequestBody(body, codexInstructions, userConfig);
-				expect(result.model).toBe('gpt-5-codex');
+				expect(result.model).toBe('gpt-5.3-codex');
 				expect(result.reasoning?.effort).toBe('xhigh');
 				expect(result.reasoning?.summary).toBe('detailed');
 			});
@@ -1921,7 +1923,7 @@ describe('Request Transformer Module', () => {
 				models: {},
 			};
 			const result = await transformRequestBody(body, codexInstructions, userConfig);
-				expect(result.model).toBe('gpt-5-codex');
+				expect(result.model).toBe('gpt-5.2-codex');
 				expect(result.reasoning?.effort).toBe('low');
 			});
 
@@ -1935,7 +1937,7 @@ describe('Request Transformer Module', () => {
 					models: {},
 				};
 				const result = await transformRequestBody(body, codexInstructions, userConfig);
-				expect(result.model).toBe('gpt-5-codex');
+				expect(result.model).toBe('gpt-5.3-codex');
 				expect(result.reasoning?.effort).toBe('low');
 			});
 
@@ -1949,7 +1951,7 @@ describe('Request Transformer Module', () => {
 					models: {},
 				};
 				const result = await transformRequestBody(body, codexInstructions, userConfig);
-				expect(result.model).toBe('gpt-5-codex');
+				expect(result.model).toBe('gpt-5.3-codex-spark');
 				expect(result.reasoning?.effort).toBe('low');
 			});
 
@@ -1963,7 +1965,7 @@ describe('Request Transformer Module', () => {
 				models: {},
 			};
 			const result = await transformRequestBody(body, codexInstructions, userConfig);
-				expect(result.model).toBe('gpt-5-codex');
+				expect(result.model).toBe('gpt-5.2-codex');
 				expect(result.reasoning?.effort).toBe('low');
 			});
 
@@ -1977,7 +1979,7 @@ describe('Request Transformer Module', () => {
 					models: {},
 				};
 				const result = await transformRequestBody(body, codexInstructions, userConfig);
-				expect(result.model).toBe('gpt-5-codex');
+				expect(result.model).toBe('gpt-5.3-codex');
 				expect(result.reasoning?.effort).toBe('low');
 			});
 


### PR DESCRIPTION
## Summary

Fixes #169.

`oc-codex-multi-auth` was collapsing `gpt-5.3-codex-spark`, `gpt-5.3-codex`, and `gpt-5.2-codex` to `gpt-5-codex` before sending requests to the backend. On accounts where only the versioned model is available (not `gpt-5-codex`), every request failed with `model_not_supported_with_chatgpt_account`.

## Root cause

Two places performed the incorrect normalization:

1. `lib/request/helpers/model-map.ts` — 15 entries in `MODEL_MAP` mapped these three families to `"gpt-5-codex"`
2. `lib/request/request-transformer.ts` — three fallback pattern blocks in `normalizeModel()` returned `"gpt-5-codex"` for unknown variants of these families

## Changes

**`lib/request/helpers/model-map.ts`**
- `gpt-5.3-codex-spark*` (5 entries) → `"gpt-5.3-codex-spark"`
- `gpt-5.3-codex*` (5 entries) → `"gpt-5.3-codex"`
- `gpt-5.2-codex*` (5 entries) → `"gpt-5.2-codex"`
- Added `gpt-5.4-fast` and `gpt-5.4-mini-fast` entries (expected by existing tests)
- Updated section comments (these are distinct backend models, not legacy aliases)
- `-none` suffix intentionally absent for all three families — the backend rejects reasoning effort `"none"` for these models; `getReasoningConfig()` coerces it to `"low"`

**`lib/request/request-transformer.ts`**
- Fallback pattern for `gpt-5.3-codex-spark` now returns `"gpt-5.3-codex-spark"`
- Fallback pattern for `gpt-5.3-codex` now returns `"gpt-5.3-codex"`
- Fallback pattern for `gpt-5.2-codex` now returns `"gpt-5.2-codex"`
- Pattern ordering preserved: spark check remains before gpt-5.3-codex to prevent the shorter substring from swallowing spark variants

**Tests** (5 files updated)
- Updated all assertions that previously expected `"gpt-5-codex"` as the result for these three families
- Added `-none` absent assertions for each family
- Added spark-before-codex ordering regression test
- Added the three new canonical IDs to the `validNormalizedModels` set

## What is NOT changed

- `getReasoningConfig()` — already uses substring matching on the original model name; unaffected
- `getModelFamily()` — already handles versioned IDs via substring matching; returns `"gpt-5-codex"` family for prompt selection
- `DEFAULT_UNSUPPORTED_CODEX_FALLBACK_CHAIN` — already has the three families as first-class keys with correct fallback chains
- Reasoning defaults: `gpt-5.2-codex` and `gpt-5.3-codex*` continue to default to `xhigh` and not support `"none"`

## Testing

96/96 test files pass, 2487/2488 tests pass (1 pre-existing skip unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for gpt-5.4-fast and gpt-5.4-mini-fast model variants.

* **Bug Fixes**
  * Model normalization now preserves distinct versioned Codex model IDs (e.g., gpt-5.2-codex, gpt-5.3-codex, gpt-5.3-codex-spark) instead of collapsing them to a generic identifier.

* **Tests**
  * Updated test expectations to reflect the new normalization and fallback behavior for Codex models.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

fixes the silent model-ID collapse where `gpt-5.3-codex-spark`, `gpt-5.3-codex`, and `gpt-5.2-codex` were all being sent to the backend as `gpt-5-codex`, causing `model_not_supported_with_chatgpt_account` on accounts where only the versioned model is available.

- **`model-map.ts`**: 15 map entries corrected to identity mappings; `gpt-5.4-fast` and `gpt-5.4-mini-fast` added; `-none` intentionally omitted for all three codex families with in-code documentation.
- **`request-transformer.ts`**: three pattern-fallback blocks updated to return versioned canonical IDs; spark check preserved above the gpt-5.3-codex check to prevent substring swallowing.
- **tests**: assertions across 5 files updated; `validNormalizedModels` extended; full spark fallback chain (3 steps) now covered; the `gpt-5.3-codex → gpt-5.2-codex` second fallback step is the one live edge that still lacks a dedicated test case.

<h3>Confidence Score: 5/5</h3>

safe to merge — the normalization fix is mechanically straightforward, the fallback chain and reasoning-config logic were already wired for versioned IDs, and 96 test files pass.

both changed source files make targeted, correct identity substitutions with no branching logic introduced. getReasoningConfig and the fallback chain function were pre-wired for these canonical IDs and are unaffected. test coverage is comprehensive for the new paths, with one minor gap on the gpt-5.3-codex second fallback step that poses no merge risk.

test/model-map.test.ts — the gpt-5.3-codex → gpt-5.2-codex second fallback step is the only live runtime edge without a dedicated assertion.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/request/helpers/model-map.ts | 15 map entries for gpt-5.3-codex-spark, gpt-5.3-codex, and gpt-5.2-codex corrected from "gpt-5-codex" to their own canonical IDs; gpt-5.4-fast and gpt-5.4-mini-fast added; -none intentionally omitted with clear comments. |
| lib/request/request-transformer.ts | Three fallback pattern blocks in normalizeModel() updated to return the correct versioned canonical IDs; spark check still precedes gpt-5.3-codex check to prevent substring swallowing; getReasoningConfig() is unaffected since it uses substring matching on the raw model name. |
| test/model-map.test.ts | Updated assertions for all three families; added -none absent checks; full spark fallback chain (3 steps) covered; gpt-5.3-codex chain only exercises step 1 (→ gpt-5-codex), leaving the gpt-5.3-codex → gpt-5.2-codex second step untested. |
| test/request-transformer.test.ts | All assertions updated to expect versioned canonical IDs; regression test added confirming spark is not swallowed by the gpt-5.3-codex pattern; coverage looks thorough. |
| test/fetch-helpers.test.ts | Three assertion sites updated from "gpt-5-codex" to "gpt-5.3-codex" to match the new canonical model ID sent in request bodies. |
| test/edge-cases.test.ts | One concurrent-normalization assertion updated to expect "gpt-5.3-codex" instead of "gpt-5-codex"; change is correct and minimal. |
| test/gpt54-models.test.ts | Single coexistence assertion updated; gpt-5.3-codex now expected to produce "gpt-5.3-codex" while getModelFamily still returns "gpt-5-codex" — both sides of the contract verified correctly. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Incoming model ID] --> B{Strip provider prefix}
    B --> C{MODEL_MAP exact match?}
    C -- yes --> D[Return canonical ID]
    C -- no --> E{Pattern fallback in normalizeModel}

    E -- includes gpt-5.3-codex-spark --> F["gpt-5.3-codex-spark"]
    E -- includes gpt-5.3-codex --> G["gpt-5.3-codex"]
    E -- includes gpt-5.2-codex --> H["gpt-5.2-codex"]
    E -- other patterns --> I["gpt-5.4 / gpt-5.5 / etc."]

    F --> J{Backend rejects?}
    G --> J
    H --> J
    D --> J

    J -- model_not_supported --> K[resolveUnsupportedCodexFallbackModel]
    K -- spark chain --> L["gpt-5-codex → gpt-5.3-codex → gpt-5.2-codex"]
    K -- 5.3-codex chain --> M["gpt-5-codex → gpt-5.2-codex"]
    K -- 5.2-codex chain --> N["gpt-5-codex"]
    K -- gpt-5-codex chain --> O["gpt-5.4 → gpt-5.4-mini → gpt-5.4-nano"]
```

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Foc-codex-multi-auth%22%20on%20the%20existing%20branch%20%22fix%2Fpreserve-versioned-codex-model-ids%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fpreserve-versioned-codex-model-ids%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atest%2Fmodel-map.test.ts%3A222-240%0A**Missing%20second-step%20fallback%20for%20gpt-5.3-codex%20chain**%0A%0Athe%20%60gpt-5.3-codex%60%20section%20only%20walks%20step%201%20%28%60%E2%86%92%20gpt-5-codex%60%29.%20the%20runtime%20chain%20is%20%60%5B%22gpt-5-codex%22%2C%20%22gpt-5.2-codex%22%5D%60%2C%20so%20the%20second%20step%20%E2%80%94%20%60attemptedModels%3A%20%5Bnormalized53%2C%20%22gpt-5-codex%22%5D%60%20%E2%86%92%20expect%20%60%22gpt-5.2-codex%22%60%20%E2%80%94%20is%20never%20exercised.%20given%20the%20bug%20this%20PR%20fixes%20was%20silent%20model-ID%20collapsing%2C%20leaving%20a%20live%20fallback%20edge%20untested%20means%20a%20future%20regression%20on%20this%20path%20would%20go%20undetected%20the%20same%20way.%0A%0A&repo=ndycode%2Foc-codex-multi-auth&pr=170&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
test/model-map.test.ts:222-240
**Missing second-step fallback for gpt-5.3-codex chain**

the `gpt-5.3-codex` section only walks step 1 (`→ gpt-5-codex`). the runtime chain is `["gpt-5-codex", "gpt-5.2-codex"]`, so the second step — `attemptedModels: [normalized53, "gpt-5-codex"]` → expect `"gpt-5.2-codex"` — is never exercised. given the bug this PR fixes was silent model-ID collapsing, leaving a live fallback edge untested means a future regression on this path would go undetected the same way.

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["test: add fallback-chain coverage for gp..."](https://github.com/ndycode/oc-codex-multi-auth/commit/611abd0f769d19f398f18ab7ef6c113d191e1d0c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36732768)</sub>

<!-- /greptile_comment -->