### PR TITLE
fix(request): set reasoning.context="all_turns" on responses-lite requests

### DIFF
--- a/lib/request/helpers/responses-lite.ts
+++ b/lib/request/helpers/responses-lite.ts
@@ -162,5 +162,7 @@ export function applyResponsesLite(body: RequestBody): RequestBody {
 
 	stripImageDetails(body.input);
 
+	body.reasoning = { ...body.reasoning, context: "all_turns" };
+
 	return body;
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -45,6 +45,7 @@ export interface ConfigOptions {
 export interface ReasoningConfig {
 	effort: "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max";
 	summary: "auto" | "concise" | "detailed";
+	context?: "all_turns";
 }
 
 export interface OAuthServerInfo {

--- a/test/responses-lite.test.ts
+++ b/test/responses-lite.test.ts
@@ -139,6 +139,31 @@ describe("responses-lite", () => {
 		});
 	});
 
+	describe("reasoning.context", () => {
+		it("sets reasoning.context to all_turns on the lite body", () => {
+			const body = applyResponsesLite(
+				makeBody({ reasoning: { effort: "low", summary: "auto" } }),
+			);
+			expect(body.reasoning?.context).toBe("all_turns");
+		});
+
+		it("preserves an existing resolved effort and summary", () => {
+			const body = applyResponsesLite(
+				makeBody({ reasoning: { effort: "high", summary: "concise" } }),
+			);
+			expect(body.reasoning).toEqual({
+				effort: "high",
+				summary: "concise",
+				context: "all_turns",
+			});
+		});
+
+		it("sets reasoning.context even when the body has no reasoning", () => {
+			const body = applyResponsesLite(makeBody({ reasoning: undefined }));
+			expect(body.reasoning?.context).toBe("all_turns");
+		});
+	});
+
 	describe("image detail stripping", () => {
 		it("strips detail from message input_image content", () => {
 			const body = applyResponsesLite(
@@ -280,6 +305,15 @@ describe("responses-lite", () => {
 			const original = body.input?.[0] as Record<string, unknown>;
 			const content = original.content as Record<string, unknown>[];
 			expect(content[0].detail).toBe("high");
+		});
+
+		it("does not add reasoning.context to a non-lite body", () => {
+			const body = makeBody({
+				model: "gpt-5.5",
+				reasoning: { effort: "high", summary: "auto" },
+			});
+			const shaped = shapeBodyForModel(body);
+			expect(shaped.reasoning?.context).toBeUndefined();
 		});
 	});
 });


### PR DESCRIPTION
## Summary

- **What changed?** `applyResponsesLite` now sets `reasoning.context = "all_turns"` on the responses-lite body (GPT-5.6 sol/terra/luna), and `ReasoningConfig` gains an optional `context?: "all_turns"` so the assignment is type-safe under strict / `no-explicit-any`.
- **Why is this needed?** The plugin sends the `x-openai-internal-codex-responses-lite: true` header, but the backend rejects any such request that lacks `reasoning.context = "all_turns"`, so every `gpt-5.6-*` request currently fails with HTTP 400 (`unsupported_value` on `reasoning.context`). The string `all_turns` appeared nowhere in the source. Verified against the live Codex backend: an identical `POST /codex/responses` 400s without the field and 200s with it (`response.created`, `model: gpt-5.6-sol`).

## Testing

- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm test`  (107 files, 2694 passed, 1 skipped)
- [ ] Not applicable

Also `npm run typecheck` and `npm run audit:ci` clean. The new `reasoning.context` tests are mutation teeth-checked: reverting the one-line fix fails exactly the three new tests. A non-lite regression asserts `gpt-5.5` gets no `context`.

## Compliance Confirmation

- [x] This change stays within the repository scope and OpenAI Terms of Service expectations.
- [x] This change uses official authentication flows only and does not add bypass, scraping, or credential-sharing behavior.
- [x] I updated tests when the change affected repository behavior.

## Notes

- Linked issue: Fixes #191
- Follow-up / rollout: `reasoning.context` is set only inside the lite reshaping, which `shapeBodyForModel` applies to a `structuredClone` for lite models only — so the canonical body and the `5.6 → 5.5` fallback are untouched. This closes the "no request in this release has been exercised against the live Codex backend" gap noted in the 6.7.0 release notes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reasoning configuration for lite models by consistently applying the `"all_turns"` context.
  * Preserved existing reasoning settings while adding the required context.
  * Prevented this context from being added to non-lite models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

fixes the live 400 error on all `gpt-5.6-*` requests by injecting `reasoning.context = "all_turns"` into the responses-lite body, and adds `context?: "all_turns"` to `ReasoningConfig` so the assignment is type-safe under strict mode. the change is intentionally scoped to `applyResponsesLite`, which operates on a `structuredClone`, leaving the canonical body and the `5.6 → 5.5` fallback path untouched.

- `lib/request/helpers/responses-lite.ts` — one-line spread at end of `applyResponsesLite`; handles `undefined` reasoning gracefully and preserves existing effort/summary fields
- `lib/types.ts` — extends `ReasoningConfig` with `context?: "all_turns"`; no breaking change to existing consumers
- `test/responses-lite.test.ts` — 4 new vitest cases covering injection, field preservation, undefined-reasoning path, and non-lite regression

<h3>Confidence Score: 4/5</h3>

safe to merge — the fix is a single-line spread in an already-cloned body, the non-lite path is unaffected, and tests verify all three reasoning states.

the change correctly unblocks all gpt-5.6-* requests that were failing with 400. the one gap is that no test explicitly asserts the original body's reasoning reference is unchanged after shapeBodyForModel on a lite model — the structuredClone makes this safe today, but the contract is untested and could silently break if the clone boundary shifts.

test/responses-lite.test.ts — worth adding a mutation-isolation assertion for the reasoning field after shapeBodyForModel on a lite model

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/request/helpers/responses-lite.ts | adds `body.reasoning = { ...body.reasoning, context: "all_turns" }` at end of `applyResponsesLite`; correctly handles undefined reasoning, preserves existing effort/summary, and operates only on the structuredClone copy so canonical body is safe |
| lib/types.ts | adds `context?: "all_turns"` to `ReasoningConfig` — single-value literal union, optional, type-safe; no other interface changes |
| test/responses-lite.test.ts | adds 4 new vitest cases covering context injection for lite, preservation of existing reasoning fields, undefined-reasoning path, and non-lite regression; missing explicit mutation-isolation test for the canonical body's reasoning reference after shapeBodyForModel |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[shapeBodyForModel] -->|usesResponsesLite?| B{lite model?}
    B -- no --> C[return body unchanged]
    B -- yes --> D[structuredClone body]
    D --> E[applyResponsesLite clone]
    E --> F[move tools into input as additional_tools]
    F --> G[prepend developer message if instructions]
    G --> H[clear top-level instructions and tools]
    H --> I[parallel_tool_calls = false]
    I --> J[stripImageDetails]
    J --> K["body.reasoning = { ...body.reasoning, context: 'all_turns' }"]
    K --> L[return shaped body]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[shapeBodyForModel] -->|usesResponsesLite?| B{lite model?}
    B -- no --> C[return body unchanged]
    B -- yes --> D[structuredClone body]
    D --> E[applyResponsesLite clone]
    E --> F[move tools into input as additional_tools]
    F --> G[prepend developer message if instructions]
    G --> H[clear top-level instructions and tools]
    H --> I[parallel_tool_calls = false]
    I --> J[stripImageDetails]
    J --> K["body.reasoning = { ...body.reasoning, context: 'all_turns' }"]
    K --> L[return shaped body]
```

</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
test/responses-lite.test.ts:139-169
**missing mutation-isolation test for reasoning**

`shapeBodyForModel` wraps `applyResponsesLite` in a `structuredClone`, so the canonical `body.reasoning` object should never be mutated. the new line sets `body.reasoning` to a new spread object (correct), but no test verifies the pre-call `reasoning` reference on the original body is untouched after `shapeBodyForModel` for a lite model. if the clone boundary ever shifts, a silent mutation would go undetected. adding a case like `const original = makeBody({ reasoning: { effort: "high", summary: "auto" } }); shapeBodyForModel(original); expect(original.reasoning?.context).toBeUndefined()` would make that contract explicit.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(request): set reasoning.context=all\_..."](https://github.com/ndycode/oc-codex-multi-auth/commit/246ab99b8193928202822734f84c2140dce6e66a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43195589)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->