### PR TITLE
fix: fail over and cool down on 401 token-invalidated responses (#171)

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -144,6 +144,7 @@ import {
         handleErrorResponse,
         handleSuccessResponse,
 	isDeactivatedWorkspaceError,
+	isInvalidatedAuthTokenError,
 	getUnsupportedCodexModelInfo,
 	resolveUnsupportedCodexFallbackModel,
         refreshAndUpdateToken,
@@ -155,6 +156,7 @@ import {
 	createDeactivatedWorkspaceError,
 	DEACTIVATED_WORKSPACE_ERROR_CODE,
 	isDeactivatedWorkspaceErrorMessage,
+	isInvalidatedAuthTokenMessage,
 } from "./lib/error-sentinels.js";
 import {
 	applyFastSessionDefaults,
@@ -2629,6 +2631,89 @@ while (attempted.size < Math.max(1, accountCount)) {
 																																}
 																														break;
 																													}
+																													// A 401 token-invalidated response means the access token presented for
+																													// THIS account was rejected by the backend even though the proactive
+																													// refresh above either ran or judged the token still fresh. Without an
+																													// explicit handler the 401 fell straight through to `return errorResponse`
+																													// below, so persisted family routing kept pinning every request to the dead
+																													// account slot instead of failing over (issue #171). Treat it as an
+																													// account-health failure: cool the refresh-token group down (or remove it
+																													// past the failure threshold) and rotate to the next healthy account.
+																													//
+																													// Note: 401s intentionally do NOT feed the circuit breaker — the breaker
+																													// guards against upstream faults (network / 5xx), not client-side auth
+																													// decisions (see the 5xx handler above).
+																													if (isInvalidatedAuthTokenError(errorBody, response.status)) {
+																														const accountLabel = formatAccountLabel(account, account.index, {
+																															maskEmail: maskEmailEnabled,
+																														});
+																														accountManager.refundToken(account, modelFamily, model);
+																														accountManager.recordFailure(account, modelFamily, model);
+																														account.lastSwitchReason = "rotation";
+																														runtimeMetrics.failedRequests++;
+																														runtimeMetrics.accountRotations++;
+																														runtimeMetrics.lastError = `Auth token invalidated on ${accountLabel}`;
+																														runtimeMetrics.lastErrorCategory = "auth-invalidated";
+
+																														const failures = await accountManager.incrementAuthFailures(account);
+																														if (failures >= ACCOUNT_LIMITS.MAX_AUTH_FAILURES_BEFORE_REMOVAL) {
+																															const removedCount =
+																																accountManager.removeAccountsWithSameRefreshToken(account);
+																															if (removedCount > 0) {
+																																accountManager.saveToDiskDebounced();
+																																await showToast(
+																																	removedCount > 1
+																																		? `Removed ${removedCount} accounts (same refresh token) after ${failures} auth-token failures. Run 'opencode auth login' to re-add.`
+																																		: `Removed ${accountLabel} after ${failures} auth-token failures. Run 'opencode auth login' to re-add.`,
+																																	"error",
+																																	{ duration: toastDurationMs * 2 },
+																																);
+																																// Indices shift after removal; restart traversal with a fresh
+																																// attempted set so no healthy account is skipped.
+																																attempted.clear();
+																																accountCount = accountManager.getAccountCount();
+																																break;
+																															}
+																															logWarn(
+																																`[${PLUGIN_NAME}] Expected grouped account removal after auth-token invalidation, but removed ${removedCount}.`,
+																															);
+																														}
+
+																														// Below the removal threshold (or grouped removal was a no-op): cool the
+																														// account's whole refresh-token group down so selection skips it, then
+																														// rotate to the next healthy account instead of returning the 401.
+																														const cooledCount = accountManager.markAccountsWithRefreshTokenCoolingDown(
+																															account.refreshToken,
+																															ACCOUNT_LIMITS.AUTH_FAILURE_COOLDOWN_MS,
+																															"auth-failure",
+																														);
+																														if (cooledCount <= 0) {
+																															accountManager.markAccountCoolingDown(
+																																account,
+																																ACCOUNT_LIMITS.AUTH_FAILURE_COOLDOWN_MS,
+																																"auth-failure",
+																															);
+																														}
+																														accountManager.saveToDiskDebounced();
+																														logWarn(
+																															accountCount > 1
+																																? `Auth token invalidated for account ${account.index + 1}. Cooling down and rotating to next account.`
+																																: `Auth token invalidated for account ${account.index + 1}. Cooling down; no other account available.`,
+																														);
+																														if (
+																															accountCount > 1 &&
+																															accountManager.shouldShowAccountToast(account.index, rateLimitToastDebounceMs)
+																														) {
+																															await showToast(
+																																`Account ${account.index + 1} sign-in expired. Switching accounts.`,
+																																"warning",
+																																{ duration: toastDurationMs },
+																															);
+																															accountManager.markToastShown(account.index);
+																														}
+																														break;
+																													}
+
 																													runtimeMetrics.failedRequests++;
 																													runtimeMetrics.lastError = `HTTP ${response.status}`;
 																													runtimeMetrics.lastErrorCategory = "http";
@@ -2708,6 +2793,12 @@ while (attempted.size < Math.max(1, accountCount)) {
 					}
 
 					accountManager.recordSuccess(account, modelFamily, model);
+					// A successful request proves the account's credentials are good
+					// again, so reset the auth-failure counter that a prior 401
+					// token-invalidated response (or refresh failure) may have bumped.
+					// Otherwise stale counts could accumulate across requests and
+					// eventually remove a now-healthy account.
+					accountManager.clearAuthFailures(account);
 					// RC-8: closes a half-open gate or prunes the failure window so a
 					// sequence of successes keeps the breaker healthy.
 					circuitBreaker.recordSuccess();
@@ -3332,6 +3423,23 @@ while (attempted.size < Math.max(1, accountCount)) {
 													...account,
 													flaggedAt: Date.now(),
 													flaggedReason: "workspace-deactivated",
+													lastError: message,
+												};
+												flaggedUpdates.set(
+													getWorkspaceIdentityKey(flaggedRecord),
+													flaggedRecord,
+												);
+												removeFromActive.add(getWorkspaceIdentityKey(account));
+												flaggedChanged = true;
+											} else if (isInvalidatedAuthTokenMessage(message)) {
+												// The cached access token probed OK locally but the backend
+												// rejected it (401 invalidated). Surface it so `codex-doctor
+												// --fix` repairs the active routing instead of leaving a dead
+												// slot selected (issue #171).
+												const flaggedRecord: FlaggedAccountMetadataV1 = {
+													...account,
+													flaggedAt: Date.now(),
+													flaggedReason: "token-invalid",
 													lastError: message,
 												};
 												flaggedUpdates.set(

--- a/index.ts
+++ b/index.ts
@@ -3178,6 +3178,17 @@ while (attempted.size < Math.max(1, accountCount)) {
 											if (isDeactivatedWorkspaceError(errorBody, response.status)) {
 												throw createDeactivatedWorkspaceError();
 											}
+											// A 401 here proves the token is invalid even when the body
+											// carries only a generic "Unauthorized" string. The status is
+											// dropped once we throw a plain Error, so normalize to the
+											// canonical message the catch below matches — otherwise a
+											// non-specific 401 would leave a dead routing slot unflagged
+											// for codex-doctor --fix (issue #171).
+											if (isInvalidatedAuthTokenError(errorBody, response.status)) {
+												throw new Error(
+													"Your authentication token has been invalidated. Please try signing in again.",
+												);
+											}
 											throw new Error(message);
 										}
 

--- a/lib/error-sentinels.ts
+++ b/lib/error-sentinels.ts
@@ -14,6 +14,31 @@
 export const DEACTIVATED_WORKSPACE_ERROR_CODE = "deactivated_workspace";
 export const USAGE_REQUEST_TIMEOUT_MESSAGE = "Usage request timed out";
 
+/**
+ * Matches the "authentication token has been invalidated" auth failure that the
+ * Codex/OpenAI backend returns (HTTP 401) when a stored account's access token
+ * has been revoked server-side — for example after the user re-runs
+ * `opencode auth login` on another machine.
+ *
+ * This is the *request-path* counterpart to the token-refresh failure path: the
+ * stored access token can still look unexpired locally, so no proactive refresh
+ * fires, yet the upstream rejects it mid-request. The orchestrator in `index.ts`
+ * and the `codex-health`/`codex-doctor` probe use this matcher to treat such a
+ * response as an account-health failure (cool down + rotate / flag) instead of
+ * bubbling the 401 straight back to the caller and pinning every request to the
+ * dead account slot.
+ *
+ * The pattern tolerates the "(run `opencode auth login` if this persists)" hint
+ * the plugin appends to 401 bodies and minor wording variants.
+ */
+export const INVALIDATED_AUTH_TOKEN_MESSAGE_PATTERN =
+	/(?:authentication )?token has been invalidated|please (?:try )?sign(?:ing)?[\s-]*in again/i;
+
+export function isInvalidatedAuthTokenMessage(message: string | undefined): boolean {
+	if (!message) return false;
+	return INVALIDATED_AUTH_TOKEN_MESSAGE_PATTERN.test(message);
+}
+
 export function createDeactivatedWorkspaceError(): Error {
 	return new Error(DEACTIVATED_WORKSPACE_ERROR_CODE);
 }

--- a/lib/error-sentinels.ts
+++ b/lib/error-sentinels.ts
@@ -30,9 +30,16 @@ export const USAGE_REQUEST_TIMEOUT_MESSAGE = "Usage request timed out";
  *
  * The pattern tolerates the "(run `opencode auth login` if this persists)" hint
  * the plugin appends to 401 bodies and minor wording variants.
+ *
+ * The second branch deliberately requires an explicit token/credential keyword
+ * before "sign in again": this matcher is also used on the status-less
+ * codex-health/codex-doctor probe path, where a bare "please sign in again"
+ * could otherwise come from a generic session-expiry, workspace-lock, or
+ * license error (e.g. a 402/403 body) and wrongly flag a healthy account as
+ * token-invalid.
  */
 export const INVALIDATED_AUTH_TOKEN_MESSAGE_PATTERN =
-	/(?:authentication )?token has been invalidated|please (?:try )?sign(?:ing)?[\s-]*in again/i;
+	/token has been invalidated|(?:authentication|auth|access|session|login)\s+token\b[^.]*\bsign(?:ing)?[\s-]*in again/i;
 
 export function isInvalidatedAuthTokenMessage(message: string | undefined): boolean {
 	if (!message) return false;

--- a/lib/request/fetch-helpers.ts
+++ b/lib/request/fetch-helpers.ts
@@ -419,12 +419,17 @@ function getStructuredErrorMessage(errorBody: unknown): string | undefined {
 }
 
 /**
- * Auth error codes the Codex/OpenAI backend uses for a rejected or revoked
- * access token. These are distinct from rate limits (429) and entitlement gates
- * (403/`model_not_supported_*`), which have their own rotation/fallback paths.
+ * Auth error codes the Codex/OpenAI backend uses for a specifically invalidated
+ * or revoked OAuth token. Kept deliberately narrow: generic codes like
+ * `unauthorized` (permission-denied) or `invalid_api_key` (wrong key) are
+ * excluded so the status-less code/message fallback cannot cool down a healthy
+ * account on a non-token error. HTTP 401 remains the primary signal; these are
+ * only a fallback for paths that carry a structured code but no status. Distinct
+ * from rate limits (429) and entitlement gates (403/`model_not_supported_*`),
+ * which have their own rotation/fallback paths.
  */
 const INVALIDATED_AUTH_TOKEN_CODE_PATTERN =
-	/^(?:invalid_token|invalid_grant|invalid_api_key|unauthorized|token_expired|token_revoked)$/i;
+	/^(?:invalid_token|invalid_grant|token_expired|token_revoked)$/i;
 
 /**
  * Detects the "authentication token invalidated" failure on the *request* path

--- a/lib/request/fetch-helpers.ts
+++ b/lib/request/fetch-helpers.ts
@@ -20,7 +20,10 @@ import { GPT_55_MODEL_ID } from "./helpers/model-map.js";
 import { convertSseToJson, ensureContentType } from "./response-handler.js";
 import type { OAuthAuthDetails, UserConfig, RequestBody } from "../types.js";
 import { CodexAuthError } from "../errors.js";
-import { DEACTIVATED_WORKSPACE_ERROR_CODE } from "../error-sentinels.js";
+import {
+	DEACTIVATED_WORKSPACE_ERROR_CODE,
+	isInvalidatedAuthTokenMessage,
+} from "../error-sentinels.js";
 import { isRecord } from "../utils.js";
 import {
         CODEX_BASE_URL,
@@ -392,6 +395,56 @@ function getStructuredErrorCode(errorBody: unknown): string | undefined {
 	}
 
 	return undefined;
+}
+
+function getStructuredErrorMessage(errorBody: unknown): string | undefined {
+	if (typeof errorBody === "string") return errorBody.trim() || undefined;
+	if (!isRecord(errorBody)) return undefined;
+
+	const nestedError = errorBody.error;
+	if (isRecord(nestedError) && typeof nestedError.message === "string" && nestedError.message.trim()) {
+		return nestedError.message;
+	}
+
+	const directMessage = errorBody.message;
+	if (typeof directMessage === "string" && directMessage.trim()) return directMessage;
+
+	const detail = errorBody.detail;
+	if (typeof detail === "string" && detail.trim()) return detail;
+	if (isRecord(detail) && typeof detail.message === "string" && detail.message.trim()) {
+		return detail.message;
+	}
+
+	return undefined;
+}
+
+/**
+ * Auth error codes the Codex/OpenAI backend uses for a rejected or revoked
+ * access token. These are distinct from rate limits (429) and entitlement gates
+ * (403/`model_not_supported_*`), which have their own rotation/fallback paths.
+ */
+const INVALIDATED_AUTH_TOKEN_CODE_PATTERN =
+	/^(?:invalid_token|invalid_grant|invalid_api_key|unauthorized|token_expired|token_revoked)$/i;
+
+/**
+ * Detects the "authentication token invalidated" failure on the *request* path
+ * (as opposed to the token-refresh path in {@link refreshAndUpdateToken}).
+ *
+ * The backend returns HTTP 401 with a body like
+ * "Your authentication token has been invalidated. Please try signing in
+ * again." When the access token presented for a request is rejected, the owning
+ * account must be cooled down and the request rotated to the next healthy
+ * account — otherwise persisted family routing keeps pinning every request to
+ * the dead account slot (issue #171).
+ *
+ * Driven primarily by the HTTP 401 status; the structured code and message are
+ * fallbacks for paths (probe/exception) that only carry an error string.
+ */
+export function isInvalidatedAuthTokenError(errorBody: unknown, status?: number): boolean {
+	if (status === HTTP_STATUS.UNAUTHORIZED) return true;
+	const code = getStructuredErrorCode(errorBody);
+	if (code && INVALIDATED_AUTH_TOKEN_CODE_PATTERN.test(code)) return true;
+	return isInvalidatedAuthTokenMessage(getStructuredErrorMessage(errorBody));
 }
 
 function isServerOverloadedError(errorBody: unknown): boolean {

--- a/test/error-sentinels.test.ts
+++ b/test/error-sentinels.test.ts
@@ -4,6 +4,7 @@ import {
 	createUsageRequestTimeoutError,
 	DEACTIVATED_WORKSPACE_ERROR_CODE,
 	isDeactivatedWorkspaceErrorMessage,
+	isInvalidatedAuthTokenMessage,
 	isUsageRequestTimeoutMessage,
 	USAGE_REQUEST_TIMEOUT_MESSAGE,
 } from "../lib/error-sentinels.js";
@@ -20,5 +21,26 @@ describe("error sentinels", () => {
 		expect(usageTimeoutError.message).toBe(USAGE_REQUEST_TIMEOUT_MESSAGE);
 		expect(isUsageRequestTimeoutMessage(usageTimeoutError.message)).toBe(true);
 		expect(isUsageRequestTimeoutMessage("request timed out")).toBe(false);
+	});
+
+	it("matches the token-invalidated auth error message (issue #171)", () => {
+		// The exact upstream message, with and without the plugin's appended hint.
+		expect(
+			isInvalidatedAuthTokenMessage(
+				"Your authentication token has been invalidated. Please try signing in again.",
+			),
+		).toBe(true);
+		expect(
+			isInvalidatedAuthTokenMessage(
+				"Your authentication token has been invalidated. Please try signing in again. (run `opencode auth login` if this persists)",
+			),
+		).toBe(true);
+		expect(isInvalidatedAuthTokenMessage("Please sign in again")).toBe(true);
+
+		// Must not match unrelated errors.
+		expect(isInvalidatedAuthTokenMessage("Rate limit exceeded")).toBe(false);
+		expect(isInvalidatedAuthTokenMessage("The server had an error")).toBe(false);
+		expect(isInvalidatedAuthTokenMessage(undefined)).toBe(false);
+		expect(isInvalidatedAuthTokenMessage("")).toBe(false);
 	});
 });

--- a/test/error-sentinels.test.ts
+++ b/test/error-sentinels.test.ts
@@ -35,9 +35,16 @@ describe("error sentinels", () => {
 				"Your authentication token has been invalidated. Please try signing in again. (run `opencode auth login` if this persists)",
 			),
 		).toBe(true);
-		expect(isInvalidatedAuthTokenMessage("Please sign in again")).toBe(true);
+		// The "sign in again" branch requires explicit token/credential context.
+		expect(
+			isInvalidatedAuthTokenMessage("Your auth token is no longer valid, please sign in again."),
+		).toBe(true);
 
-		// Must not match unrelated errors.
+		// Must not match unrelated errors — including a bare "sign in again"
+		// that can come from generic session-expiry / workspace-lock / license
+		// bodies on the status-less probe path.
+		expect(isInvalidatedAuthTokenMessage("Please sign in again")).toBe(false);
+		expect(isInvalidatedAuthTokenMessage("Your session has expired. Please sign in again.")).toBe(false);
 		expect(isInvalidatedAuthTokenMessage("Rate limit exceeded")).toBe(false);
 		expect(isInvalidatedAuthTokenMessage("The server had an error")).toBe(false);
 		expect(isInvalidatedAuthTokenMessage(undefined)).toBe(false);

--- a/test/fetch-helpers.test.ts
+++ b/test/fetch-helpers.test.ts
@@ -10,6 +10,7 @@ import {
     handleSuccessResponse,
     isEntitlementError,
     isDeactivatedWorkspaceError,
+    isInvalidatedAuthTokenError,
     createEntitlementErrorResponse,
 	getUnsupportedCodexModelInfo,
 	resolveUnsupportedCodexFallbackModel,
@@ -1406,6 +1407,52 @@ describe('Fetch Helpers Module', () => {
 			expect(result?.body).toBeDefined();
 			expect(result?.body.model).toBe('gpt-5.1');
 			expect(result?.updatedInit).toBeDefined();
+		});
+	});
+
+	describe('isInvalidatedAuthTokenError (issue #171)', () => {
+		it('treats any HTTP 401 as a token-invalidated auth failure', () => {
+			expect(isInvalidatedAuthTokenError(undefined, 401)).toBe(true);
+			expect(
+				isInvalidatedAuthTokenError(
+					{ error: { message: 'Your authentication token has been invalidated.' } },
+					401,
+				),
+			).toBe(true);
+		});
+
+		it('matches structured auth error codes without a 401 status', () => {
+			expect(isInvalidatedAuthTokenError({ error: { code: 'invalid_token' } })).toBe(true);
+			expect(isInvalidatedAuthTokenError({ error: { type: 'invalid_grant' } })).toBe(true);
+			expect(isInvalidatedAuthTokenError({ code: 'token_expired' })).toBe(true);
+		});
+
+		it('matches the invalidated-token message when only a string body is available', () => {
+			expect(
+				isInvalidatedAuthTokenError(
+					'Your authentication token has been invalidated. Please try signing in again.',
+				),
+			).toBe(true);
+			expect(
+				isInvalidatedAuthTokenError({
+					error: {
+						message:
+							'Your authentication token has been invalidated. Please try signing in again. (run `opencode auth login` if this persists)',
+					},
+				}),
+			).toBe(true);
+		});
+
+		it('does not match rate limits, entitlement gates, or server errors', () => {
+			expect(isInvalidatedAuthTokenError({ error: { code: 'rate_limit_exceeded' } }, 429)).toBe(false);
+			expect(
+				isInvalidatedAuthTokenError(
+					{ error: { code: 'model_not_supported_with_chatgpt_account' } },
+					403,
+				),
+			).toBe(false);
+			expect(isInvalidatedAuthTokenError({ error: { message: 'server error' } }, 500)).toBe(false);
+			expect(isInvalidatedAuthTokenError(undefined, undefined)).toBe(false);
 		});
 	});
 });

--- a/test/fetch-helpers.test.ts
+++ b/test/fetch-helpers.test.ts
@@ -1443,6 +1443,14 @@ describe('Fetch Helpers Module', () => {
 			).toBe(true);
 		});
 
+		it('does not treat generic permission/wrong-key codes as invalidated tokens (status-less)', () => {
+			// `unauthorized` (permission-denied) and `invalid_api_key` (wrong key)
+			// are excluded so the status-less fallback cannot cool down a healthy
+			// account on a non-token error.
+			expect(isInvalidatedAuthTokenError({ error: { code: 'unauthorized' } })).toBe(false);
+			expect(isInvalidatedAuthTokenError({ error: { code: 'invalid_api_key' } })).toBe(false);
+		});
+
 		it('does not match rate limits, entitlement gates, or server errors', () => {
 			expect(isInvalidatedAuthTokenError({ error: { code: 'rate_limit_exceeded' } }, 429)).toBe(false);
 			expect(

--- a/test/index-retry.test.ts
+++ b/test/index-retry.test.ts
@@ -45,6 +45,7 @@ vi.mock("../lib/request/fetch-helpers.js", () => ({
 		return { response };
 	},
 	isDeactivatedWorkspaceError: () => false,
+	isInvalidatedAuthTokenError: (_errorBody: unknown, status?: number) => status === 401,
 	resolveUnsupportedCodexFallbackModel: () => undefined,
 	getUnsupportedCodexModelInfo: () => ({
 		isUnsupported: false,
@@ -95,6 +96,25 @@ vi.mock("../lib/accounts.js", () => {
 		recordRateLimit() {}
 
 		recordFailure() {}
+
+		authFailures = 0;
+
+		async incrementAuthFailures() {
+			this.authFailures += 1;
+			return this.authFailures;
+		}
+
+		clearAuthFailures() {
+			this.authFailures = 0;
+		}
+
+		removeAccountsWithSameRefreshToken() {
+			return 1;
+		}
+
+		markAccountsWithRefreshTokenCoolingDown() {
+			return 1;
+		}
 
 	toAuthDetails() {
 		return {
@@ -358,6 +378,51 @@ describe("OpenAIAuthPlugin rate-limit retry", () => {
 		expect(fetchMock).toHaveBeenCalledTimes(2);
 
 		const response = await fetchPromise;
+		expect(response.status).toBe(200);
+	});
+
+	it("fails over to the next account when one returns a 401 token-invalidated error", async () => {
+		const { OpenAIAuthPlugin } = (await import("../index.js")) as any;
+		const client = {
+			tui: { showToast: vi.fn() },
+			auth: { set: vi.fn() },
+		} as any;
+
+		const plugin = await OpenAIAuthPlugin({ client } as any);
+
+		const getAuth = async () => ({
+			type: "oauth" as const,
+			access: "a",
+			refresh: "r",
+			expires: Date.now() + 60_000,
+			multiAccount: true,
+		});
+
+		const sdk = (await (plugin.auth as any).loader(getAuth, { options: {}, models: {} } as any)) as any;
+		const fetchMock = vi.mocked(globalThis.fetch);
+		fetchMock.mockReset();
+		fetchMock
+			.mockResolvedValueOnce(
+				new Response(
+					JSON.stringify({
+						error: {
+							message:
+								"Your authentication token has been invalidated. Please try signing in again.",
+						},
+					}),
+					{ status: 401, headers: { "content-type": "application/json" } },
+				),
+			)
+			.mockResolvedValueOnce(new Response("ok", { status: 200 }));
+
+		const fetchPromise = sdk.fetch("https://example.com", {});
+
+		await vi.runAllTimersAsync();
+
+		const response = await fetchPromise;
+		// The first account's 401 must trigger rotation to the second account
+		// rather than bubbling the 401 straight back (issue #171).
+		expect(fetchMock).toHaveBeenCalledTimes(2);
 		expect(response.status).toBe(200);
 	});
 });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -238,6 +238,7 @@ vi.mock("../lib/request/rate-limit-backoff.js", () => ({
 				undefined;
 			return code === "deactivated_workspace";
 		}),
+		isInvalidatedAuthTokenError: vi.fn((_errorBody: unknown, status?: number) => status === 401),
 	getUnsupportedCodexModelInfo: vi.fn(() => ({ isUnsupported: false })),
 	resolveUnsupportedCodexFallbackModel: vi.fn(() => undefined),
 	shouldFallbackToGpt52OnUnsupportedGpt53: vi.fn(() => false),


### PR DESCRIPTION
## Summary

Fixes #171 — a stored OAuth account whose access token is invalidated server-side returns HTTP 401 (`Your authentication token has been invalidated. Please try signing in again.`), but the request pipeline had **no 401 handler**. The error fell straight through to `return errorResponse` without rotating or marking the account unhealthy, so persisted family routing kept pinning every request to the dead account slot. The only workaround was hand-editing `activeIndex`/`activeIndexByFamily` in `oc-codex-multi-auth-accounts.json`.

## Root cause

In the request loop (`index.ts`), non-OK responses are classified for workspace-deactivation, unsupported-model, recoverable, 5xx server, and rate-limit handling — each with a rotation/cooldown path. A 401 matched **none** of these and hit the generic fall-through (`lastErrorCategory = "http"; return errorResponse`), which neither cools the account down nor fails over. The plugin already refreshes tokens proactively, but a token invalidated *server-side* can still look unexpired locally, so no refresh fires and the stale token is rejected mid-request.

## Fix

Treat a request-path 401 as an account-health failure, mirroring the existing token-refresh failure handling:

- **New detectors:** `isInvalidatedAuthTokenError(errorBody, status)` (request-path, driven by HTTP 401 with structured-code/message fallbacks) and `isInvalidatedAuthTokenMessage()` (pure message matcher, single source of truth for the wording + appended `opencode auth login` hint).
- **Failover in the request loop:** refund the consumed token, record the failure, increment the shared auth-failure counter, cool the refresh-token group down, and rotate to the next healthy account. Past `MAX_AUTH_FAILURES_BEFORE_REMOVAL` the group is removed and traversal restarts. 401s intentionally **do not** feed the circuit breaker (it guards upstream faults, not client-side auth decisions).
- **Recovery:** clear the auth-failure counter on a successful request so a recovered account does not accumulate stale failures toward removal.
- **codex-health / codex-doctor:** the quota probe now flags `token-invalid` on an invalidated-token error, so `codex-doctor --fix` repairs the active routing without manual JSON edits.

Once the bad slot is cooled down, the next successful rotation persists the updated family routing, so the failure **self-heals across restarts** — no more manual `activeIndex` editing.

## Tests

- Unit tests for both detectors (`test/error-sentinels.test.ts`, `test/fetch-helpers.test.ts`), including non-matching rate-limit / entitlement / server-error cases.
- End-to-end regression test (`test/index-retry.test.ts`) asserting a 401 on the first account fails over to the second and returns 200.
- Full suite green: **2494 tests pass**, `tsc --noEmit` and `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PwrFRje1b1FmpjPE8grMPn

---
_Generated by [Claude Code](https://claude.ai/code/session_01PwrFRje1b1FmpjPE8grMPn)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic detection and rotation when authentication tokens are invalidated or revoked
  * Auth failure tracking with cooldown/removal of affected accounts after a failure threshold
* **Bug Fixes**
  * 401 “invalidated token” responses now trigger auth-failure handling instead of generic HTTP errors
  * Health-check/doctor probing now flags invalidated tokens for repair and removes them from rotation
  * Auth-failure state is cleared after successful requests
* **Tests**
  * Added coverage for invalidated-token detection and retry/rotation regression scenarios
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---


<h3>Greptile Summary</h3>

this pr fixes issue #171 by adding an explicit 401 token-invalidated handler in the main request loop and the `codex-health`/`codex-doctor` probe path, replacing a silent fall-through that kept dead accounts permanently pinned in family routing.

- **request loop**: on a 401, the plugin refunds the token, increments an auth-failure counter, cools the refresh-token group down (or removes it past `MAX_AUTH_FAILURES_BEFORE_REMOVAL`), and rotates to the next healthy account; `clearAuthFailures` is called on the first success to prevent stale counts from accumulating.
- **detectors**: `isInvalidatedAuthTokenError` (primary signal is http 401; code/message fallbacks are narrow to avoid false-positives on the status-less probe path) and `isInvalidatedAuthTokenMessage` (single-source regex, deliberately requires an explicit token keyword to avoid matching generic session-expiry bodies).
- **codex-doctor**: the health probe normalises any 401 to the canonical invalidated-token message so `--fix` can flag and repair the dead routing slot without manual json edits.

<h3>Confidence Score: 5/5</h3>

safe to merge — the 401 failover path is correct, detectors are narrow and well-tested, and the success-path counter reset prevents stale accumulation

the core fix is sound: any 401 in the request loop now cools the account down and rotates instead of pinning the dead slot. detector logic is narrow and backed by thorough unit tests. the only gap is the `removedCount == 0` branch where the failure counter isn't cleared after a failed removal, causing repeated warn+cooldown cycles for standalone accounts — noisy and potentially chatty on disk, but rotation continues correctly and no data is lost

index.ts around the `logWarn` branch at `MAX_AUTH_FAILURES_BEFORE_REMOVAL` and the corresponding mock in test/index-retry.test.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| index.ts | adds 401 token-invalidated handler in the request loop (cooldown + rotate) and the codex-health probe path; clears auth-failure counter on success; logic is sound but the `removedCount == 0` branch leaves failure counter elevated across cycles |
| lib/request/fetch-helpers.ts | adds `getStructuredErrorMessage` helper and `isInvalidatedAuthTokenError`; HTTP 401 status is the primary signal; code/message fallbacks are narrow and exclude generic permission codes |
| lib/error-sentinels.ts | adds `INVALIDATED_AUTH_TOKEN_MESSAGE_PATTERN` and `isInvalidatedAuthTokenMessage`; pattern is deliberately narrow to avoid false positives on the status-less probe path; well-documented |
| test/index-retry.test.ts | adds e2e failover test for 401 rotation; `removeAccountsWithSameRefreshToken` mock always returns 1, leaving the `removedCount == 0` branch (standalone account at threshold) uncovered |
| test/fetch-helpers.test.ts | covers 401-by-status, code fallbacks, message fallback, and non-matching cases; tests are accurate against the implementation |
| test/error-sentinels.test.ts | good coverage of the message pattern matcher including positive, negative, and edge cases; no issues found |
| test/index.test.ts | adds `isInvalidatedAuthTokenError` mock to the existing suite mock so the new handler doesn't break existing tests; minimal change, no issues |

</details>



<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[fetch request] --> B{response.ok?}
    B -- yes --> C[recordSuccess\nclearAuthFailures\ncircuitBreaker.recordSuccess]
    B -- no --> D[parse errorBody]
    D --> E{deactivated\nworkspace?}
    E -- yes --> F[throw createDeactivatedWorkspaceError]
    E -- no --> G{rate limit\n429?}
    G -- yes --> H[cooldown + rotate]
    G -- no --> I{unsupported\nmodel?}
    I -- yes --> J[fallback model + rotate]
    I -- no --> K{isInvalidatedAuthTokenError\nstatus=401?}
    K -- yes --> L[refundToken\nrecordFailure\nincrementAuthFailures]
    L --> M{failures >=\nMAX_AUTH_FAILURES\n_BEFORE_REMOVAL?}
    M -- yes --> N[removeAccountsWithSameRefreshToken]
    N --> O{removedCount > 0?}
    O -- yes --> P[saveToDisk\ntoast\nattempted.clear\nbreak]
    O -- no --> Q[logWarn\n counter not cleared]
    Q --> R[markAccountsWithRefreshToken\nCoolingDown]
    M -- no --> R
    R --> S{cooledCount <= 0?}
    S -- yes --> T[markAccountCoolingDown]
    S -- no --> U[saveToDisk\nlogWarn\nmaybe toast\nbreak]
    T --> U
    K -- no --> V[generic HTTP error\nreturn errorResponse]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[fetch request] --> B{response.ok?}
    B -- yes --> C[recordSuccess\nclearAuthFailures\ncircuitBreaker.recordSuccess]
    B -- no --> D[parse errorBody]
    D --> E{deactivated\nworkspace?}
    E -- yes --> F[throw createDeactivatedWorkspaceError]
    E -- no --> G{rate limit\n429?}
    G -- yes --> H[cooldown + rotate]
    G -- no --> I{unsupported\nmodel?}
    I -- yes --> J[fallback model + rotate]
    I -- no --> K{isInvalidatedAuthTokenError\nstatus=401?}
    K -- yes --> L[refundToken\nrecordFailure\nincrementAuthFailures]
    L --> M{failures >=\nMAX_AUTH_FAILURES\n_BEFORE_REMOVAL?}
    M -- yes --> N[removeAccountsWithSameRefreshToken]
    N --> O{removedCount > 0?}
    O -- yes --> P[saveToDisk\ntoast\nattempted.clear\nbreak]
    O -- no --> Q[logWarn\n counter not cleared]
    Q --> R[markAccountsWithRefreshToken\nCoolingDown]
    M -- no --> R
    R --> S{cooledCount <= 0?}
    S -- yes --> T[markAccountCoolingDown]
    S -- no --> U[saveToDisk\nlogWarn\nmaybe toast\nbreak]
    T --> U
    K -- no --> V[generic HTTP error\nreturn errorResponse]
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `test/index-retry.test.ts`, line 97-122 ([link](https://github.com/ndycode/oc-codex-multi-auth/blob/cb845b5eb2fe75d2c562fa1bd42a6d8bf5170de5/test/index-retry.test.ts#L97-L122)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`markAccountCoolingDown` fallback path has no test coverage**

   the mock always returns `1` from `markAccountsWithRefreshTokenCoolingDown`, so the `cooledCount <= 0` branch that calls `markAccountCoolingDown` (index.ts ~line 2690) is never exercised. this fallback fires when no accounts share the refresh token (e.g. a standalone account not part of a token group), and on windows that's also the path that triggers `saveToDiskDebounced` writes on a single-account install — worth covering with a test that returns 0 from the group-cooldown mock to verify the per-account fallback fires instead.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: test/index-retry.test.ts
   Line: 97-122

   Comment:
   **`markAccountCoolingDown` fallback path has no test coverage**

   the mock always returns `1` from `markAccountsWithRefreshTokenCoolingDown`, so the `cooledCount <= 0` branch that calls `markAccountCoolingDown` (index.ts ~line 2690) is never exercised. this fallback fires when no accounts share the refresh token (e.g. a standalone account not part of a token group), and on windows that's also the path that triggers `saveToDiskDebounced` writes on a single-account install — worth covering with a test that returns 0 from the group-cooldown mock to verify the per-account fallback fires instead.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Foc-codex-multi-auth%22%20on%20the%20existing%20branch%20%22claude%2Fgithub-issue-171-6kyby4%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Fgithub-issue-171-6kyby4%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20test%2Findex-retry.test.ts%0ALine%3A%2097-122%0A%0AComment%3A%0A**%60markAccountCoolingDown%60%20fallback%20path%20has%20no%20test%20coverage**%0A%0Athe%20mock%20always%20returns%20%601%60%20from%20%60markAccountsWithRefreshTokenCoolingDown%60%2C%20so%20the%20%60cooledCount%20%3C%3D%200%60%20branch%20that%20calls%20%60markAccountCoolingDown%60%20%28index.ts%20~line%202690%29%20is%20never%20exercised.%20this%20fallback%20fires%20when%20no%20accounts%20share%20the%20refresh%20token%20%28e.g.%20a%20standalone%20account%20not%20part%20of%20a%20token%20group%29%2C%20and%20on%20windows%20that's%20also%20the%20path%20that%20triggers%20%60saveToDiskDebounced%60%20writes%20on%20a%20single-account%20install%20%E2%80%94%20worth%20covering%20with%20a%20test%20that%20returns%200%20from%20the%20group-cooldown%20mock%20to%20verify%20the%20per-account%20fallback%20fires%20instead.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=ndycode%2Foc-codex-multi-auth&pr=172&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["fix: tighten invalidated-token detectors..."](https://github.com/ndycode/oc-codex-multi-auth/commit/855102672a47fcb1b9e422fcf556f6421ddc7c30) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38059686)</sub>

<!-- /greptile_comment -->