### PR TITLE
fix(prompts): source system instructions from the Codex model catalog

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -59,7 +59,21 @@ GPT-5.6 notes:
 - `max` and `ultra` are new in 5.6. Requesting them on an older family steps down to `xhigh` (then `high` where xhigh is unsupported).
 - `ultra` is a client-side tier. Codex rewrites it to `max` before the request leaves the client, and the subagent orchestration that distinguishes ultra lives in the Codex client rather than the request body. This plugin is a proxy, so `-ultra` is accepted as an alias and sent on the wire as `max` — it does **not** spawn subagents.
 - 5.6 is opt-in: the legacy `gpt-5` alias and the plugin default still resolve to `gpt-5.5` / `gpt-5.4`. Because 5.6 shipped as a limited preview, an account without access falls back down the 5.6 tiers and then to `gpt-5.5`. The lite shape is applied per request attempt, so a request that falls back from `gpt-5.6-sol` to `gpt-5.5` is re-serialized into the classic shape and keeps its tools.
-- Instructions for the 5.6 tiers come from the Codex model catalog (`base_instructions` in `codex-rs/models-manager/models.json`), not from a `*_prompt.md` file — upstream ships none for 5.6, and Sol, Terra, and Luna each carry distinct text. If the pinned Codex release predates a tier, the plugin falls back to that family's prompt file.
+- Instructions for the 5.6 tiers come from the Codex model catalog — see "System instructions" below.
+
+### System instructions
+
+Modern Codex carries a full `base_instructions` string **per model** in its catalog (`base_instructions` in `codex-rs/models-manager/models.json`) and sends that, rather than the legacy `*_prompt.md` files. The plugin sources instructions from the catalog for every model the catalog covers:
+
+| Model | Instruction source |
+|-------|--------------------|
+| `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna` | catalog (each tier has distinct text) |
+| `gpt-5.5` | catalog |
+| `gpt-5.4`, `gpt-5.4-mini` | catalog |
+| `gpt-5.2` | catalog |
+| `gpt-5-codex`, `gpt-5.1*`, `gpt-5.2-codex`, `gpt-5.4-nano`, `gpt-5.4-pro` | `*_prompt.md` file (absent from the catalog) |
+
+Catalog-sourced instructions cache per model id (`catalog-<slug>-instructions.md`); file-sourced instructions keep the historical per-family cache. This matters because `gpt-5.5` and `gpt-5.4` share the `gpt-5.4` family but have different catalog text — a family-keyed cache would let one serve the other's prompt. `models.json` is fetched once per release tag and shared across models. If the pinned Codex release has no catalog entry for a model, the plugin falls back to that family's prompt file.
 
 For context sizing, shipped templates use:
 - `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna`: `context=1050000`, `output=128000`

--- a/lib/prompts/codex.ts
+++ b/lib/prompts/codex.ts
@@ -18,7 +18,7 @@ const __dirname = dirname(__filename);
 
 const MAX_CACHE_SIZE = 50;
 const memoryCache = new Map<string, { content: string; timestamp: number }>();
-const refreshPromises = new Map<ModelFamily, Promise<void>>();
+const refreshPromises = new Map<string, Promise<void>>();
 const RELEASE_TAG_TTL_MS = 5 * 60 * 1000;
 let latestReleaseTagCache: { tag: string; checkedAt: number } | null = null;
 
@@ -29,6 +29,7 @@ let latestReleaseTagCache: { tag: string; checkedAt: number } | null = null;
 export function __clearCacheForTesting(): void {
 	memoryCache.clear();
 	refreshPromises.clear();
+	catalogMemo = null;
 	latestReleaseTagCache = null;
 }
 
@@ -118,22 +119,100 @@ const CACHE_FILES: Record<ModelFamily, string> = {
 };
 
 /**
- * Model families whose base instructions live in the Codex model catalog
+ * Canonical model ids whose base instructions live in the Codex model catalog
  * (`codex-rs/models-manager/models.json`) rather than in a `*_prompt.md` file.
  *
- * openai/codex ships no 5.6 prompt file. Each 5.6 tier instead carries a full
- * `base_instructions` string in the catalog, and the three tiers do NOT share
- * it — Sol, Terra, and Luna each have distinct text. Falling back to
- * `gpt_5_2_prompt.md` would tell a 5.6 model it is "GPT-5.2 running in the
- * Codex CLI", so the catalog is the only correct source here.
+ * Modern Codex carries a full `base_instructions` string per model in the
+ * catalog and sends that, not the legacy prompt files. The two differ
+ * substantially: `gpt_5_2_prompt.md` opens "You are GPT-5.2 running in the
+ * Codex CLI", while every catalog entry opens "You are Codex, ... based on
+ * GPT-5". Models absent from the catalog (gpt-5-codex, gpt-5.1*, gpt-5.4-nano,
+ * gpt-5.4-pro, gpt-5.2-codex) still use their prompt file.
+ *
+ * Keyed by model id, not by family: `gpt-5.5` and `gpt-5.4` share the
+ * `gpt-5.4` family but have different catalog text, so a family-keyed cache
+ * would let one poison the other.
  */
-const CATALOG_MODEL_SLUGS: Partial<Record<ModelFamily, string>> = {
-	"gpt-5.6-sol": "gpt-5.6-sol",
-	"gpt-5.6-terra": "gpt-5.6-terra",
-	"gpt-5.6-luna": "gpt-5.6-luna",
-};
+const CATALOG_SLUGS: ReadonlySet<string> = new Set([
+	"gpt-5.2",
+	"gpt-5.4",
+	"gpt-5.4-mini",
+	"gpt-5.5",
+	"gpt-5.6-sol",
+	"gpt-5.6-terra",
+	"gpt-5.6-luna",
+]);
 
 const CATALOG_PATH = "codex-rs/models-manager/models.json";
+
+/**
+ * Where one model's instructions come from, and where they are cached.
+ *
+ * Catalog-sourced instructions cache per model id; file-sourced instructions
+ * cache per family, preserving the historical layout.
+ */
+interface InstructionSource {
+	/** Memory-cache and in-flight-refresh key. */
+	key: string;
+	cacheFile: string;
+	cacheMetaFile: string;
+	/** Prompt file: the source for non-catalog models, and the catalog fallback. */
+	promptFile: string;
+	/** Set when the model has catalog `base_instructions`. */
+	catalogSlug?: string;
+}
+
+function resolveInstructionSource(normalizedModel: string): InstructionSource {
+	const modelFamily = getModelFamily(normalizedModel);
+	const promptFile = PROMPT_FILES[modelFamily];
+	const slug = normalizedModel.toLowerCase();
+	const catalogSlug = CATALOG_SLUGS.has(slug) ? slug : undefined;
+
+	// Distinct filenames keep catalog content from being served out of a disk
+	// cache written by the older prompt-file source, and vice versa.
+	const baseName = catalogSlug
+		? `catalog-${catalogSlug}-instructions.md`
+		: CACHE_FILES[modelFamily];
+
+	// Namespace the key: slug-space and family-space overlap. `gpt-5.4-nano` has
+	// no catalog entry and belongs to the `gpt-5.4` family, which is also a
+	// catalog slug — an un-namespaced key would let nano and gpt-5.4 serve each
+	// other's instructions out of memoryCache/refreshPromises. Same for bare
+	// `gpt-5.6` (family `gpt-5.6-sol`) against the `gpt-5.6-sol` slug.
+	const key = catalogSlug ? `catalog:${catalogSlug}` : `family:${modelFamily}`;
+
+	return {
+		key,
+		cacheFile: join(CACHE_DIR, baseName),
+		cacheMetaFile: join(CACHE_DIR, baseName.replace(".md", "-meta.json")),
+		promptFile,
+		catalogSlug,
+	};
+}
+
+/**
+ * models.json is ~300KB and shared by every catalog-sourced model, so fetch it
+ * once per release tag instead of once per model.
+ */
+let catalogMemo: { tag: string; text: string; timestamp: number } | null = null;
+
+async function fetchCatalogText(tag: string): Promise<string> {
+	const now = Date.now();
+	if (catalogMemo && catalogMemo.tag === tag && now - catalogMemo.timestamp < CACHE_TTL_MS) {
+		return catalogMemo.text;
+	}
+	const url = `https://raw.githubusercontent.com/openai/codex/${tag}/${CATALOG_PATH}`;
+	const response = await fetch(url);
+	if (!response.ok) {
+		throw new PromptError(`HTTP ${response.status}`, {
+			code: "HTTP_ERROR",
+			context: { status: response.status },
+		});
+	}
+	const text = await response.text();
+	catalogMemo = { tag, text, timestamp: now };
+	return text;
+}
 
 interface CatalogModelEntry {
 	slug?: string;
@@ -356,19 +435,13 @@ async function getLatestReleaseTag(): Promise<string> {
 export async function getCodexInstructions(
 	normalizedModel = "gpt-5-codex",
 ): Promise<string> {
-	const modelFamily = getModelFamily(normalizedModel);
+	const source = resolveInstructionSource(normalizedModel);
+	const { key, cacheFile, cacheMetaFile } = source;
 	const now = Date.now();
-	const cached = memoryCache.get(modelFamily);
+	const cached = memoryCache.get(key);
 	if (cached && now - cached.timestamp < CACHE_TTL_MS) {
 		return rewriteInstructionIdentity(cached.content, normalizedModel);
 	}
-
-	const promptFile = PROMPT_FILES[modelFamily];
-	const cacheFile = join(CACHE_DIR, CACHE_FILES[modelFamily]);
-	const cacheMetaFile = join(
-		CACHE_DIR,
-		`${CACHE_FILES[modelFamily].replace(".md", "-meta.json")}`,
-	);
 
 	let cachedMetadata: CacheMetadata | null = null;
 	const [metaContent, diskContent] = await Promise.all([
@@ -386,79 +459,89 @@ export async function getCodexInstructions(
 
 	if (diskContent && cachedMetadata?.lastChecked) {
 		if (now - cachedMetadata.lastChecked < CACHE_TTL_MS) {
-			setCacheEntry(modelFamily, { content: diskContent, timestamp: now });
+			setCacheEntry(key, { content: diskContent, timestamp: now });
 			return rewriteInstructionIdentity(diskContent, normalizedModel);
 		}
 		// Stale-while-revalidate: return stale cache immediately and refresh in background.
-		setCacheEntry(modelFamily, { content: diskContent, timestamp: now });
-		void refreshInstructionsInBackground(
-			modelFamily,
-			promptFile,
-			cacheFile,
-			cacheMetaFile,
-			cachedMetadata,
-		);
+		setCacheEntry(key, { content: diskContent, timestamp: now });
+		void refreshInstructionsInBackground(source, cachedMetadata);
 		return rewriteInstructionIdentity(diskContent, normalizedModel);
 	}
 
 	if (cached && now - cached.timestamp >= CACHE_TTL_MS) {
 		// Keep session latency stable by serving stale memory cache while refreshing.
-		setCacheEntry(modelFamily, { content: cached.content, timestamp: now });
-		void refreshInstructionsInBackground(
-			modelFamily,
-			promptFile,
-			cacheFile,
-			cacheMetaFile,
-			cachedMetadata,
-		);
+		setCacheEntry(key, { content: cached.content, timestamp: now });
+		void refreshInstructionsInBackground(source, cachedMetadata);
 		return rewriteInstructionIdentity(cached.content, normalizedModel);
 	}
 
 	try {
-		const instructions = await fetchAndPersistInstructions(
-			modelFamily,
-			promptFile,
-			cacheFile,
-			cacheMetaFile,
-			cachedMetadata,
-		);
+		const instructions = await fetchAndPersistInstructions(source, cachedMetadata);
 		return rewriteInstructionIdentity(instructions, normalizedModel);
 	} catch (error) {
 		const err = error as Error;
-		logError(
-			`Failed to fetch ${modelFamily} instructions from GitHub: ${err.message}`,
-		);
+		logError(`Failed to fetch ${key} instructions from GitHub: ${err.message}`);
 
 		if (diskContent) {
-			logWarn(`Using cached ${modelFamily} instructions`);
-			setCacheEntry(modelFamily, { content: diskContent, timestamp: now });
+			logWarn(`Using cached ${key} instructions`);
+			setCacheEntry(key, { content: diskContent, timestamp: now });
 			return rewriteInstructionIdentity(diskContent, normalizedModel);
 		}
 
-		logWarn(`Falling back to bundled instructions for ${modelFamily}`);
+		logWarn(`Falling back to bundled instructions for ${key}`);
 		const bundled = await fs.readFile(
 			join(__dirname, "codex-instructions.md"),
 			"utf8",
 		);
-		setCacheEntry(modelFamily, { content: bundled, timestamp: now });
+		setCacheEntry(key, { content: bundled, timestamp: now });
 		return rewriteInstructionIdentity(bundled, normalizedModel);
 	}
 }
 
+async function persistInstructions(
+	source: InstructionSource,
+	instructions: string,
+	meta: CacheMetadata,
+): Promise<string> {
+	await fs.mkdir(CACHE_DIR, { recursive: true });
+	await Promise.all([
+		fs.writeFile(source.cacheFile, instructions, "utf8"),
+		fs.writeFile(source.cacheMetaFile, JSON.stringify(meta), "utf8"),
+	]);
+	setCacheEntry(source.key, { content: instructions, timestamp: Date.now() });
+	return instructions;
+}
+
 async function fetchAndPersistInstructions(
-	modelFamily: ModelFamily,
-	promptFile: string,
-	cacheFile: string,
-	cacheMetaFile: string,
+	source: InstructionSource,
 	cachedMetadata: CacheMetadata | null,
 ): Promise<string> {
+	const { key, cacheFile, promptFile, catalogSlug } = source;
+	const latestTag = await getLatestReleaseTag();
+
+	if (catalogSlug) {
+		const catalogUrl = `https://raw.githubusercontent.com/openai/codex/${latestTag}/${CATALOG_PATH}`;
+		const fromCatalog = extractCatalogInstructions(
+			await fetchCatalogText(latestTag),
+			catalogSlug,
+		);
+		if (fromCatalog) {
+			return persistInstructions(source, fromCatalog, {
+				etag: null,
+				tag: latestTag,
+				lastChecked: Date.now(),
+				url: catalogUrl,
+			});
+		}
+		// The pinned release predates this model; fall through to the prompt file.
+		logWarn(
+			`No catalog entry for ${catalogSlug} at ${latestTag}; falling back to ${promptFile}`,
+		);
+	}
+
 	let cachedETag = cachedMetadata?.etag ?? null;
 	const cachedTag = cachedMetadata?.tag ?? null;
-	const latestTag = await getLatestReleaseTag();
-	const catalogSlug = CATALOG_MODEL_SLUGS[modelFamily];
-	const instructionsUrl = catalogSlug
-		? `https://raw.githubusercontent.com/openai/codex/${latestTag}/${CATALOG_PATH}`
-		: `https://raw.githubusercontent.com/openai/codex/${latestTag}/codex-rs/core/${promptFile}`;
+	const instructionsUrl = `https://raw.githubusercontent.com/openai/codex/${latestTag}/codex-rs/core/${promptFile}`;
 
 	if (cachedTag !== latestTag) {
 		cachedETag = null;
@@ -473,10 +556,10 @@ async function fetchAndPersistInstructions(
 	if (response.status === 304) {
 		const diskContent = await readFileOrNull(cacheFile);
 		if (diskContent) {
-			setCacheEntry(modelFamily, { content: diskContent, timestamp: Date.now() });
+			setCacheEntry(key, { content: diskContent, timestamp: Date.now() });
 			await fs.mkdir(CACHE_DIR, { recursive: true });
 			await fs.writeFile(
-				cacheMetaFile,
+				source.cacheMetaFile,
 				JSON.stringify(
 					{
 						etag: cachedETag,
@@ -498,78 +581,33 @@ async function fetchAndPersistInstructions(
 		});
 	}
 
-	const payload = await response.text();
-	let instructions = payload;
-	if (catalogSlug) {
-		const fromCatalog = extractCatalogInstructions(payload, catalogSlug);
-		if (fromCatalog) {
-			instructions = fromCatalog;
-		} else {
-			// The pinned release predates this model. Fall back to the family's
-			// prompt file rather than persisting a whole models.json as a prompt.
-			logWarn(
-				`No catalog entry for ${catalogSlug} at ${latestTag}; falling back to ${promptFile}`,
-			);
-			const fallbackUrl = `https://raw.githubusercontent.com/openai/codex/${latestTag}/codex-rs/core/${promptFile}`;
-			const fallbackResponse = await fetch(fallbackUrl);
-			if (!fallbackResponse.ok) {
-				throw new PromptError(`HTTP ${fallbackResponse.status}`, {
-					code: "HTTP_ERROR",
-					context: { status: fallbackResponse.status },
-				});
-			}
-			instructions = await fallbackResponse.text();
-		}
-	}
-	const newETag = response.headers.get("etag");
-	await fs.mkdir(CACHE_DIR, { recursive: true });
-	await Promise.all([
-		fs.writeFile(cacheFile, instructions, "utf8"),
-		fs.writeFile(
-			cacheMetaFile,
-			JSON.stringify(
-				{
-					etag: newETag,
-					tag: latestTag,
-					lastChecked: Date.now(),
-					url: instructionsUrl,
-				} satisfies CacheMetadata,
-			),
-			"utf8",
-		),
-	]);
-	setCacheEntry(modelFamily, { content: instructions, timestamp: Date.now() });
-	return instructions;
+	return persistInstructions(source, await response.text(), {
+		etag: response.headers.get("etag"),
+		tag: latestTag,
+		lastChecked: Date.now(),
+		url: instructionsUrl,
+	});
 }
 
 function refreshInstructionsInBackground(
-	modelFamily: ModelFamily,
-	promptFile: string,
-	cacheFile: string,
-	cacheMetaFile: string,
+	source: InstructionSource,
 	cachedMetadata: CacheMetadata | null,
 ): Promise<void> {
-	const existing = refreshPromises.get(modelFamily);
+	const existing = refreshPromises.get(source.key);
 	if (existing) return existing;
 
-	const refreshPromise = fetchAndPersistInstructions(
-		modelFamily,
-		promptFile,
-		cacheFile,
-		cacheMetaFile,
-		cachedMetadata,
-	)
+	const refreshPromise = fetchAndPersistInstructions(source, cachedMetadata)
 		.then(() => undefined)
 		.catch((error) => {
-			logDebug(`Background prompt refresh failed for ${modelFamily}`, {
+			logDebug(`Background prompt refresh failed for ${source.key}`, {
 				error: String(error),
 			});
 		})
 		.finally(() => {
-			refreshPromises.delete(modelFamily);
+			refreshPromises.delete(source.key);
 		});
 
-	refreshPromises.set(modelFamily, refreshPromise);
+	refreshPromises.set(source.key, refreshPromise);
 	return refreshPromise;
 }
 

--- a/lib/prompts/codex.ts
+++ b/lib/prompts/codex.ts
@@ -30,6 +30,7 @@ export function __clearCacheForTesting(): void {
 	memoryCache.clear();
 	refreshPromises.clear();
 	catalogMemo = null;
+	catalogInflight = null;
 	latestReleaseTagCache = null;
 }
 
@@ -196,22 +197,49 @@ function resolveInstructionSource(normalizedModel: string): InstructionSource {
  */
 let catalogMemo: { tag: string; text: string; timestamp: number } | null = null;
 
+/**
+ * In-flight fetch, shared by callers that arrive before the first one resolves.
+ *
+ * Without this, `prewarmCodexInstructions` — which fires every catalog model
+ * concurrently via `void getCodexInstructions(...)` — would have each of them
+ * miss the (not yet populated) memo and download models.json independently.
+ */
+let catalogInflight: { tag: string; promise: Promise<string> } | null = null;
+
 async function fetchCatalogText(tag: string): Promise<string> {
 	const now = Date.now();
 	if (catalogMemo && catalogMemo.tag === tag && now - catalogMemo.timestamp < CACHE_TTL_MS) {
 		return catalogMemo.text;
 	}
-	const url = `https://raw.githubusercontent.com/openai/codex/${tag}/${CATALOG_PATH}`;
-	const response = await fetch(url);
-	if (!response.ok) {
-		throw new PromptError(`HTTP ${response.status}`, {
-			code: "HTTP_ERROR",
-			context: { status: response.status },
-		});
+	if (catalogInflight && catalogInflight.tag === tag) {
+		return catalogInflight.promise;
 	}
-	const text = await response.text();
-	catalogMemo = { tag, text, timestamp: now };
-	return text;
+
+	const url = `https://raw.githubusercontent.com/openai/codex/${tag}/${CATALOG_PATH}`;
+	const promise = (async () => {
+		const response = await fetch(url);
+		if (!response.ok) {
+			throw new PromptError(`HTTP ${response.status}`, {
+				code: "HTTP_ERROR",
+				context: { status: response.status },
+			});
+		}
+		const text = await response.text();
+		// Only a successful fetch populates the memo; a failure leaves any prior
+		// value untouched and lets the next caller retry.
+		catalogMemo = { tag, text, timestamp: Date.now() };
+		return text;
+	})();
+
+	const entry = { tag, promise };
+	catalogInflight = entry;
+	try {
+		return await promise;
+	} finally {
+		if (catalogInflight === entry) {
+			catalogInflight = null;
+		}
+	}
 }
 
 interface CatalogModelEntry {

--- a/test/codex-prompts.test.ts
+++ b/test/codex-prompts.test.ts
@@ -578,7 +578,158 @@ describe("Codex Prompts Module", () => {
 					expect(rawGitHubCall?.[0]).toContain("gpt_5_codex_prompt.md");
 				});
 
-				it("should map gpt-5.4 prompts to the gpt_5_2 prompt file", async () => {
+				// Modern Codex sends per-model `base_instructions` from the model
+				// catalog. gpt_5_2_prompt.md would open "You are GPT-5.2 running in
+				// the Codex CLI", which is not what the backend expects for 5.4/5.5.
+				const catalogPayload = JSON.stringify({
+					models: [
+						{ slug: "gpt-5.4", base_instructions: "GPT54 CATALOG PROMPT" },
+						{ slug: "gpt-5.4-mini", base_instructions: "GPT54MINI CATALOG PROMPT" },
+						{ slug: "gpt-5.5", base_instructions: "GPT55 CATALOG PROMPT" },
+					],
+				});
+
+				it("should source gpt-5.4 instructions from the model catalog", async () => {
+					mockedReadFile.mockRejectedValue(new Error("ENOENT"));
+					mockFetch.mockResolvedValue({
+						ok: true,
+						json: () => Promise.resolve({ tag_name: "rust-v0.111.0" }),
+						text: () => Promise.resolve(catalogPayload),
+						headers: { get: () => "etag" },
+					});
+					mockedMkdir.mockResolvedValue(undefined);
+					mockedWriteFile.mockResolvedValue(undefined);
+
+					const result = await getCodexInstructions("gpt-5.4");
+					const fetchCalls = mockFetch.mock.calls;
+					const rawGitHubCall = fetchCalls.find(
+						(call) =>
+							typeof call[0] === "string" &&
+							call[0].includes("raw.githubusercontent.com"),
+					);
+					expect(rawGitHubCall?.[0]).toContain("models-manager/models.json");
+					expect(result).toContain("GPT54 CATALOG PROMPT");
+					// No prompt-file fetch when the catalog has the slug.
+					expect(
+						fetchCalls.some(
+							(call) =>
+								typeof call[0] === "string" && call[0].includes("gpt_5_2_prompt.md"),
+						),
+					).toBe(false);
+				});
+
+				it("should give gpt-5.5 its own catalog text and cache file, not gpt-5.4's", async () => {
+					mockedReadFile.mockRejectedValue(new Error("ENOENT"));
+					mockFetch.mockResolvedValue({
+						ok: true,
+						json: () => Promise.resolve({ tag_name: "rust-v0.111.0" }),
+						text: () => Promise.resolve(catalogPayload),
+						headers: { get: () => "etag" },
+					});
+					mockedMkdir.mockResolvedValue(undefined);
+					mockedWriteFile.mockResolvedValue(undefined);
+
+					// gpt-5.5 and gpt-5.4 share the `gpt-5.4` model family, so a
+					// family-keyed cache would let one serve the other's prompt.
+					const result = await getCodexInstructions("gpt-5.5");
+					expect(result).toContain("GPT55 CATALOG PROMPT");
+					expect(result).not.toContain("GPT54 CATALOG PROMPT");
+
+					const writeTargets = mockedWriteFile.mock.calls.map(([target]) =>
+						String(target),
+					);
+					expect(
+						writeTargets.some((target) =>
+							target.includes("catalog-gpt-5.5-instructions.md"),
+						),
+					).toBe(true);
+					expect(
+						writeTargets.some((target) =>
+							target.includes("catalog-gpt-5.4-instructions.md"),
+						),
+					).toBe(false);
+				});
+
+				// Regression: slug-space and family-space overlap. gpt-5.4-nano has no
+				// catalog entry and lives in the `gpt-5.4` family, which IS a catalog
+				// slug. An un-namespaced cache key let them serve each other's
+				// instructions in-process within the TTL window.
+				it("should not serve gpt-5.4 catalog text to gpt-5.4-nano within one TTL", async () => {
+					mockedReadFile.mockRejectedValue(new Error("ENOENT"));
+					mockFetch.mockImplementation((url: unknown) => {
+						const href = String(url);
+						const body = href.includes("models.json")
+							? catalogPayload
+							: "PROMPT FILE CONTENT";
+						return Promise.resolve({
+							ok: true,
+							json: () => Promise.resolve({ tag_name: "rust-v0.111.0" }),
+							text: () => Promise.resolve(body),
+							headers: { get: () => "etag" },
+						});
+					});
+					mockedMkdir.mockResolvedValue(undefined);
+					mockedWriteFile.mockResolvedValue(undefined);
+
+					// Warm the catalog entry first, exactly as prewarmCodexInstructions does.
+					const catalogResult = await getCodexInstructions("gpt-5.4");
+					expect(catalogResult).toContain("GPT54 CATALOG PROMPT");
+
+					// nano must NOT pick up the memory-cached catalog text.
+					const nanoResult = await getCodexInstructions("gpt-5.4-nano");
+					expect(nanoResult).toContain("PROMPT FILE CONTENT");
+					expect(nanoResult).not.toContain("GPT54 CATALOG PROMPT");
+				});
+
+				it("should not let a prompt-file model poison a catalog model's cache", async () => {
+					mockedReadFile.mockRejectedValue(new Error("ENOENT"));
+					mockFetch.mockImplementation((url: unknown) => {
+						const href = String(url);
+						const body = href.includes("models.json")
+							? catalogPayload
+							: "PROMPT FILE CONTENT";
+						return Promise.resolve({
+							ok: true,
+							json: () => Promise.resolve({ tag_name: "rust-v0.111.0" }),
+							text: () => Promise.resolve(body),
+							headers: { get: () => "etag" },
+						});
+					});
+					mockedMkdir.mockResolvedValue(undefined);
+					mockedWriteFile.mockResolvedValue(undefined);
+
+					// Reverse order: nano first, then gpt-5.4.
+					const nanoResult = await getCodexInstructions("gpt-5.4-nano");
+					expect(nanoResult).toContain("PROMPT FILE CONTENT");
+
+					const catalogResult = await getCodexInstructions("gpt-5.4");
+					expect(catalogResult).toContain("GPT54 CATALOG PROMPT");
+					expect(catalogResult).not.toContain("PROMPT FILE CONTENT");
+				});
+
+				it("should fall back to the prompt file when the tag has no catalog entry", async () => {
+					mockedReadFile.mockRejectedValue(new Error("ENOENT"));
+					// Catalog without gpt-5.4 — simulates a release predating the slug.
+					mockFetch.mockResolvedValue({
+						ok: true,
+						json: () => Promise.resolve({ tag_name: "rust-v0.111.0" }),
+						text: () => Promise.resolve(JSON.stringify({ models: [] })),
+						headers: { get: () => "etag" },
+					});
+					mockedMkdir.mockResolvedValue(undefined);
+					mockedWriteFile.mockResolvedValue(undefined);
+
+					await getCodexInstructions("gpt-5.4");
+					const fetchCalls = mockFetch.mock.calls;
+					expect(
+						fetchCalls.some(
+							(call) =>
+								typeof call[0] === "string" && call[0].includes("gpt_5_2_prompt.md"),
+						),
+					).toBe(true);
+				});
+
+				it("should still use the prompt file for models absent from the catalog", async () => {
 					mockedReadFile.mockRejectedValue(new Error("ENOENT"));
 					mockFetch.mockResolvedValue({
 						ok: true,
@@ -589,14 +740,21 @@ describe("Codex Prompts Module", () => {
 					mockedMkdir.mockResolvedValue(undefined);
 					mockedWriteFile.mockResolvedValue(undefined);
 
-					await getCodexInstructions("gpt-5.4");
+					// gpt-5.1 has no catalog entry; it must not fetch models.json at all.
+					await getCodexInstructions("gpt-5.1");
 					const fetchCalls = mockFetch.mock.calls;
-					const rawGitHubCall = fetchCalls.find(
-						(call) =>
-							typeof call[0] === "string" &&
-							call[0].includes("raw.githubusercontent.com"),
-					);
-					expect(rawGitHubCall?.[0]).toContain("gpt_5_2_prompt.md");
+					expect(
+						fetchCalls.some(
+							(call) =>
+								typeof call[0] === "string" && call[0].includes("models.json"),
+						),
+					).toBe(false);
+					expect(
+						fetchCalls.some(
+							(call) =>
+								typeof call[0] === "string" && call[0].includes("gpt_5_1_prompt.md"),
+						),
+					).toBe(true);
 				});
 
 				it("should map gpt-5.4-pro prompts to gpt_5_2 prompt file with isolated cache key", async () => {
@@ -625,18 +783,18 @@ describe("Codex Prompts Module", () => {
 					).toBe(false);
 				});
 
-				it("should map gpt-5.4-mini prompts to gpt_5_2 prompt file with isolated cache key", async () => {
+				it("should source gpt-5.4-mini from the catalog with an isolated cache key", async () => {
 					mockedReadFile.mockRejectedValue(new Error("ENOENT"));
 					mockFetch.mockResolvedValue({
 						ok: true,
 						json: () => Promise.resolve({ tag_name: "rust-v0.111.0" }),
-						text: () => Promise.resolve("content"),
+						text: () => Promise.resolve(catalogPayload),
 						headers: { get: () => "etag" },
 					});
 					mockedMkdir.mockResolvedValue(undefined);
 					mockedWriteFile.mockResolvedValue(undefined);
 
-					await getCodexInstructions("gpt-5.4-mini");
+					const result = await getCodexInstructions("gpt-5.4-mini");
 					const fetchCalls = mockFetch.mock.calls;
 					const rawGitHubCall = fetchCalls.find(
 						(call) =>
@@ -644,10 +802,15 @@ describe("Codex Prompts Module", () => {
 							call[0].includes("raw.githubusercontent.com"),
 					);
 					const writeTargets = mockedWriteFile.mock.calls.map(([target]) => String(target));
-					expect(rawGitHubCall?.[0]).toContain("gpt_5_2_prompt.md");
-					expect(writeTargets.some((target) => target.includes("gpt-5.4-mini-instructions.md"))).toBe(true);
+					expect(rawGitHubCall?.[0]).toContain("models-manager/models.json");
+					expect(result).toContain("GPT54MINI CATALOG PROMPT");
 					expect(
-						writeTargets.some((target) => /gpt-5\.4-instructions\.md$/.test(target)),
+						writeTargets.some((target) =>
+							target.includes("catalog-gpt-5.4-mini-instructions.md"),
+						),
+					).toBe(true);
+					expect(
+						writeTargets.some((target) => /catalog-gpt-5\.4-instructions\.md$/.test(target)),
 					).toBe(false);
 					expect(
 						writeTargets.some((target) => /gpt-5\.4-pro-instructions\.md$/.test(target)),

--- a/test/codex-prompts.test.ts
+++ b/test/codex-prompts.test.ts
@@ -707,6 +707,57 @@ describe("Codex Prompts Module", () => {
 					expect(catalogResult).not.toContain("PROMPT FILE CONTENT");
 				});
 
+				// prewarmCodexInstructions fires every catalog model concurrently, so a
+				// memo that is only populated after the await lets each caller start
+				// its own ~300KB models.json download.
+				it("should fetch models.json once when catalog models are requested concurrently", async () => {
+					mockedReadFile.mockRejectedValue(new Error("ENOENT"));
+					let resolveCatalog: ((value: unknown) => void) | undefined;
+					const catalogGate = new Promise((resolve) => {
+						resolveCatalog = resolve;
+					});
+
+					mockFetch.mockImplementation((url: unknown) => {
+						const href = String(url);
+						if (href.includes("models.json")) {
+							// Hold the fetch open so every caller arrives before it resolves.
+							return catalogGate.then(() => ({
+								ok: true,
+								json: () => Promise.resolve({ tag_name: "rust-v0.111.0" }),
+								text: () => Promise.resolve(catalogPayload),
+								headers: { get: () => "etag" },
+							}));
+						}
+						return Promise.resolve({
+							ok: true,
+							json: () => Promise.resolve({ tag_name: "rust-v0.111.0" }),
+							text: () => Promise.resolve("PROMPT FILE CONTENT"),
+							headers: { get: () => "etag" },
+						});
+					});
+					mockedMkdir.mockResolvedValue(undefined);
+					mockedWriteFile.mockResolvedValue(undefined);
+
+					const pending = Promise.all([
+						getCodexInstructions("gpt-5.4"),
+						getCodexInstructions("gpt-5.5"),
+						getCodexInstructions("gpt-5.4-mini"),
+					]);
+					// Let all three reach fetchCatalogText before the fetch resolves.
+					await new Promise((resolve) => setTimeout(resolve, 0));
+					resolveCatalog?.(undefined);
+
+					const [a, b, c] = await pending;
+					expect(a).toContain("GPT54 CATALOG PROMPT");
+					expect(b).toContain("GPT55 CATALOG PROMPT");
+					expect(c).toContain("GPT54MINI CATALOG PROMPT");
+
+					const catalogFetches = mockFetch.mock.calls.filter(
+						(call) => typeof call[0] === "string" && call[0].includes("models.json"),
+					);
+					expect(catalogFetches).toHaveLength(1);
+				});
+
 				it("should fall back to the prompt file when the tag has no catalog entry", async () => {
 					mockedReadFile.mockRejectedValue(new Error("ENOENT"));
 					// Catalog without gpt-5.4 — simulates a release predating the slug.


### PR DESCRIPTION
## Summary

- **What changed?** System instructions now come from the Codex model catalog (`base_instructions` in `codex-rs/models-manager/models.json`) for every model the catalog covers, instead of from the legacy `*_prompt.md` files.
- **Why is this needed?** Modern Codex sends per-model `base_instructions` from the catalog. This plugin was sending `gpt_5_2_prompt.md` — which opens *"You are GPT-5.2 running in the Codex CLI"* — to `gpt-5.2`, `gpt-5.4`, `gpt-5.4-mini`, and `gpt-5.5`. Those models were getting the wrong system prompt and a false identity.

Follow-up to #189, which fixed this for the 5.6 tiers only. The divergence for 5.2/5.4/5.4-mini/5.5 predates that PR.

### Instruction source per model

| Model | Source |
|-------|--------|
| `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna` | catalog (each tier has distinct text) |
| `gpt-5.5` | catalog |
| `gpt-5.4`, `gpt-5.4-mini` | catalog |
| `gpt-5.2` | catalog |
| `gpt-5-codex`, `gpt-5.1*`, `gpt-5.2-codex`, `gpt-5.4-nano`, `gpt-5.4-pro` | `*_prompt.md` (absent from the catalog) |

A catalog miss (pinned release predates the slug) falls back to the family prompt file.

### Cache keying

Catalog instructions cache **per model id**, not per family. `gpt-5.5` and `gpt-5.4` share the `gpt-5.4` family but carry different catalog text, so a family-keyed cache would let one serve the other's prompt. Disk paths get a `catalog-` prefix, which also prevents a pre-upgrade prompt-file cache from being read as catalog content — no migration step needed.

Cache keys are namespaced (`catalog:` / `family:`) because slug-space and family-space **overlap**:

```
gpt-5.4        family=gpt-5.4   catalog=yes   -> key catalog:gpt-5.4
gpt-5.4-nano   family=gpt-5.4   catalog=no    -> key family:gpt-5.4
gpt-5.6        family=gpt-5.6-sol catalog=no  -> key family:gpt-5.6-sol
gpt-5.6-sol    family=gpt-5.6-sol catalog=yes -> key catalog:gpt-5.6-sol
```

Without namespacing, `gpt-5.4` and `gpt-5.4-nano` shared a `memoryCache` / `refreshPromises` key and served each other's instructions inside the 15-minute TTL — reachable through `prewarmCodexInstructions`, which warms `gpt-5.4` but not nano. Regression-tested in both orders; both tests fail against the un-namespaced key.

`models.json` (~300KB) is fetched once per release tag and shared across models. `fetchCatalogText` both memoizes the result and shares the in-flight promise, so the concurrent fan-out in `prewarmCodexInstructions` collapses to a single download (regression-tested: 3 fetches without the dedup, 1 with).

### Verified against the live catalog

Not just mocks — fetched the real `models.json` at the pinned release tag:

```
gpt-5.4        len=12879  catalog text ("You are Codex, a coding agent based on GPT-5")
gpt-5.4-nano   len=21569  prompt file, uncontaminated ("Your capabilities:" marker present)
gpt-5.5        len=19737  distinct from gpt-5.4
gpt-5.6-sol    len=16299  catalog text
gpt-5.1        len=24086  prompt file, unchanged
```

## Testing

- [x] `npm run lint` (0 errors; 3 pre-existing warnings in generated `coverage/`)
- [x] `npm run build`
- [x] `npm test` (2689 passed, 1 skipped)
- [ ] Not applicable

## Compliance Confirmation

- [x] This change stays within the repository scope and OpenAI Terms of Service expectations.
- [x] This change uses official authentication flows only and does not add bypass, scraping, or credential-sharing behavior.
- [x] I updated tests and documentation when the change affected users, maintainers, or repository behavior.

## Notes

- Linked issue: _none_
- Follow-up work or rollout notes:
  - **This changes the system prompt for `gpt-5.2`, `gpt-5.4`, `gpt-5.4-mini`, and `gpt-5.5`** — the models most users are on. The new text is what Codex itself sends, so this should be a correctness improvement, but it is a behavior change and worth a look before merging. It is independently revertable from #189.
  - No live backend request was made. Instruction *sourcing* is verified against the real catalog; model *responses* to the new prompt are not.
  - Minor, left alone: the catalog path stores `etag: null`, so a background refresh re-downloads `models.json` once per TTL per tag rather than issuing a conditional request. Efficiency only.
  - Review on this branch caught a real in-flight race in `fetchCatalogText` (fixed in fb58487). The "fetched once per release tag" claim above did not originally hold under concurrency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated Codex model instruction handling to use model-specific catalog instructions where available.
  * Added support for safely managing separate instruction sources across models and families.

* **Bug Fixes**
  * Prevented instruction cache conflicts between related models.
  * Added fallback to bundled prompt files when catalog instructions are unavailable.
  * Improved responsiveness by reusing cached instructions while refreshing stale content in the background.

* **Documentation**
  * Clarified instruction sources, caching behavior, release-tag catalog retrieval, and fallback handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

this pr extends catalog-based instruction sourcing to `gpt-5.2`, `gpt-5.4`, `gpt-5.4-mini`, and `gpt-5.5`, fixes a per-model vs per-family cache key collision, and adds `catalogInflight` to deduplicate concurrent `models.json` downloads triggered by `prewarmCodexInstructions`.

- **instruction source routing** — `resolveInstructionSource` now returns a namespaced `key` (`catalog:` vs `family:`) and per-model cache filenames, preventing `gpt-5.4-nano` and `gpt-5.4` from sharing a key, and `gpt-5.5` from being served `gpt-5.4`'s cached text within one TTL window.
- **`catalogInflight` deduplication** — a module-level in-flight guard ensures all concurrent callers share the same in-flight promise; `__clearCacheForTesting` now resets both `catalogMemo` and `catalogInflight`.
- **test coverage** — new vitest cases cover catalog-vs-file isolation in both orders, the concurrent single-fetch invariant, and the catalog-miss fallback to prompt file.

<h3>Confidence Score: 5/5</h3>

the change is safe to merge — it corrects the system prompt served to gpt-5.2/5.4/5.4-mini/5.5 and fixes the cache key collision; no incorrect data can be served under the new routing logic.

the concurrency issue flagged in the previous review thread is addressed by catalogInflight and the regression test passes. the key-namespace change correctly prevents slug/family collisions. the catalog-miss fallback is functionally correct.

no files require special attention; lib/prompts/codex.ts is the most complex change but is well-commented with solid test coverage.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/prompts/codex.ts | core of the pr — adds resolveInstructionSource, catalogInflight, persistInstructions, and extends CATALOG_SLUGS; key/cache namespacing and inflight deduplication look correct. |
| test/codex-prompts.test.ts | adds 7 new cases covering catalog vs prompt-file isolation, both collision orders, concurrent fetch deduplication, catalog-miss fallback, and models absent from catalog. |
| docs/configuration.md | adds system instructions table and prose documenting catalog vs prompt-file routing and per-model cache semantics; consistent with the code. |

<sub>Reviews (2): Last reviewed commit: ["fix(prompts): dedupe concurrent models.j..."](https://github.com/ndycode/oc-codex-multi-auth/commit/fb584878f8916520498eed77eb5c5774ac962522) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43160734)</sub>

<!-- /greptile_comment -->