### PR TITLE
fix(storage): token-source duplicate must not disable the real org account on merge (#171)

### DIFF
--- a/lib/storage/identity.ts
+++ b/lib/storage/identity.ts
@@ -23,6 +23,7 @@ export type AccountLike = {
   refreshToken: string;
   addedAt?: number;
   lastUsed?: number;
+  enabled?: boolean;
 };
 
 const normalizeWorkspaceIdentityPart = (value: unknown): string | undefined =>
@@ -136,6 +137,37 @@ function pickNewestAccountIndex<T extends AccountLike>(
   return newest === candidate ? candidateIndex : existingIndex;
 }
 
+function isOrgLikeAccount<T extends AccountLike>(account: T): boolean {
+  return (
+    !!normalizeWorkspaceIdentityPart(account.organizationId) ||
+    account.accountIdSource === "org"
+  );
+}
+
+/**
+ * Resolve the merged `enabled` flag.
+ *
+ * Default is fail-closed: if either side is explicitly disabled, the merge is
+ * disabled. The ONE exception (issue #171): when exactly one side is an
+ * org-backed real account and the other is a token-source duplicate (a plugin
+ * re-login artifact), the org account's own `enabled` state governs. A disabled
+ * token duplicate must never silently disable the real account it collapses
+ * into — otherwise the canonical account becomes unroutable and unrecoverable.
+ */
+function resolveMergedEnabled<T extends AccountLike>(target: T, source: T): boolean | undefined {
+  const targetOrgLike = isOrgLikeAccount(target);
+  const sourceOrgLike = isOrgLikeAccount(source);
+  const targetTokenDup = !targetOrgLike && target.accountIdSource === "token";
+  const sourceTokenDup = !sourceOrgLike && source.accountIdSource === "token";
+
+  if (targetOrgLike && sourceTokenDup) return target.enabled;
+  if (sourceOrgLike && targetTokenDup) return source.enabled;
+
+  // Fail-closed for every other shape (same-identity, two real accounts, etc.).
+  if (target.enabled === false || source.enabled === false) return false;
+  return target.enabled ?? source.enabled;
+}
+
 function mergeAccountRecords<T extends AccountLike>(target: T, source: T): T {
   const newest = selectNewestAccount(target, source);
   const older = newest === target ? source : target;
@@ -147,6 +179,7 @@ function mergeAccountRecords<T extends AccountLike>(target: T, source: T): T {
     accountIdSource: target.accountIdSource ?? source.accountIdSource,
     accountLabel: target.accountLabel ?? source.accountLabel,
     email: target.email ?? source.email,
+    enabled: resolveMergedEnabled(target, source),
   };
 }
 

--- a/test/chaos/doctor-recovery-171-stress.test.ts
+++ b/test/chaos/doctor-recovery-171-stress.test.ts
@@ -28,6 +28,14 @@ import {
 	clearRefreshedAccountsStaleState,
 	findDisabledTokenSourceDuplicates,
 } from "../../lib/accounts/stale-state.js";
+import {
+	loadAccounts,
+	saveAccounts,
+	setStoragePathDirect,
+} from "../../lib/storage.js";
+import { promises as fsp } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 const FAMILY: ModelFamily = "codex";
 const NOW = 1_700_000_000_000;
@@ -334,3 +342,80 @@ describe("chaos/doctor-recovery — real manager + real recovery helpers (issue 
 	});
 });
 
+describe("chaos/doctor-recovery — single-account + disabled dup, real save/load (issue #171)", () => {
+	let dir: string;
+
+	afterEach(async () => {
+		setStoragePathDirect(null);
+		if (dir) await fsp.rm(dir, { recursive: true, force: true });
+	});
+
+	it("recovers a lone org account whose disabled token-dup merged in", async () => {
+		dir = await fsp.mkdtemp(join(tmpdir(), "ralph171-"));
+		setStoragePathDirect(join(dir, "oc-codex-multi-auth-accounts.json"));
+		const FUTURE = Date.now() + 3_600_000;
+
+		// Reporter shape reduced to a single real account: an org account in
+		// auth-failure cooldown, plus a disabled token-source duplicate (same
+		// email) minted by a fresh re-login. Before the merge fix this collapsed
+		// to ONE disabled account that neither doctor nor health could recover.
+		await saveAccounts({
+			version: 3,
+			activeIndex: 0,
+			accounts: [
+				{
+					accountId: "org-AAA",
+					organizationId: "org-AAA",
+					accountIdSource: "org",
+					email: "user@example.com",
+					refreshToken: "OLD-refresh",
+					addedAt: 100,
+					lastUsed: 200,
+					coolingDownUntil: FUTURE,
+					cooldownReason: "auth-failure",
+				},
+				{
+					accountId: "uuid-fresh",
+					accountIdSource: "token",
+					email: "user@example.com",
+					refreshToken: "FRESH-refresh",
+					addedAt: 999,
+					lastUsed: 999,
+					enabled: false,
+				},
+			],
+		});
+
+		// Merge on load: ONE enabled org account, dark (cooldown active).
+		const loaded = await loadAccounts();
+		expect(loaded?.accounts).toHaveLength(1);
+		const acct = loaded!.accounts[0]!;
+		expect(acct.enabled).not.toBe(false);
+		const before = new AccountManager(undefined, loaded!);
+		expect(
+			before
+				.getSelectionExplainability(FAMILY, "gpt-5.4-mini", Date.now())
+				.filter((e) => e.eligible).length,
+		).toBe(0);
+		before.disposeShutdownHandler();
+
+		// codex-doctor --fix: refresh enabled accounts, clear stale state, persist.
+		const refreshable = loaded!.accounts.filter((a) => a.enabled !== false);
+		expect(refreshable).toHaveLength(1);
+		for (const a of refreshable) a.refreshToken = "NEW-" + a.refreshToken;
+		clearRefreshedAccountsStaleState(refreshable);
+		await saveAccounts(loaded!);
+
+		// After restart: pool is eligible again.
+		const after = await loadAccounts();
+		const mgr = new AccountManager(undefined, after!);
+		const eligible = mgr
+			.getSelectionExplainability(FAMILY, "gpt-5.4-mini", Date.now())
+			.filter((e) => e.eligible).length;
+		expect(eligible).toBe(1);
+		const selected = mgr.getCurrentOrNextForFamilyHybrid(FAMILY, "gpt-5.4-mini");
+		expect(selected?.organizationId).toBe("org-AAA");
+		expect(mgr.isAccountCoolingDown(selected as NonNullable<Active>)).toBe(false);
+		mgr.disposeShutdownHandler();
+	});
+});

--- a/test/chaos/doctor-recovery-171-stress.test.ts
+++ b/test/chaos/doctor-recovery-171-stress.test.ts
@@ -346,6 +346,9 @@ describe("chaos/doctor-recovery — single-account + disabled dup, real save/loa
 	let dir: string;
 
 	afterEach(async () => {
+		while (liveManagers.length > 0) {
+			liveManagers.pop()?.disposeShutdownHandler();
+		}
 		setStoragePathDirect(null);
 		if (dir) await fsp.rm(dir, { recursive: true, force: true });
 	});
@@ -391,13 +394,12 @@ describe("chaos/doctor-recovery — single-account + disabled dup, real save/loa
 		expect(loaded?.accounts).toHaveLength(1);
 		const acct = loaded!.accounts[0]!;
 		expect(acct.enabled).not.toBe(false);
-		const before = new AccountManager(undefined, loaded!);
+		const before = makeManager(loaded!);
 		expect(
 			before
 				.getSelectionExplainability(FAMILY, "gpt-5.4-mini", Date.now())
 				.filter((e) => e.eligible).length,
 		).toBe(0);
-		before.disposeShutdownHandler();
 
 		// codex-doctor --fix: refresh enabled accounts, clear stale state, persist.
 		const refreshable = loaded!.accounts.filter((a) => a.enabled !== false);
@@ -408,7 +410,7 @@ describe("chaos/doctor-recovery — single-account + disabled dup, real save/loa
 
 		// After restart: pool is eligible again.
 		const after = await loadAccounts();
-		const mgr = new AccountManager(undefined, after!);
+		const mgr = makeManager(after!);
 		const eligible = mgr
 			.getSelectionExplainability(FAMILY, "gpt-5.4-mini", Date.now())
 			.filter((e) => e.eligible).length;
@@ -416,6 +418,5 @@ describe("chaos/doctor-recovery — single-account + disabled dup, real save/loa
 		const selected = mgr.getCurrentOrNextForFamilyHybrid(FAMILY, "gpt-5.4-mini");
 		expect(selected?.organizationId).toBe("org-AAA");
 		expect(mgr.isAccountCoolingDown(selected as NonNullable<Active>)).toBe(false);
-		mgr.disposeShutdownHandler();
 	});
 });

--- a/test/storage.test.ts
+++ b/test/storage.test.ts
@@ -316,6 +316,75 @@ describe("storage", () => {
       expect(loaded?.activeIndexByFamily?.codex).toBe(0);
     });
 
+    // Issue #171: a disabled token-source duplicate (a plugin re-login artifact)
+    // must NOT disable the real org account it collapses into during dedup.
+    it("keeps the org account enabled when a disabled token-source duplicate merges in (#171)", async () => {
+      const now = Date.now();
+      await saveAccounts({
+        version: 3,
+        activeIndex: 0,
+        accounts: [
+          {
+            accountId: "org-AAA",
+            organizationId: "org-AAA",
+            accountIdSource: "org",
+            email: "user@example.com",
+            refreshToken: "OLD-refresh",
+            addedAt: 100,
+            lastUsed: 200,
+            coolingDownUntil: now + 3_600_000,
+            cooldownReason: "auth-failure",
+          },
+          {
+            accountId: "uuid-fresh",
+            accountIdSource: "token",
+            email: "user@example.com",
+            refreshToken: "FRESH-refresh",
+            addedAt: 999,
+            lastUsed: 999,
+            enabled: false,
+          },
+        ],
+      });
+      const loaded = await loadAccounts();
+      expect(loaded?.accounts).toHaveLength(1);
+      const survivor = loaded!.accounts[0]!;
+      expect(survivor.organizationId).toBe("org-AAA");
+      // The real account must remain routable: NOT disabled by the dup.
+      expect(survivor.enabled).not.toBe(false);
+      // And it carries the fresh token from the newer (dup) record.
+      expect(survivor.refreshToken).toBe("FRESH-refresh");
+    });
+
+    it("preserves fail-closed when a same-identity record was user-disabled (#171 guard)", async () => {
+      await saveAccounts({
+        version: 3,
+        activeIndex: 0,
+        accounts: [
+          { accountId: "org-X", organizationId: "org-X", accountIdSource: "org", email: "u@e.com", refreshToken: "RT", addedAt: 100, lastUsed: 100, enabled: false },
+          { accountId: "org-X", organizationId: "org-X", accountIdSource: "org", email: "u@e.com", refreshToken: "RT", addedAt: 200, lastUsed: 200, enabled: true },
+        ],
+      });
+      const loaded = await loadAccounts();
+      expect(loaded?.accounts).toHaveLength(1);
+      // User intent wins: a genuinely disabled real account stays disabled.
+      expect(loaded!.accounts[0]!.enabled).toBe(false);
+    });
+
+    it("keeps two distinct real org accounts both enabled (no merge regression)", async () => {
+      await saveAccounts({
+        version: 3,
+        activeIndex: 0,
+        accounts: [
+          { accountId: "org-1", organizationId: "org-1", accountIdSource: "org", email: "a@e.com", refreshToken: "R1", addedAt: 100, lastUsed: 100, enabled: true },
+          { accountId: "org-2", organizationId: "org-2", accountIdSource: "org", email: "b@e.com", refreshToken: "R2", addedAt: 100, lastUsed: 100, enabled: true },
+        ],
+      });
+      const loaded = await loadAccounts();
+      expect(loaded?.accounts).toHaveLength(2);
+      expect(loaded!.accounts.every((a) => a.enabled !== false)).toBe(true);
+    });
+
     it("retains per-account rate-limit and cooldown metadata through save/load round-trip", async () => {
       await saveAccounts({
         version: 3,


### PR DESCRIPTION
## Summary

Closes the **last** #171 recovery gap — found by testing the *real* persisted path, not just in-memory state. When storage dedup collapses a disabled `accountIdSource:"token"` duplicate (a plugin re-login artifact) into the matching real org-source account by email, the survivor inherited `enabled:false`. Combined with `codex-doctor`/`codex-health` skipping disabled accounts (the guard added in #177), a **single-real-account pool could end up dark and unrecoverable** — no automatic path back.

## Root cause

`lib/storage/identity.ts` `mergeAccountRecords` had **no `enabled` resolution** — the flag fell through the `{...older, ...newest}` spread, and the disabled token-dup (often the newest by `lastUsed`) won.

## Fix

Add `resolveMergedEnabled(target, source)`:
- When exactly one side is **org-like** (`organizationId` present OR `accountIdSource==="org"`) and the other is a **token-source duplicate**, the org account's own `enabled` governs — a re-login artifact can never disable a real account.
- Every other shape stays **fail-closed** (either disabled ⇒ disabled), preserving user-disable intent and the same-identity merge semantics behind #64 (multi-org) and #85 (workspace preservation).

## Why this is the only place the bug lives (architect-reviewed)

`login-runner.ts mergeStoredAccountPair` only merges **exact-identity** collisions — a token-dup (no `organizationId`, keyed in the `email:` namespace) and the real org account (keyed in the `org:` namespace) never collide there. It's also backstopped: every persist re-runs this fixed dedup via `normalizeAccountStorage`. So `identity.ts` is the single chokepoint, and the fix is there.

## Tests
- `test/storage.test.ts`: token-dup does not disable the org account (fresh token carried); fail-closed preserved for a user-disabled same-identity record; two distinct real org accounts both stay enabled (no #64/#85 regression).
- `test/chaos/doctor-recovery-171-stress.test.ts`: the single-account + disabled-dup scenario recovers **end-to-end** through real `saveAccounts`/`loadAccounts` + the recovery helpers.
- **Mutation teeth-check**: reverting `resolveMergedEnabled` fails the merge test.

## Verification
- Full suite: **2542 passed**, 1 skipped. `tsc --noEmit`, `eslint`, `npm run build` clean. `npm audit`: 0 vulnerabilities.

With this, the #171 recovery is reliable for **both** multi-account and single-account pools, the previously-stuck case included.

Relates to #171. Builds on #173/#175/#177/#178/#179.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved account deduplication logic to correctly preserve enabled/disabled states when merging duplicate accounts, preventing unintended account lockouts during recovery operations

* **Tests**
  * Added comprehensive test coverage for account deduplication behavior and recovery scenarios to ensure reliability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---


<h3>Greptile Summary</h3>

fixes the last recovery gap from #171: `mergeAccountRecords` now calls `resolveMergedEnabled` to explicitly set the `enabled` flag instead of letting the spread carry in the token-dup's `enabled: false`, which could make a single-account pool permanently dark and unrecoverable.

- **`lib/storage/identity.ts`**: adds `isOrgLikeAccount` and `resolveMergedEnabled` — org account's own `enabled` governs when exactly one side is org-like and the other is a token-source dup; every other shape stays fail-closed.
- **`test/storage.test.ts`**: three new unit cases cover the happy path, the fail-closed guard, and the two-distinct-orgs no-regression scenario.
- **`test/chaos/doctor-recovery-171-stress.test.ts`**: new end-to-end stress describe exercises real `saveAccounts`/`loadAccounts` + doctor helpers for the single-account + disabled-dup scenario; the shutdown-listener leak flagged in the previous review is also addressed here.

<h3>Confidence Score: 5/5</h3>

safe to merge — the fix is surgical, isolated to `mergeAccountRecords`, and both dedup call-sites (`deduplicateAccountsByKey` and `deduplicateLegacyRefreshTokenDuplicates`) are correctly covered by the new `resolveMergedEnabled` logic.

the `resolveMergedEnabled` function handles all four shapes (org+tokenDup, tokenDup+org, same-identity, two-real-orgs), including the edge case where the token dup is the newer record and becomes `target` in the exact-key dedup path. the explicit `enabled:` assignment in the return object of `mergeAccountRecords` correctly overrides whatever the `...newest` spread would have propagated. no concurrency or windows filesystem concerns introduced. test coverage is solid for the main paths; the one untested branch (disabled org account + token-dup merge) was already noted in a prior review.

no files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| lib/storage/identity.ts | adds `resolveMergedEnabled` and `isOrgLikeAccount` helpers; `mergeAccountRecords` now explicitly resolves the `enabled` flag instead of letting the spread overwrite it — the core bug fix for #171 |
| test/storage.test.ts | adds three new cases for `resolveMergedEnabled` behaviour: disabled token-dup does not disable the org survivor, fail-closed on same-identity disable, and two distinct orgs stay enabled; the disabled-org + token-dup merge path remains untested (carried from prior review) |
| test/chaos/doctor-recovery-171-stress.test.ts | new describe exercises the full save → load → doctor-fix → reload cycle for the single-account + disabled-dup scenario; managers now routed through `makeManager()` + `liveManagers`, fixing the shutdown-listener leak noted in the previous review |

</details>



<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[deduplicateAccountsForStorage] --> B[deduplicateAccountsByKey\nexact identity key collisions]
    B --> C[deduplicateLegacyRefreshTokenDuplicates\norg + token-dup, matched by email]
    C --> D[deduplicateAccountsByEmail\nlegacy no-id email dedup]

    C -->|org vs token-dup detected| E[mergeAccountRecords\ntarget=org, source=tokenDup]
    E --> F{resolveMergedEnabled}
    F -->|targetOrgLike && sourceTokenDup| G[return target.enabled\norg account governs ✓]
    F -->|sourceOrgLike && targetTokenDup| H[return source.enabled\norg account governs ✓]
    F -->|same-identity / two real orgs| I[fail-closed:\neither false → false\notherwise target ?? source]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[deduplicateAccountsForStorage] --> B[deduplicateAccountsByKey\nexact identity key collisions]
    B --> C[deduplicateLegacyRefreshTokenDuplicates\norg + token-dup, matched by email]
    C --> D[deduplicateAccountsByEmail\nlegacy no-id email dedup]

    C -->|org vs token-dup detected| E[mergeAccountRecords\ntarget=org, source=tokenDup]
    E --> F{resolveMergedEnabled}
    F -->|targetOrgLike && sourceTokenDup| G[return target.enabled\norg account governs ✓]
    F -->|sourceOrgLike && targetTokenDup| H[return source.enabled\norg account governs ✓]
    F -->|same-identity / two real orgs| I[fail-closed:\neither false → false\notherwise target ?? source]
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `test/storage.test.ts`, line 357-393 ([link](https://github.com/ndycode/oc-codex-multi-auth/blob/f5836a41fe57f0b285ceb85a183272128721c7c2/test/storage.test.ts#L357-L393)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **missing vitest coverage: org account explicitly disabled + token-dup merge**

   no test covers an org account with `enabled: false` merging with a token dup. `resolveMergedEnabled` correctly returns `target.enabled = false` there, but the mutation teeth-check the PR mentions won’t catch a regression in that branch — e.g. if `targetOrgLike && sourceTokenDup` accidentally returns `source.enabled` instead.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: test/storage.test.ts
   Line: 357-393

   Comment:
   **missing vitest coverage: org account explicitly disabled + token-dup merge**

   no test covers an org account with `enabled: false` merging with a token dup. `resolveMergedEnabled` correctly returns `target.enabled = false` there, but the mutation teeth-check the PR mentions won’t catch a regression in that branch — e.g. if `targetOrgLike && sourceTokenDup` accidentally returns `source.enabled` instead.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Foc-codex-multi-auth%22%20on%20the%20existing%20branch%20%22fix%2Fissue-171-merge-disable-gap%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fissue-171-merge-disable-gap%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20test%2Fstorage.test.ts%0ALine%3A%20357-393%0A%0AComment%3A%0A**missing%20vitest%20coverage%3A%20org%20account%20explicitly%20disabled%20%2B%20token-dup%20merge**%0A%0Ano%20test%20covers%20an%20org%20account%20with%20%60enabled%3A%20false%60%20merging%20with%20a%20token%20dup.%20%60resolveMergedEnabled%60%20correctly%20returns%20%60target.enabled%20%3D%20false%60%20there%2C%20but%20the%20mutation%20teeth-check%20the%20PR%20mentions%20won%E2%80%99t%20catch%20a%20regression%20in%20that%20branch%20%E2%80%94%20e.g.%20if%20%60targetOrgLike%20%26%26%20sourceTokenDup%60%20accidentally%20returns%20%60source.enabled%60%20instead.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=ndycode%2Foc-codex-multi-auth&pr=180&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["test: route #171 composite managers thro..."](https://github.com/ndycode/oc-codex-multi-auth/commit/1927672789ef61838a7afe331db866597e0d6f75) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38631026)</sub>

<!-- /greptile_comment -->