### PR TITLE
fix(quota): drop disabled zero-length windows; feat(codex-reset): redeem banked rate-limit resets

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ If browser launch is blocked, use the alternate login paths in [docs/getting-sta
 | `codex-warm` | How do I start every account's usage window now (stagger quota cooldowns)? |
 | `codex-status` | Which account, model family, and routing state are active? |
 | `codex-limits` | What quota or rate-limit state is visible now? |
+| `codex-reset` | Do I have a banked rate-limit reset credit, and how do I redeem it? |
 | `codex-dashboard` | Can I manage accounts from one interactive surface? |
 
 Most of these also run as a **direct CLI** with no agent/model involvement (no token cost) — e.g. `oc-codex-multi-auth warm`, `oc-codex-multi-auth status`, or `npx -y oc-codex-multi-auth@latest warm`. Use `oc-codex-multi-auth warm` to open every enabled account's usage window at the start of a session and stagger the rolling quota cooldowns. Add `--json` for scriptable output.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -72,7 +72,7 @@ Native mode keeps the host payload shape whenever possible. Legacy mode applies 
 Common groups:
 
 - setup: `codex-setup`, `codex-help`, `codex-next`
-- daily account use: `codex-list`, `codex-switch`, `codex-status`, `codex-limits`
+- daily account use: `codex-list`, `codex-switch`, `codex-status`, `codex-limits`, `codex-reset`
 - account metadata: `codex-label`, `codex-tag`, `codex-note`, `codex-remove`, `codex-refresh`
 - diagnostics and resilience: `codex-health`, `codex-metrics`, `codex-doctor`, `codex-diag`, `codex-diff`
 - backup and secrets: `codex-export`, `codex-import`, `codex-keychain`

--- a/docs/development/ARCHITECTURE.md
+++ b/docs/development/ARCHITECTURE.md
@@ -45,7 +45,7 @@ index.ts
   |- ToolContext construction
   v
 lib/tools/index.ts
-  |- registers 22 OpenCode tools
+  |- registers 23 OpenCode tools
   |- each tool delegates to lib/tools/codex-*.ts
 
 Request path
@@ -90,7 +90,7 @@ tui.ts
 | Storage | `lib/storage.ts`, `lib/storage/` | V3 JSON storage, atomic writes, migrations, per-project paths, backups, import/export, keychain opt-in, flagged accounts |
 | Request bridge | `lib/request/fetch-helpers.ts`, `lib/request/request-transformer.ts`, `lib/request/response-handler.ts`, `lib/request/retry-budget.ts`, `lib/request/rate-limit-backoff.ts` | URL/body/header shaping, Codex invariants, SSE conversion, retry budgets, backoff, error mapping |
 | Model/prompt mapping | `lib/prompts/codex.ts`, `lib/prompts/opencode-codex.ts`, `lib/prompts/codex-opencode-bridge.ts`, `lib/request/helpers/model-map.ts` | model-family detection, Codex instructions cache, OpenCode prompt adaptation, fallback aliases |
-| Tool registry | `lib/tools/index.ts`, `lib/tools/codex-*.ts` | 22 OpenCode tools for setup, account switching, status, health, diagnostics, backup, keychain, and recovery |
+| Tool registry | `lib/tools/index.ts`, `lib/tools/codex-*.ts` | 23 OpenCode tools for setup, account switching, status, health, quota resets, diagnostics, backup, keychain, and recovery |
 | Runtime support | `lib/runtime.ts`, `lib/circuit-breaker.ts`, `lib/proactive-refresh.ts`, `lib/parallel-probe.ts`, `lib/recovery/`, `lib/shutdown.ts` | pure runtime helpers, failure isolation, refresh scheduling, health probing, session recovery, cleanup |
 | UI helpers | `lib/ui/` | terminal formatting, auth menu, select/confirm prompts, theme/color handling, beginner checklist |
 | Config templates | `config/opencode-modern.json`, `config/opencode-legacy.json`, `config/minimal-opencode.json`, `config/README.md` | copy-paste OpenCode provider templates and model catalog guidance |
@@ -169,7 +169,7 @@ Legacy mode exists for compatibility with older OpenCode/AI SDK payload behavior
 
 ## Tool Registry Architecture
 
-The plugin exposes 22 OpenCode tools through `lib/tools/index.ts`. `index.ts` builds one `ToolContext` from plugin-closure state and helper functions, then passes it to `createToolRegistry(ctx)`.
+The plugin exposes 23 OpenCode tools through `lib/tools/index.ts`. `index.ts` builds one `ToolContext` from plugin-closure state and helper functions, then passes it to `createToolRegistry(ctx)`.
 
 Why this shape exists:
 
@@ -183,7 +183,7 @@ Tool groups:
 | Group | Tools |
 | --- | --- |
 | Setup and help | `codex-setup`, `codex-help`, `codex-next` |
-| Daily account use | `codex-list`, `codex-switch`, `codex-status`, `codex-limits`, `codex-dashboard` |
+| Daily account use | `codex-list`, `codex-switch`, `codex-status`, `codex-limits`, `codex-reset`, `codex-dashboard` |
 | Account metadata | `codex-label`, `codex-tag`, `codex-note`, `codex-remove`, `codex-refresh` |
 | Diagnostics | `codex-health`, `codex-metrics`, `codex-doctor`, `codex-diag`, `codex-diff` |
 | Backup/secrets | `codex-export`, `codex-import`, `codex-keychain` |

--- a/lib/codex-reset.ts
+++ b/lib/codex-reset.ts
@@ -1,0 +1,269 @@
+/**
+ * Client for Codex banked rate-limit reset credits.
+ *
+ * OpenAI grants eligible ChatGPT plans a small number of "reset credits" that
+ * clear the current rate-limit windows early. Redemption is exposed in the
+ * Codex desktop app, the IDE extensions, and the Codex CLI `/usage` screen —
+ * but not on a surface Linux users of this plugin can reach. This module wraps
+ * the same two backend endpoints those clients use so `codex-reset` can list
+ * and redeem credits:
+ *
+ * - `GET  /wham/rate-limit-reset-credits`          — list credits
+ * - `POST /wham/rate-limit-reset-credits/consume`  — redeem one credit
+ *
+ * Both are undocumented and authenticate exactly like `/wham/usage` (see
+ * `lib/codex-usage.ts`), so they share its bearer credentials, timeout, and
+ * error-body sanitization. Redeeming is irreversible and consumes a real,
+ * finite credit, so the redeem path is never taken implicitly — the caller must
+ * pass an explicit confirmation (see `lib/tools/codex-reset.ts`).
+ */
+
+import { randomUUID } from "node:crypto";
+
+import {
+	isCodexAbortError,
+	sanitizeCodexApiErrorMessage,
+} from "./codex-usage.js";
+import { getFetchTimeoutMs, loadPluginConfig } from "./config.js";
+import { CODEX_BASE_URL } from "./constants.js";
+import { createUsageRequestTimeoutError } from "./error-sentinels.js";
+import { createCodexHeaders } from "./request/fetch-helpers.js";
+
+/** Status string the backend uses for a credit that can still be redeemed. */
+export const CODEX_RESET_CREDIT_AVAILABLE_STATUS = "available";
+
+const RESET_CREDITS_PATH = "/wham/rate-limit-reset-credits";
+const RESET_CREDITS_CONSUME_PATH = "/wham/rate-limit-reset-credits/consume";
+const resetErrorBodyMaxChars = 4096;
+
+/** Raw credit entry as returned by the backend. */
+export type CodexResetCreditEntry = {
+	id?: string;
+	status?: string;
+	reset_type?: string;
+	granted_at?: string;
+	expires_at?: string;
+	title?: string;
+};
+
+/** Raw list response. */
+export type CodexResetCreditsPayload = {
+	credits?: CodexResetCreditEntry[] | null;
+	available_count?: number;
+};
+
+/** Raw consume response. */
+export type CodexResetConsumePayload = {
+	code?: string;
+	windows_reset?: unknown;
+	credit?: { id?: string; status?: string; redeemed_at?: string } | null;
+};
+
+/** Normalized credit entry used by the tool and its JSON output. */
+export type CodexResetCredit = {
+	id: string;
+	status: string;
+	isAvailable: boolean;
+	resetType: string | null;
+	grantedAt: string | null;
+	expiresAt: string | null;
+	title: string | null;
+};
+
+export type CodexResetCreditsSummary = {
+	availableCount: number;
+	credits: CodexResetCredit[];
+};
+
+/** Outcome of choosing which credit to redeem. */
+export type CodexResetCreditSelection =
+	| { type: "selected"; credit: CodexResetCredit }
+	| { type: "none-available" }
+	| { type: "not-found"; creditId: string };
+
+function toTrimmedString(value: unknown): string | null {
+	return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+/**
+ * Normalize the list response.
+ *
+ * Credits without an `id` are dropped: an id is required to redeem, so an
+ * entry lacking one is not actionable and would only pad the display. The
+ * server's `available_count` is trusted when it is a sane number and otherwise
+ * derived from the credits themselves, so a missing counter never understates
+ * what the user actually has.
+ */
+export function parseCodexResetCredits(
+	payload: CodexResetCreditsPayload,
+): CodexResetCreditsSummary {
+	const credits: CodexResetCredit[] = [];
+	for (const entry of payload.credits ?? []) {
+		const id = toTrimmedString(entry?.id);
+		if (!id) continue;
+		const status = toTrimmedString(entry?.status) ?? "unknown";
+		credits.push({
+			id,
+			status,
+			isAvailable: status === CODEX_RESET_CREDIT_AVAILABLE_STATUS,
+			resetType: toTrimmedString(entry?.reset_type),
+			grantedAt: toTrimmedString(entry?.granted_at),
+			expiresAt: toTrimmedString(entry?.expires_at),
+			title: toTrimmedString(entry?.title),
+		});
+	}
+
+	const reported = payload.available_count;
+	const availableCount =
+		typeof reported === "number" && Number.isFinite(reported) && reported >= 0
+			? Math.trunc(reported)
+			: credits.filter((credit) => credit.isAvailable).length;
+
+	return { availableCount, credits };
+}
+
+/**
+ * Pick the credit to redeem.
+ *
+ * Only credits the backend still reports as available are eligible, so an
+ * explicit `creditId` naming an expired or already-redeemed credit is reported
+ * as not-found rather than being sent to the consume endpoint.
+ */
+export function selectRedeemableCredit(
+	summary: CodexResetCreditsSummary,
+	creditId?: string,
+): CodexResetCreditSelection {
+	const available = summary.credits.filter((credit) => credit.isAvailable);
+	const requestedId = creditId?.trim();
+	if (requestedId) {
+		const credit = available.find((entry) => entry.id === requestedId);
+		return credit
+			? { type: "selected", credit }
+			: { type: "not-found", creditId: requestedId };
+	}
+	const credit = available[0];
+	return credit ? { type: "selected", credit } : { type: "none-available" };
+}
+
+export function formatCodexResetCredit(credit: CodexResetCredit): string {
+	const parts = [credit.id, `status=${credit.status}`];
+	if (credit.resetType) parts.push(`type=${credit.resetType}`);
+	if (credit.grantedAt) parts.push(`granted=${credit.grantedAt}`);
+	if (credit.expiresAt) parts.push(`expires=${credit.expiresAt}`);
+	return parts.join("  ");
+}
+
+/** Fresh idempotency key for a redeem request. */
+export function createRedeemRequestId(): string {
+	return randomUUID();
+}
+
+async function requestCodexResetJson<T>(params: {
+	path: string;
+	method: "GET" | "POST";
+	accountId: string;
+	accessToken: string;
+	organizationId: string | undefined;
+	body?: unknown;
+	timeoutMs?: number;
+}): Promise<T> {
+	const headers = createCodexHeaders(
+		undefined,
+		params.accountId,
+		params.accessToken,
+		{ organizationId: params.organizationId },
+	);
+	headers.set("accept", "application/json");
+	if (params.body !== undefined) {
+		headers.set("content-type", "application/json");
+	}
+
+	const controller = new AbortController();
+	const timeout = setTimeout(
+		() => controller.abort(),
+		params.timeoutMs ?? getFetchTimeoutMs(loadPluginConfig()),
+	);
+
+	try {
+		const response = await fetch(`${CODEX_BASE_URL}${params.path}`, {
+			method: params.method,
+			headers,
+			body: params.body === undefined ? undefined : JSON.stringify(params.body),
+			signal: controller.signal,
+		});
+		if (!response.ok) {
+			let bodyText = "";
+			try {
+				bodyText = (await response.text()).slice(0, resetErrorBodyMaxChars);
+			} catch (error) {
+				if (isCodexAbortError(error) || controller.signal.aborted) {
+					throw createUsageRequestTimeoutError();
+				}
+				throw error;
+			}
+			if (controller.signal.aborted) {
+				throw createUsageRequestTimeoutError();
+			}
+			throw new Error(sanitizeCodexApiErrorMessage(response.status, bodyText));
+		}
+		return (await response.json()) as T;
+	} catch (error) {
+		if (isCodexAbortError(error)) {
+			throw createUsageRequestTimeoutError();
+		}
+		throw error;
+	} finally {
+		clearTimeout(timeout);
+	}
+}
+
+export async function fetchCodexResetCredits(params: {
+	accountId: string;
+	accessToken: string;
+	organizationId: string | undefined;
+	timeoutMs?: number;
+}): Promise<CodexResetCreditsPayload> {
+	return await requestCodexResetJson<CodexResetCreditsPayload>({
+		...params,
+		path: RESET_CREDITS_PATH,
+		method: "GET",
+	});
+}
+
+/**
+ * Redeem one banked credit. Irreversible.
+ *
+ * `redeemRequestId` is echoed to the backend as an idempotency key so a retry
+ * of the same logical redemption cannot spend two credits.
+ */
+export async function consumeCodexResetCredit(params: {
+	accountId: string;
+	accessToken: string;
+	organizationId: string | undefined;
+	creditId: string;
+	redeemRequestId: string;
+	timeoutMs?: number;
+}): Promise<CodexResetConsumePayload> {
+	const { creditId, redeemRequestId, ...rest } = params;
+	return await requestCodexResetJson<CodexResetConsumePayload>({
+		...rest,
+		path: RESET_CREDITS_CONSUME_PATH,
+		method: "POST",
+		body: { credit_id: creditId, redeem_request_id: redeemRequestId },
+	});
+}
+
+export function formatCodexResetConsumeResult(
+	result: CodexResetConsumePayload,
+): string {
+	const parts: string[] = [];
+	if (result.code) parts.push(`code=${result.code}`);
+	const redeemedAt = toTrimmedString(result.credit?.redeemed_at);
+	if (redeemedAt) parts.push(`redeemed=${redeemedAt}`);
+	if (Array.isArray(result.windows_reset) && result.windows_reset.length > 0) {
+		parts.push(`windows_reset=${result.windows_reset.join(", ")}`);
+	} else if (typeof result.windows_reset === "string") {
+		parts.push(`windows_reset=${result.windows_reset}`);
+	}
+	return parts.length > 0 ? parts.join("  ") : "redeemed";
+}

--- a/lib/codex-usage.ts
+++ b/lib/codex-usage.ts
@@ -136,6 +136,27 @@ export function formatUsageReset(
 	return `${time} on ${day}`;
 }
 
+/**
+ * Convert a reported window length in seconds to minutes.
+ *
+ * A non-positive length means the plan has the window switched off, and is
+ * preserved as `0` — the disabled marker {@link hasUsageWindow} filters on.
+ * Rounding it up to `1` would surface a disabled window as a real `1m` limit.
+ * A missing/non-finite length is an unknown window, which stays `undefined`.
+ */
+function mapUsageWindowMinutes(
+	limitWindowSeconds: number | undefined,
+): number | undefined {
+	if (
+		typeof limitWindowSeconds !== "number" ||
+		!Number.isFinite(limitWindowSeconds)
+	) {
+		return undefined;
+	}
+	if (limitWindowSeconds <= 0) return 0;
+	return Math.max(1, Math.ceil(limitWindowSeconds / 60));
+}
+
 export function mapUsageWindow(window: UsageWindow): LimitWindow {
 	if (!window) return {};
 	return {
@@ -144,11 +165,7 @@ export function mapUsageWindow(window: UsageWindow): LimitWindow {
 			Number.isFinite(window.used_percent)
 				? window.used_percent
 				: undefined,
-		windowMinutes:
-			typeof window.limit_window_seconds === "number" &&
-			Number.isFinite(window.limit_window_seconds)
-				? Math.max(1, Math.ceil(window.limit_window_seconds / 60))
-				: undefined,
+		windowMinutes: mapUsageWindowMinutes(window.limit_window_seconds),
 		resetAtMs:
 			typeof window.reset_at === "number" && window.reset_at > 0
 				? window.reset_at * 1000
@@ -215,7 +232,14 @@ export function formatAdditionalUsageLimitName(
 		.replace(/\b\w/g, (match) => match.toUpperCase());
 }
 
+/**
+ * A window reported with a length of zero is disabled for the plan (e.g. the
+ * 5-hour window on plans where OpenAI has switched it off), not a window whose
+ * length is merely unknown. It still reports `used_percent: 0`, so it has to be
+ * rejected on the explicit zero length or it renders as a full quota.
+ */
 export function hasUsageWindow(window: LimitWindow): boolean {
+	if (window.windowMinutes === 0) return false;
 	return Boolean(
 		window.windowMinutes ||
 			typeof window.usedPercent === "number" ||
@@ -244,10 +268,13 @@ export function parseCodexUsagePayload(
 			),
 			window: mapUsageWindow(entry.rate_limit?.primary_window ?? null),
 		}));
-	const limits = [
-		toUsageLimitPayload(formatUsageLimitTitle(primary.windowMinutes), primary),
-		toUsageLimitPayload(formatUsageLimitTitle(secondary.windowMinutes), secondary),
-	];
+	const limits: UsageLimitPayload[] = [];
+	for (const window of [primary, secondary]) {
+		if (!hasUsageWindow(window)) continue;
+		limits.push(
+			toUsageLimitPayload(formatUsageLimitTitle(window.windowMinutes), window),
+		);
+	}
 	if (hasUsageWindow(codeReview)) {
 		limits.push(toUsageLimitPayload("Code review", codeReview));
 	}
@@ -266,7 +293,17 @@ export function parseCodexUsagePayload(
 	};
 }
 
-function sanitizeUsageErrorMessage(status: number, bodyText: string): string {
+/**
+ * Build a safe error message from a failed Codex backend response.
+ *
+ * Shared with the reset-credit client in `lib/codex-reset.ts`: both talk to
+ * `chatgpt.com/backend-api` with the same bearer credentials, so both must
+ * scrub tokens out of an error body before it reaches tool output or logs.
+ */
+export function sanitizeCodexApiErrorMessage(
+	status: number,
+	bodyText: string,
+): string {
 	const normalized = bodyText.replace(/\s+/g, " ").trim();
 	const redacted = normalized
 		.replace(/Bearer\s+\S+/gi, "Bearer [redacted]")
@@ -279,7 +316,7 @@ function sanitizeUsageErrorMessage(status: number, bodyText: string): string {
 	return redacted ? `HTTP ${status}: ${redacted.slice(0, 200)}` : `HTTP ${status}`;
 }
 
-function isAbortError(error: unknown): boolean {
+export function isCodexAbortError(error: unknown): boolean {
 	return (
 		(error instanceof Error && error.name === "AbortError") ||
 		(typeof DOMException !== "undefined" &&
@@ -320,7 +357,7 @@ export async function fetchCodexUsage(params: {
 			try {
 				bodyText = (await response.text()).slice(0, usageErrorBodyMaxChars);
 			} catch (error) {
-				if (isAbortError(error) || controller.signal.aborted) {
+				if (isCodexAbortError(error) || controller.signal.aborted) {
 					throw createUsageRequestTimeoutError();
 				}
 				throw error;
@@ -328,11 +365,11 @@ export async function fetchCodexUsage(params: {
 			if (controller.signal.aborted) {
 				throw createUsageRequestTimeoutError();
 			}
-			throw new Error(sanitizeUsageErrorMessage(response.status, bodyText));
+			throw new Error(sanitizeCodexApiErrorMessage(response.status, bodyText));
 		}
 		return (await response.json()) as UsagePayload;
 	} catch (error) {
-		if (isAbortError(error)) {
+		if (isCodexAbortError(error)) {
 			throw createUsageRequestTimeoutError();
 		}
 		throw error;

--- a/lib/tools/AGENTS.md
+++ b/lib/tools/AGENTS.md
@@ -1,6 +1,6 @@
 # lib/tools/
 
-Per-tool modules for the 22 `codex-*` tools registered by the plugin.
+Per-tool modules for the 23 `codex-*` tools registered by the plugin.
 
 ## Status
 
@@ -18,6 +18,7 @@ lib/tools/
   codex-switch.ts
   codex-status.ts
   codex-limits.ts
+  codex-reset.ts
   codex-metrics.ts
   codex-help.ts
   codex-setup.ts

--- a/lib/tools/codex-limits.ts
+++ b/lib/tools/codex-limits.ts
@@ -218,12 +218,12 @@ export function createCodexLimitsTool(ctx: ToolContext): ToolDefinition {
 
 					if (ui.v2Enabled) {
 						lines.push(formatUiItem(ui, `${displayLabel}${activeSuffix}`));
-						lines.push(
-							`  ${formatUiKeyValue(ui, formatUsageLimitTitle(usage.primary.windowMinutes), formatUsageLimitSummary(usage.primary), "muted")}`,
-						);
-						lines.push(
-							`  ${formatUiKeyValue(ui, formatUsageLimitTitle(usage.secondary.windowMinutes), formatUsageLimitSummary(usage.secondary), "muted")}`,
-						);
+						for (const window of [usage.primary, usage.secondary]) {
+							if (!hasUsageWindow(window)) continue;
+							lines.push(
+								`  ${formatUiKeyValue(ui, formatUsageLimitTitle(window.windowMinutes), formatUsageLimitSummary(window), "muted")}`,
+							);
+						}
 						if (hasUsageWindow(usage.codeReview)) {
 							lines.push(
 								`  ${formatUiKeyValue(ui, "Code review", formatUsageLimitSummary(usage.codeReview), "muted")}`,
@@ -246,12 +246,12 @@ export function createCodexLimitsTool(ctx: ToolContext): ToolDefinition {
 						}
 					} else {
 						lines.push(`${displayLabel}${activeSuffix}:`);
-						lines.push(
-							`  ${formatUsageLimitTitle(usage.primary.windowMinutes)}: ${formatUsageLimitSummary(usage.primary)}`,
-						);
-						lines.push(
-							`  ${formatUsageLimitTitle(usage.secondary.windowMinutes)}: ${formatUsageLimitSummary(usage.secondary)}`,
-						);
+						for (const window of [usage.primary, usage.secondary]) {
+							if (!hasUsageWindow(window)) continue;
+							lines.push(
+								`  ${formatUsageLimitTitle(window.windowMinutes)}: ${formatUsageLimitSummary(window)}`,
+							);
+						}
 						if (hasUsageWindow(usage.codeReview)) {
 							lines.push(
 								`  Code review: ${formatUsageLimitSummary(usage.codeReview)}`,

--- a/lib/tools/codex-reset.ts
+++ b/lib/tools/codex-reset.ts
@@ -1,0 +1,375 @@
+/**
+ * `codex-reset` tool — view and redeem banked Codex rate-limit reset credits.
+ *
+ * Closes the gap for users who cannot reach OpenAI's redemption UI (desktop
+ * app / IDE extensions / Codex CLI `/usage`): the credits are granted per
+ * account, and this plugin already holds the credentials needed to spend them.
+ *
+ * Redeeming is irreversible and spends a finite credit, so `action="consume"`
+ * only issues the POST when `confirm` is `true`. A tool call has no interactive
+ * y/N prompt, so confirmation is an explicit argument instead — an unconfirmed
+ * consume renders the same preview a dry run does and changes nothing.
+ */
+
+import { tool, type ToolDefinition } from "@opencode-ai/plugin/tool";
+
+import {
+	consumeCodexResetCredit,
+	createRedeemRequestId,
+	fetchCodexResetCredits,
+	formatCodexResetConsumeResult,
+	formatCodexResetCredit,
+	parseCodexResetCredits,
+	selectRedeemableCredit,
+	type CodexResetCreditsSummary,
+} from "../codex-reset.js";
+import {
+	ensureCodexUsageAccessToken,
+	fetchCodexUsage,
+	formatUsageLimitSummary,
+	formatUsageLimitTitle,
+	hasUsageWindow,
+	parseCodexUsagePayload,
+	resolveCodexUsageAccountId,
+	type CodexUsageSummary,
+} from "../codex-usage.js";
+import { loadAccounts } from "../storage.js";
+import {
+	formatUiHeader,
+	formatUiItem,
+	formatUiKeyValue,
+} from "../ui/format.js";
+import { normalizeToolOutputFormat, renderJsonOutput } from "../runtime.js";
+import type { ToolContext } from "./index.js";
+
+type CodexResetArgs = {
+	action?: string;
+	creditId?: string;
+	confirm?: boolean;
+	dryRun?: boolean;
+	account?: number;
+	format?: string;
+	includeSensitive?: boolean;
+};
+
+function normalizeResetAction(action?: string): "status" | "consume" {
+	if (action === undefined || action === "status") return "status";
+	if (action === "consume") return "consume";
+	throw new Error(
+		`Invalid action "${action}". Expected "status" or "consume".`,
+	);
+}
+
+/**
+ * Resolve the 1-based `account` argument to a storage index.
+ *
+ * Defaults to the active Codex account, since credits are granted per account
+ * and the one serving requests is the one whose windows the user wants reset.
+ */
+function resolveResetAccountIndex(
+	accountCount: number,
+	activeIndex: number,
+	account?: number,
+): number {
+	if (account === undefined) return activeIndex;
+	if (
+		!Number.isInteger(account) ||
+		account < 1 ||
+		account > accountCount
+	) {
+		throw new Error(
+			`Invalid account ${account}. Expected 1-${accountCount}.`,
+		);
+	}
+	return account - 1;
+}
+
+function buildUsageLines(usage: CodexUsageSummary): string[] {
+	const lines: string[] = [];
+	for (const window of [usage.primary, usage.secondary]) {
+		if (!hasUsageWindow(window)) continue;
+		lines.push(
+			`  ${formatUsageLimitTitle(window.windowMinutes)}: ${formatUsageLimitSummary(window)}`,
+		);
+	}
+	return lines;
+}
+
+function buildCreditLines(summary: CodexResetCreditsSummary): string[] {
+	const lines = [
+		`banked credits: ${summary.availableCount} available`,
+	];
+	for (const credit of summary.credits) {
+		lines.push(`  ${formatCodexResetCredit(credit)}`);
+		if (credit.title) lines.push(`      "${credit.title}"`);
+	}
+	if (summary.credits.length === 0) {
+		lines.push("  (none granted)");
+	}
+	return lines;
+}
+
+export function createCodexResetTool(ctx: ToolContext): ToolDefinition {
+	const {
+		resolveUiRuntime,
+		resolveActiveIndex,
+		formatCommandAccountLabel,
+		resolveMaskEmail,
+		buildJsonAccountIdentity,
+		invalidateAccountManagerCache,
+	} = ctx;
+
+	return tool({
+		description:
+			"View banked Codex rate-limit reset credits, and redeem one to clear the current usage windows. Redeeming is irreversible and requires confirm=true.",
+		args: {
+			action: tool.schema
+				.string()
+				.optional()
+				.describe(
+					'"status" (default) lists banked credits and current usage. "consume" redeems one credit.',
+				),
+			creditId: tool.schema
+				.string()
+				.optional()
+				.describe(
+					"Redeem this specific credit id. Defaults to the first available credit.",
+				),
+			confirm: tool.schema
+				.boolean()
+				.optional()
+				.describe(
+					"Must be true for action=\"consume\" to actually redeem. Without it the redemption is only previewed.",
+				),
+			dryRun: tool.schema
+				.boolean()
+				.optional()
+				.describe("Preview the redemption without spending the credit."),
+			account: tool.schema
+				.number()
+				.optional()
+				.describe(
+					"1-based account number to act on. Defaults to the active Codex account.",
+				),
+			format: tool.schema
+				.string()
+				.optional()
+				.describe('Output format: "text" (default) or "json".'),
+			includeSensitive: tool.schema
+				.boolean()
+				.optional()
+				.describe(
+					"Include raw account labels, emails, and account IDs in JSON output. Defaults to false.",
+				),
+		},
+		async execute({
+			action,
+			creditId,
+			confirm,
+			dryRun,
+			account,
+			format,
+			includeSensitive,
+		}: CodexResetArgs = {}) {
+			const ui = resolveUiRuntime();
+			const maskEmail = resolveMaskEmail();
+			const outputFormat = normalizeToolOutputFormat(format);
+			const resetAction = normalizeResetAction(action);
+			const includeSensitiveOutput = includeSensitive === true;
+
+			const storage = await loadAccounts();
+			if (!storage || storage.accounts.length === 0) {
+				if (outputFormat === "json") {
+					return renderJsonOutput({
+						message: "No Codex accounts configured. Run: opencode auth login",
+						action: resetAction,
+						credits: [],
+						availableCount: 0,
+					});
+				}
+				if (ui.v2Enabled) {
+					return [
+						...formatUiHeader(ui, "Codex reset"),
+						"",
+						formatUiItem(ui, "No accounts configured.", "warning"),
+						formatUiItem(ui, "Run: opencode auth login", "accent"),
+					].join("\n");
+				}
+				return "No Codex accounts configured. Run: opencode auth login";
+			}
+
+			const activeIndex = resolveActiveIndex(storage, "codex");
+			const index = resolveResetAccountIndex(
+				storage.accounts.length,
+				activeIndex,
+				account,
+			);
+			const target = storage.accounts[index];
+			if (!target) {
+				throw new Error(`No account at position ${index + 1}.`);
+			}
+			const label = formatCommandAccountLabel(target, index);
+			const displayLabel = formatCommandAccountLabel(target, index, {
+				maskEmail,
+			});
+			const identity = buildJsonAccountIdentity(index, {
+				includeSensitive: includeSensitiveOutput,
+				account: target,
+				label,
+			});
+
+			try {
+				const credentials = await ensureCodexUsageAccessToken({
+					storage,
+					account: target,
+				});
+				if (credentials.persisted) invalidateAccountManagerCache();
+
+				const accountId = resolveCodexUsageAccountId({
+					account: target,
+					accessToken: credentials.accessToken,
+				});
+				if (!accountId) throw new Error("Missing account id");
+
+				const request = {
+					accountId,
+					accessToken: credentials.accessToken,
+					organizationId: target.organizationId,
+				};
+				const summary = parseCodexResetCredits(
+					await fetchCodexResetCredits(request),
+				);
+				const usage = parseCodexUsagePayload(await fetchCodexUsage(request));
+
+				if (resetAction === "status") {
+					if (outputFormat === "json") {
+						return renderJsonOutput({
+							...identity,
+							action: "status",
+							availableCount: summary.availableCount,
+							credits: summary.credits,
+							planType: usage.planType,
+							limits: usage.limits,
+						});
+					}
+					const lines = ui.v2Enabled
+						? [...formatUiHeader(ui, "Codex reset"), ""]
+						: [];
+					lines.push(`${displayLabel}:`);
+					lines.push(...buildCreditLines(summary));
+					lines.push("", "current usage:");
+					lines.push(...buildUsageLines(usage));
+					if (summary.availableCount > 0) {
+						lines.push(
+							"",
+							'Redeem with: codex-reset action="consume" confirm=true',
+						);
+					}
+					return lines.join("\n");
+				}
+
+				const selection = selectRedeemableCredit(summary, creditId);
+				if (selection.type !== "selected") {
+					const message =
+						selection.type === "not-found"
+							? `No available credit with id ${selection.creditId}.`
+							: "No available credits to redeem.";
+					if (outputFormat === "json") {
+						return renderJsonOutput({
+							...identity,
+							action: "consume",
+							redeemed: false,
+							reason: selection.type,
+							message,
+							availableCount: summary.availableCount,
+							credits: summary.credits,
+						});
+					}
+					return [`${displayLabel}:`, `  ${message}`].join("\n");
+				}
+
+				const credit = selection.credit;
+				// A consume without explicit confirmation is a preview, not a
+				// redemption: spending a credit cannot be undone, and a tool call
+				// offers no interactive prompt to fall back on.
+				const previewOnly = dryRun === true || confirm !== true;
+				if (previewOnly) {
+					const reason = dryRun === true ? "dry-run" : "unconfirmed";
+					if (outputFormat === "json") {
+						return renderJsonOutput({
+							...identity,
+							action: "consume",
+							redeemed: false,
+							reason,
+							credit,
+							message:
+								reason === "dry-run"
+									? "Dry run: credit not redeemed."
+									: "Not redeemed. Pass confirm=true to redeem this credit.",
+						});
+					}
+					return [
+						`${displayLabel}:`,
+						"  about to redeem:",
+						`    ${formatCodexResetCredit(credit)}`,
+						reason === "dry-run"
+							? "  dry run: credit not redeemed."
+							: '  not redeemed. Re-run with confirm=true to redeem this credit.',
+					].join("\n");
+				}
+
+				const result = await consumeCodexResetCredit({
+					...request,
+					creditId: credit.id,
+					redeemRequestId: createRedeemRequestId(),
+				});
+				const usageAfter = parseCodexUsagePayload(
+					await fetchCodexUsage(request),
+				);
+
+				if (outputFormat === "json") {
+					return renderJsonOutput({
+						...identity,
+						action: "consume",
+						redeemed: true,
+						credit,
+						result: {
+							code: result.code ?? null,
+							windowsReset: result.windows_reset ?? null,
+							redeemedAt: result.credit?.redeemed_at ?? null,
+						},
+						planType: usageAfter.planType,
+						limits: usageAfter.limits,
+					});
+				}
+				return [
+					`${displayLabel}:`,
+					`  redeemed ${credit.id}`,
+					`  ${formatCodexResetConsumeResult(result)}`,
+					"",
+					"new usage:",
+					...buildUsageLines(usageAfter),
+				].join("\n");
+			} catch (error) {
+				const message = error instanceof Error ? error.message : String(error);
+				if (outputFormat === "json") {
+					return renderJsonOutput({
+						...identity,
+						action: resetAction,
+						redeemed: false,
+						error: message.slice(0, 160),
+					});
+				}
+				if (ui.v2Enabled) {
+					return [
+						formatUiItem(ui, displayLabel),
+						`  ${formatUiKeyValue(ui, "Error", message.slice(0, 160), "danger")}`,
+					].join("\n");
+				}
+				return [`${displayLabel}:`, `  Error: ${message.slice(0, 160)}`].join(
+					"\n",
+				);
+			}
+		},
+	});
+}

--- a/lib/tools/codex-reset.ts
+++ b/lib/tools/codex-reset.ts
@@ -236,12 +236,16 @@ export function createCodexResetTool(ctx: ToolContext): ToolDefinition {
 					accessToken: credentials.accessToken,
 					organizationId: target.organizationId,
 				};
-				const summary = parseCodexResetCredits(
-					await fetchCodexResetCredits(request),
-				);
-				const usage = parseCodexUsagePayload(await fetchCodexUsage(request));
-
 				if (resetAction === "status") {
+					// The two endpoints are independent, so overlap them rather than
+					// paying two serial round-trips on every status check.
+					const [creditsPayload, usagePayload] = await Promise.all([
+						fetchCodexResetCredits(request),
+						fetchCodexUsage(request),
+					]);
+					const summary = parseCodexResetCredits(creditsPayload);
+					const usage = parseCodexUsagePayload(usagePayload);
+
 					if (outputFormat === "json") {
 						return renderJsonOutput({
 							...identity,
@@ -268,6 +272,9 @@ export function createCodexResetTool(ctx: ToolContext): ToolDefinition {
 					return lines.join("\n");
 				}
 
+				const summary = parseCodexResetCredits(
+					await fetchCodexResetCredits(request),
+				);
 				const selection = selectRedeemableCredit(summary, creditId);
 				if (selection.type !== "selected") {
 					const message =
@@ -323,9 +330,18 @@ export function createCodexResetTool(ctx: ToolContext): ToolDefinition {
 					creditId: credit.id,
 					redeemRequestId: createRedeemRequestId(),
 				});
-				const usageAfter = parseCodexUsagePayload(
-					await fetchCodexUsage(request),
-				);
+
+				// Past this point the credit is spent and cannot be recovered. The
+				// usage refresh below is a courtesy read, so its failure must never
+				// reach the outer catch: reporting `redeemed: false` for a credit the
+				// server already consumed would send the user to redeem another one.
+				let usageAfter: CodexUsageSummary | undefined;
+				let usageError: string | undefined;
+				try {
+					usageAfter = parseCodexUsagePayload(await fetchCodexUsage(request));
+				} catch (error) {
+					usageError = error instanceof Error ? error.message : String(error);
+				}
 
 				if (outputFormat === "json") {
 					return renderJsonOutput({
@@ -338,8 +354,9 @@ export function createCodexResetTool(ctx: ToolContext): ToolDefinition {
 							windowsReset: result.windows_reset ?? null,
 							redeemedAt: result.credit?.redeemed_at ?? null,
 						},
-						planType: usageAfter.planType,
-						limits: usageAfter.limits,
+						planType: usageAfter?.planType ?? null,
+						limits: usageAfter?.limits ?? null,
+						usageError: usageError ? usageError.slice(0, 160) : null,
 					});
 				}
 				return [
@@ -347,8 +364,12 @@ export function createCodexResetTool(ctx: ToolContext): ToolDefinition {
 					`  redeemed ${credit.id}`,
 					`  ${formatCodexResetConsumeResult(result)}`,
 					"",
-					"new usage:",
-					...buildUsageLines(usageAfter),
+					...(usageAfter
+						? ["new usage:", ...buildUsageLines(usageAfter)]
+						: [
+								`new usage: unavailable (${usageError?.slice(0, 160)})`,
+								"The credit was redeemed. Run codex-reset to re-read usage.",
+							]),
 				].join("\n");
 			} catch (error) {
 				const message = error instanceof Error ? error.message : String(error);

--- a/lib/tools/index.ts
+++ b/lib/tools/index.ts
@@ -40,6 +40,7 @@ import { createCodexSwitchTool } from "./codex-switch.js";
 import { createCodexWarmTool } from "./codex-warm.js";
 import { createCodexStatusTool } from "./codex-status.js";
 import { createCodexLimitsTool } from "./codex-limits.js";
+import { createCodexResetTool } from "./codex-reset.js";
 import { createCodexMetricsTool } from "./codex-metrics.js";
 import { createCodexDoctorTool } from "./codex-doctor.js";
 import { createCodexLabelTool } from "./codex-label.js";
@@ -229,6 +230,7 @@ export function createToolRegistry(ctx: ToolContext): CodexToolRegistry {
 		"codex-warm": createCodexWarmTool(ctx),
 		"codex-status": createCodexStatusTool(ctx),
 		"codex-limits": createCodexLimitsTool(ctx),
+		"codex-reset": createCodexResetTool(ctx),
 		"codex-metrics": createCodexMetricsTool(ctx),
 		"codex-help": createCodexHelpTool(ctx),
 		"codex-setup": createCodexSetupTool(ctx),

--- a/lib/tui-quota-cache.ts
+++ b/lib/tui-quota-cache.ts
@@ -153,7 +153,20 @@ function parseLimit(headers: Headers, prefix: string): TuiQuotaLimit {
 	};
 }
 
+/**
+ * A window OpenAI reports with `window-minutes: 0` is switched off for the
+ * plan, not a window of unknown length. Such a window still carries
+ * `used-percent: 0`, so it must be recognized by the explicit zero rather than
+ * by the absence of data — otherwise it renders as a full `quota 100%` segment.
+ * A window whose header is absent entirely stays eligible: that is an unknown
+ * window, and it is still shown under the generic `quota` label.
+ */
+export function isDisabledQuotaLimit(limit: TuiQuotaLimit): boolean {
+	return limit.windowMinutes === 0;
+}
+
 function hasUsefulLimit(limit: TuiQuotaLimit): boolean {
+	if (isDisabledQuotaLimit(limit)) return false;
 	return Boolean(
 		limit.windowMinutes ||
 			typeof limit.usedPercent === "number" ||
@@ -267,13 +280,33 @@ export function isTuiQuotaSnapshot(value: unknown): value is TuiQuotaSnapshot {
 	);
 }
 
+/**
+ * Drop disabled windows from a snapshot read back from disk.
+ *
+ * A cache written by an older build can still hold a `windowMinutes: 0` entry.
+ * Filtering on read lets those snapshots heal without the user deleting the
+ * cache file, and keeps a stale-cache render consistent with a fresh one.
+ */
+export function sanitizeTuiQuotaSnapshot(
+	snapshot: TuiQuotaSnapshot,
+): TuiQuotaSnapshot {
+	const limits = snapshot.limits.filter(
+		(limit) => !isDisabledQuotaLimit(limit),
+	);
+	return limits.length === snapshot.limits.length
+		? snapshot
+		: { ...snapshot, limits };
+}
+
 export async function readTuiQuotaSnapshot(
 	cachePath?: string,
 ): Promise<TuiQuotaSnapshot | undefined> {
 	try {
 		const raw = await fs.readFile(cachePath ?? getTuiQuotaCachePath(), "utf-8");
 		const parsed = JSON.parse(raw) as unknown;
-		return isTuiQuotaSnapshot(parsed) ? parsed : undefined;
+		return isTuiQuotaSnapshot(parsed)
+			? sanitizeTuiQuotaSnapshot(parsed)
+			: undefined;
 	} catch {
 		return undefined;
 	}

--- a/test/codex-reset.test.ts
+++ b/test/codex-reset.test.ts
@@ -1,0 +1,203 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+	consumeCodexResetCredit,
+	createRedeemRequestId,
+	fetchCodexResetCredits,
+	formatCodexResetConsumeResult,
+	parseCodexResetCredits,
+	selectRedeemableCredit,
+} from "../lib/codex-reset.js";
+
+const request = {
+	accountId: "acct-1",
+	accessToken: "access-token",
+	organizationId: undefined,
+	timeoutMs: 5_000,
+};
+
+function jsonResponse(body: unknown, status = 200): Response {
+	return new Response(JSON.stringify(body), {
+		status,
+		headers: { "content-type": "application/json" },
+	});
+}
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("parseCodexResetCredits", () => {
+	it("normalizes credits and flags the redeemable ones", () => {
+		const summary = parseCodexResetCredits({
+			available_count: 1,
+			credits: [
+				{
+					id: "RateLimitResetCredit_a",
+					status: "available",
+					reset_type: "free",
+					granted_at: "2026-06-12",
+					expires_at: "2026-07-12",
+					title: "One free rate limit reset",
+				},
+				{ id: "RateLimitResetCredit_b", status: "redeemed" },
+			],
+		});
+
+		expect(summary.availableCount).toBe(1);
+		expect(summary.credits).toHaveLength(2);
+		expect(summary.credits[0]).toMatchObject({
+			id: "RateLimitResetCredit_a",
+			isAvailable: true,
+			resetType: "free",
+			title: "One free rate limit reset",
+		});
+		expect(summary.credits[1]?.isAvailable).toBe(false);
+	});
+
+	it("derives the available count when the server omits it", () => {
+		const summary = parseCodexResetCredits({
+			credits: [
+				{ id: "a", status: "available" },
+				{ id: "b", status: "available" },
+				{ id: "c", status: "expired" },
+			],
+		});
+
+		expect(summary.availableCount).toBe(2);
+	});
+
+	it("drops credits without an id, since they cannot be redeemed", () => {
+		const summary = parseCodexResetCredits({
+			credits: [{ status: "available" }, { id: "  ", status: "available" }],
+		});
+
+		expect(summary.credits).toEqual([]);
+	});
+
+	it("tolerates an empty payload", () => {
+		expect(parseCodexResetCredits({})).toEqual({
+			availableCount: 0,
+			credits: [],
+		});
+	});
+});
+
+describe("selectRedeemableCredit", () => {
+	const summary = parseCodexResetCredits({
+		credits: [
+			{ id: "spent", status: "redeemed" },
+			{ id: "first", status: "available" },
+			{ id: "second", status: "available" },
+		],
+	});
+
+	it("defaults to the first available credit", () => {
+		expect(selectRedeemableCredit(summary)).toMatchObject({
+			type: "selected",
+			credit: { id: "first" },
+		});
+	});
+
+	it("honors an explicit credit id", () => {
+		expect(selectRedeemableCredit(summary, "second")).toMatchObject({
+			type: "selected",
+			credit: { id: "second" },
+		});
+	});
+
+	it("refuses a credit that is not available rather than posting it", () => {
+		expect(selectRedeemableCredit(summary, "spent")).toEqual({
+			type: "not-found",
+			creditId: "spent",
+		});
+	});
+
+	it("reports when nothing is redeemable", () => {
+		const spentOnly = parseCodexResetCredits({
+			credits: [{ id: "spent", status: "redeemed" }],
+		});
+		expect(selectRedeemableCredit(spentOnly)).toEqual({ type: "none-available" });
+	});
+});
+
+describe("fetchCodexResetCredits", () => {
+	it("calls the credits endpoint with Codex auth headers", async () => {
+		const fetchMock = vi
+			.spyOn(globalThis, "fetch")
+			.mockResolvedValue(jsonResponse({ available_count: 1, credits: [] }));
+
+		await fetchCodexResetCredits(request);
+
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+		expect(url).toBe(
+			"https://chatgpt.com/backend-api/wham/rate-limit-reset-credits",
+		);
+		expect(init.method).toBe("GET");
+		const headers = new Headers(init.headers);
+		expect(headers.get("Authorization")).toBe("Bearer access-token");
+		expect(headers.get("ChatGPT-Account-Id")).toBe("acct-1");
+	});
+
+	it("sanitizes bearer tokens out of an error body", async () => {
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			new Response("denied for Bearer sk-secret-token-value", { status: 403 }),
+		);
+
+		await expect(fetchCodexResetCredits(request)).rejects.toThrow(
+			/HTTP 403.*Bearer \[redacted\]/,
+		);
+	});
+});
+
+describe("consumeCodexResetCredit", () => {
+	it("posts the credit id and the redeem request id", async () => {
+		const fetchMock = vi
+			.spyOn(globalThis, "fetch")
+			.mockResolvedValue(jsonResponse({ code: "ok" }));
+
+		await consumeCodexResetCredit({
+			...request,
+			creditId: "credit-1",
+			redeemRequestId: "redeem-1",
+		});
+
+		const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+		expect(url).toBe(
+			"https://chatgpt.com/backend-api/wham/rate-limit-reset-credits/consume",
+		);
+		expect(init.method).toBe("POST");
+		expect(JSON.parse(String(init.body))).toEqual({
+			credit_id: "credit-1",
+			redeem_request_id: "redeem-1",
+		});
+		expect(new Headers(init.headers).get("content-type")).toBe(
+			"application/json",
+		);
+	});
+});
+
+describe("createRedeemRequestId", () => {
+	it("returns a fresh id per redemption so a retry cannot spend two credits", () => {
+		expect(createRedeemRequestId()).not.toBe(createRedeemRequestId());
+	});
+});
+
+describe("formatCodexResetConsumeResult", () => {
+	it("summarizes the redeemed windows", () => {
+		expect(
+			formatCodexResetConsumeResult({
+				code: "ok",
+				windows_reset: ["primary", "secondary"],
+				credit: { redeemed_at: "2026-07-14T00:00:00Z" },
+			}),
+		).toBe(
+			"code=ok  redeemed=2026-07-14T00:00:00Z  windows_reset=primary, secondary",
+		);
+	});
+
+	it("falls back to a plain confirmation when the payload is bare", () => {
+		expect(formatCodexResetConsumeResult({})).toBe("redeemed");
+	});
+});

--- a/test/codex-usage.test.ts
+++ b/test/codex-usage.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
 	deduplicateUsageAccountIndices,
 	getUsageLeftPercent,
+	hasUsageWindow,
 	parseCodexUsagePayload,
 	resolveCodexUsageActiveAccount,
 	type UsagePayload,
@@ -207,5 +208,44 @@ describe("codex usage helpers", () => {
 			index: 1,
 			account: { accountId: "acc-2" },
 		});
+	});
+});
+
+describe("disabled usage windows (issue #194)", () => {
+	it("drops a window the server reports with a zero-second length", () => {
+		const payload: UsagePayload = {
+			plan_type: "team",
+			rate_limit: {
+				primary_window: {
+					used_percent: 23,
+					limit_window_seconds: 10080 * 60,
+				},
+				secondary_window: {
+					used_percent: 0,
+					limit_window_seconds: 0,
+					reset_after_seconds: 0,
+				},
+			},
+		};
+
+		const usage = parseCodexUsagePayload(payload);
+
+		// A zero-length window is switched off, not a one-minute window.
+		expect(usage.secondary.windowMinutes).toBe(0);
+		expect(hasUsageWindow(usage.secondary)).toBe(false);
+		expect(usage.limits).toHaveLength(1);
+		expect(usage.limits[0]).toMatchObject({
+			name: "Weekly limit",
+			leftPercent: 77,
+		});
+	});
+
+	it("keeps a window whose length the server omits", () => {
+		const usage = parseCodexUsagePayload({
+			rate_limit: { primary_window: { used_percent: 10 } },
+		});
+
+		expect(hasUsageWindow(usage.primary)).toBe(true);
+		expect(usage.limits[0]).toMatchObject({ name: "quota limit", leftPercent: 90 });
 	});
 });

--- a/test/doc-parity.test.ts
+++ b/test/doc-parity.test.ts
@@ -253,13 +253,13 @@ describe("runtime documentation parity", () => {
 		).sort();
 
 		expect(registeredTools).toEqual(toolFiles);
-		expect(registeredTools).toHaveLength(22);
+		expect(registeredTools).toHaveLength(23);
 
 		const docsExpectations: Array<[string, string[]]> = [
 			[
 				"docs/development/ARCHITECTURE.md",
 				[
-					"22 OpenCode tools",
+					"23 OpenCode tools",
 					"every registered `codex-*` tool is its own file under `lib/tools/`",
 				],
 			],
@@ -273,7 +273,7 @@ describe("runtime documentation parity", () => {
 			[
 				"lib/tools/AGENTS.md",
 				[
-					"22 `codex-*` tools",
+					"23 `codex-*` tools",
 					"codex-keychain.ts",
 				],
 			],

--- a/test/tools-codex-reset.test.ts
+++ b/test/tools-codex-reset.test.ts
@@ -1,0 +1,213 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createCodexResetTool } from "../lib/tools/codex-reset.js";
+import type { ToolContext } from "../lib/tools/index.js";
+
+vi.mock("../lib/storage.js", () => ({
+	loadAccounts: vi.fn(),
+}));
+
+import { loadAccounts } from "../lib/storage.js";
+
+const CREDITS_URL =
+	"https://chatgpt.com/backend-api/wham/rate-limit-reset-credits";
+const CONSUME_URL =
+	"https://chatgpt.com/backend-api/wham/rate-limit-reset-credits/consume";
+const USAGE_URL = "https://chatgpt.com/backend-api/wham/usage";
+
+type ToolExecute = (args?: Record<string, unknown>) => Promise<string>;
+
+function buildCtx(): ToolContext {
+	return {
+		resolveUiRuntime: () => ({
+			v2Enabled: false,
+			colorProfile: "ansi16",
+			glyphMode: "ascii",
+			theme: undefined,
+		}),
+		resolveMaskEmail: () => false,
+		resolveActiveIndex: () => 0,
+		formatCommandAccountLabel: (_account, index) => `Account ${index + 1}`,
+		buildJsonAccountIdentity: (index) => ({ account: index + 1 }),
+		invalidateAccountManagerCache: () => undefined,
+	} as unknown as ToolContext;
+}
+
+function jsonResponse(body: unknown): Response {
+	return new Response(JSON.stringify(body), {
+		status: 200,
+		headers: { "content-type": "application/json" },
+	});
+}
+
+const usagePayload = {
+	plan_type: "team",
+	rate_limit: {
+		primary_window: {
+			used_percent: 23,
+			limit_window_seconds: 10080 * 60,
+		},
+		secondary_window: null,
+	},
+};
+
+const creditsPayload = {
+	available_count: 1,
+	credits: [
+		{
+			id: "RateLimitResetCredit_1",
+			status: "available",
+			reset_type: "free",
+			granted_at: "2026-06-12",
+			expires_at: "2026-07-12",
+			title: "One free rate limit reset",
+		},
+	],
+};
+
+/** Route the mocked fetch by URL so each endpoint's calls can be asserted. */
+function mockCodexFetch(): ReturnType<typeof vi.spyOn> {
+	return vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+		const url = String(input);
+		if (url === CREDITS_URL) return jsonResponse(creditsPayload);
+		if (url === USAGE_URL) return jsonResponse(usagePayload);
+		if (url === CONSUME_URL) {
+			return jsonResponse({
+				code: "ok",
+				windows_reset: ["primary"],
+				credit: { redeemed_at: "2026-07-14T10:00:00Z" },
+			});
+		}
+		throw new Error(`unexpected fetch: ${url}`);
+	});
+}
+
+function callsTo(
+	fetchMock: ReturnType<typeof mockCodexFetch>,
+	url: string,
+): unknown[][] {
+	return fetchMock.mock.calls.filter((call) => String(call[0]) === url);
+}
+
+describe("codex-reset tool", () => {
+	beforeEach(() => {
+		vi.mocked(loadAccounts).mockResolvedValue({
+			version: 3,
+			activeIndex: 0,
+			activeIndexByFamily: {},
+			accounts: [
+				{
+					accountId: "acct-1",
+					accessToken: "access-token",
+					refreshToken: "refresh-token",
+					expiresAt: Date.now() + 3_600_000,
+					email: "user@example.com",
+				},
+			],
+		} as unknown as Awaited<ReturnType<typeof loadAccounts>>);
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("lists banked credits and current usage by default", async () => {
+		mockCodexFetch();
+		const execute = createCodexResetTool(buildCtx()).execute as ToolExecute;
+
+		const output = await execute();
+
+		expect(output).toContain("banked credits: 1 available");
+		expect(output).toContain("RateLimitResetCredit_1");
+		expect(output).toContain("Weekly limit: 77% left");
+		expect(output).toContain('codex-reset action="consume" confirm=true');
+	});
+
+	it("does not redeem when consume is called without confirmation", async () => {
+		const fetchMock = mockCodexFetch();
+		const execute = createCodexResetTool(buildCtx()).execute as ToolExecute;
+
+		const output = await execute({ action: "consume" });
+
+		expect(callsTo(fetchMock, CONSUME_URL)).toHaveLength(0);
+		expect(output).toContain("about to redeem");
+		expect(output).toContain("confirm=true");
+	});
+
+	it("does not redeem on a dry run even when confirmed", async () => {
+		const fetchMock = mockCodexFetch();
+		const execute = createCodexResetTool(buildCtx()).execute as ToolExecute;
+
+		const output = await execute({
+			action: "consume",
+			confirm: true,
+			dryRun: true,
+		});
+
+		expect(callsTo(fetchMock, CONSUME_URL)).toHaveLength(0);
+		expect(output).toContain("dry run");
+	});
+
+	it("redeems the credit once when confirmed, and reports the new usage", async () => {
+		const fetchMock = mockCodexFetch();
+		const execute = createCodexResetTool(buildCtx()).execute as ToolExecute;
+
+		const output = await execute({ action: "consume", confirm: true });
+
+		const consumeCalls = callsTo(fetchMock, CONSUME_URL);
+		expect(consumeCalls).toHaveLength(1);
+		const body = JSON.parse(
+			String((consumeCalls[0]?.[1] as RequestInit).body),
+		) as { credit_id: string; redeem_request_id: string };
+		expect(body.credit_id).toBe("RateLimitResetCredit_1");
+		expect(body.redeem_request_id).toBeTruthy();
+		expect(output).toContain("redeemed RateLimitResetCredit_1");
+		expect(output).toContain("new usage:");
+	});
+
+	it("refuses to redeem an unavailable credit id", async () => {
+		const fetchMock = mockCodexFetch();
+		const execute = createCodexResetTool(buildCtx()).execute as ToolExecute;
+
+		const output = await execute({
+			action: "consume",
+			confirm: true,
+			creditId: "RateLimitResetCredit_missing",
+		});
+
+		expect(callsTo(fetchMock, CONSUME_URL)).toHaveLength(0);
+		expect(output).toContain("No available credit with id");
+	});
+
+	it("emits machine-readable status output", async () => {
+		mockCodexFetch();
+		const execute = createCodexResetTool(buildCtx()).execute as ToolExecute;
+
+		const parsed = JSON.parse(await execute({ format: "json" })) as {
+			availableCount: number;
+			credits: Array<{ id: string; isAvailable: boolean }>;
+		};
+
+		expect(parsed.availableCount).toBe(1);
+		expect(parsed.credits[0]).toMatchObject({
+			id: "RateLimitResetCredit_1",
+			isAvailable: true,
+		});
+	});
+
+	it("rejects an unknown action", async () => {
+		mockCodexFetch();
+		const execute = createCodexResetTool(buildCtx()).execute as ToolExecute;
+
+		await expect(execute({ action: "redeem" })).rejects.toThrow(
+			/Invalid action "redeem"/,
+		);
+	});
+
+	it("reports when no accounts are configured", async () => {
+		vi.mocked(loadAccounts).mockResolvedValue(null);
+		const execute = createCodexResetTool(buildCtx()).execute as ToolExecute;
+
+		expect(await execute()).toContain("No Codex accounts configured");
+	});
+});

--- a/test/tools-codex-reset.test.ts
+++ b/test/tools-codex-reset.test.ts
@@ -165,6 +165,47 @@ describe("codex-reset tool", () => {
 		expect(output).toContain("new usage:");
 	});
 
+	it("still reports the redemption when the usage re-read fails afterwards", async () => {
+		// The POST succeeds and the credit is spent; only the courtesy usage read
+		// that follows it fails. Reporting redeemed=false here would push the user
+		// to spend a second credit for a redemption that already happened.
+		let consumed = false;
+		vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+			const url = String(input);
+			if (url === CREDITS_URL) return jsonResponse(creditsPayload);
+			if (url === CONSUME_URL) {
+				consumed = true;
+				return jsonResponse({ code: "ok" });
+			}
+			if (url === USAGE_URL) {
+				if (consumed) throw new TypeError("network down");
+				return jsonResponse(usagePayload);
+			}
+			throw new Error(`unexpected fetch: ${url}`);
+		});
+		const execute = createCodexResetTool(buildCtx()).execute as ToolExecute;
+
+		const parsed = JSON.parse(
+			await execute({ action: "consume", confirm: true, format: "json" }),
+		) as { redeemed: boolean; usageError: string | null; error?: string };
+
+		expect(parsed.redeemed).toBe(true);
+		expect(parsed.usageError).toContain("network down");
+		expect(parsed.error).toBeUndefined();
+	});
+
+	it("does not read usage before deciding whether to redeem", async () => {
+		const fetchMock = mockCodexFetch();
+		const execute = createCodexResetTool(buildCtx()).execute as ToolExecute;
+
+		await execute({ action: "consume" });
+
+		// An unconfirmed consume never redeems, so it must not spend a round-trip
+		// on the usage endpoint either.
+		expect(callsTo(fetchMock, USAGE_URL)).toHaveLength(0);
+		expect(callsTo(fetchMock, CONSUME_URL)).toHaveLength(0);
+	});
+
 	it("refuses to redeem an unavailable credit id", async () => {
 		const fetchMock = mockCodexFetch();
 		const execute = createCodexResetTool(buildCtx()).execute as ToolExecute;

--- a/test/tui-quota-cache.test.ts
+++ b/test/tui-quota-cache.test.ts
@@ -113,3 +113,77 @@ describe("TUI quota cache", () => {
 		}
 	});
 });
+
+describe("disabled quota windows (issue #194)", () => {
+	it("omits a secondary window the server reports as disabled", () => {
+		// Headers reproduced from the bug report: a paid Team workspace with an
+		// active weekly window and a secondary window switched off by OpenAI.
+		const headers = new Headers({
+			"x-codex-primary-used-percent": "23",
+			"x-codex-primary-window-minutes": "10080",
+			"x-codex-secondary-used-percent": "0",
+			"x-codex-secondary-window-minutes": "0",
+			"x-codex-secondary-reset-after-seconds": "0",
+		});
+
+		const snapshot = parseTuiQuotaSnapshotFromHeaders(headers, {
+			fingerprint: "acct",
+		});
+
+		expect(snapshot?.limits).toHaveLength(1);
+		expect(snapshot?.limits[0]).toMatchObject({
+			label: "7d",
+			leftPercent: 77,
+		});
+		expect(snapshot?.limits.some((limit) => limit.label === "quota")).toBe(false);
+	});
+
+	it("still keeps a window whose length header is absent", () => {
+		const headers = new Headers({
+			"x-codex-primary-used-percent": "40",
+		});
+
+		const snapshot = parseTuiQuotaSnapshotFromHeaders(headers, {
+			fingerprint: "acct",
+		});
+
+		expect(snapshot?.limits).toHaveLength(1);
+		expect(snapshot?.limits[0]).toMatchObject({ label: "quota", leftPercent: 60 });
+	});
+
+	it("returns undefined when every reported window is disabled", () => {
+		const headers = new Headers({
+			"x-codex-primary-window-minutes": "0",
+			"x-codex-primary-used-percent": "0",
+			"x-codex-secondary-window-minutes": "0",
+			"x-codex-secondary-used-percent": "0",
+		});
+
+		expect(
+			parseTuiQuotaSnapshotFromHeaders(headers, { fingerprint: "acct" }),
+		).toBeUndefined();
+	});
+
+	it("heals a cache already poisoned by an older build", async () => {
+		const dir = await mkdtemp(join(tmpdir(), "tui-quota-disabled-"));
+		const cachePath = join(dir, "quota.json");
+		try {
+			const poisoned = createTuiQuotaSnapshot({
+				fingerprint: "acct",
+				source: "headers",
+				limits: [
+					{ label: "7d", leftPercent: 77, usedPercent: 23, windowMinutes: 10080 },
+					{ label: "quota", leftPercent: 100, usedPercent: 0, windowMinutes: 0 },
+				],
+			});
+			await writeTuiQuotaSnapshot(poisoned, cachePath);
+
+			const restored = await readTuiQuotaSnapshot(cachePath);
+
+			expect(restored?.limits).toHaveLength(1);
+			expect(restored?.limits[0]?.label).toBe("7d");
+		} finally {
+			await rm(dir, { recursive: true, force: true });
+		}
+	});
+});


### PR DESCRIPTION
## Summary

Closes both open issues.

**#194 — phantom `quota 100%` in the TUI status line.** OpenAI reports a switched-off rate-limit window as `window-minutes: 0` / `limit_window_seconds: 0` with `used-percent: 0`, rather than omitting it. Both quota paths kept that window because `used-percent` was numeric, and rendered it as a generic full limit: `7d 77% · quota 100%`.

The fix applies one rule end-to-end — an *explicit* zero length means the window is disabled, so it is dropped. A window whose length header is *absent* is merely unknown and is still shown under the generic `quota` label, which is what the reporter asked for. Two sibling bugs of the same cause are fixed alongside the reported one:

- the `/wham/usage` path rounded a zero-second window up to one minute (`Math.max(1, ...)`), surfacing a disabled window as a real `1m` limit;
- `codex-limits` printed both windows unconditionally, so it showed the same phantom row.

Snapshots already written by an older build are filtered on read, so a poisoned cache heals on its own — the reporter noted that deleting the cache did not help.

**#193 — `codex-reset` tool.** Wraps the two endpoints the desktop app / IDE extensions / Codex CLI already use, which authenticate exactly like the existing `/wham/usage` call and therefore reuse its credentials, timeout, and error-body sanitization:

```
GET  /wham/rate-limit-reset-credits          — list credits
POST /wham/rate-limit-reset-credits/consume  — redeem one
```

```
codex-reset                                     # banked credits + current usage
codex-reset action="consume"                    # preview only — does NOT redeem
codex-reset action="consume" confirm=true       # redeem
codex-reset action="consume" confirm=true dryRun=true
codex-reset format="json"
```

Redeeming is irreversible and spends a finite credit, so it is never implicit. A tool call has no interactive y/N prompt to fall back on, so confirmation is an explicit `confirm=true` argument; without it, `consume` renders the same preview `dryRun` does and sends no POST. Each redemption carries a fresh `redeem_request_id` so a retry cannot spend two credits, and a credit id that is not currently available is refused rather than posted.

## Testing

- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm test` — 2724 passed, 1 skipped, 0 failed (109 files)

New coverage: `test/codex-reset.test.ts`, `test/tools-codex-reset.test.ts` (asserts no POST is issued unless confirmed), plus regression tests in `test/tui-quota-cache.test.ts` and `test/codex-usage.test.ts` built from the exact headers in #194.

## Compliance Confirmation

- [x] This change stays within the repository scope and OpenAI Terms of Service expectations.
- [x] This change uses official authentication flows only and does not add bypass, scraping, or credential-sharing behavior. `codex-reset` spends a credit OpenAI granted to the account; it does not circumvent any limit.
- [x] I updated tests and documentation when the change affected users, maintainers, or repository behavior.

## Notes

- Linked issues: closes #194, closes #193
- **Reviewer note — please verify before merge:** the two reset-credit endpoints are undocumented. Their contract here follows the community [aaamosh/codex-reset](https://github.com/aaamosh/codex-reset) implementation cited in #193 (request/response shapes, `credit_id` + `redeem_request_id` body). Every test mocks `fetch`, so the wiring is verified but the live contract is not — I have no account with a banked credit to redeem against. Worth one real `codex-reset` (status, then a confirmed consume) on an eligible account before release.
- Tool count moves 22 → 23; docs and the `doc-parity` registry test are updated to match.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `codex-reset` to check and redeem banked rate-limit reset credits.
  - Redemption requires explicit confirmation and displays updated usage afterward.
  - Added status and machine-readable output options.

- **Bug Fixes**
  - Disabled usage windows are no longer shown as available limits.
  - Existing cached quota data is cleaned up automatically.

- **Documentation**
  - Updated tool listings and architecture documentation for the new tool.

- **Tests**
  - Added coverage for reset-credit flows, confirmation safeguards, usage windows, and cache cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

this pr has two independent parts: a targeted quota-window fix that drops windows the backend reports with a zero-length (`window-minutes: 0` / `limit_window_seconds: 0`) as disabled — applied consistently across the TUI cache parser, the usage payload parser, and the `codex-limits` display — and a new `codex-reset` tool that lists and redeems banked rate-limit reset credits using the same bearer credentials as the existing usage path.

- **quota fix**: `mapUsageWindowMinutes` now returns `0` for non-positive lengths; `hasUsageWindow` and `hasUsefulLimit` gate on that explicit zero; `sanitizeTuiQuotaSnapshot` heals already-poisoned caches on read without requiring a manual delete.
- **codex-reset tool**: the status path fires both fetches in `Promise.all`; the post-consume usage re-read is wrapped in its own `try/catch` so a courtesy network failure can never flip `redeemed` to `false` after the credit is already spent; redemption is gated behind `confirm=true` since tool calls have no interactive prompt.
- `isCodexAbortError` and `sanitizeCodexApiErrorMessage` are promoted to exports so the new client reuses the same token-scrubbing path without duplication.

<h3>Confidence Score: 5/5</h3>

safe to merge; all logic paths for the irreversible redeem operation are guarded and tested, and the quota-window fix is well-isolated with direct regression coverage from the bug report headers.

the two concerns flagged in the previous review round (concurrent fetches on status, redeemed:false false-negative after a successful POST) are both properly addressed. the quota fix is mechanically simple and consistent across all three affected call sites. the two remaining observations are display and coverage gaps that do not affect correctness.

lib/tools/codex-reset.ts — worth confirming whether buildUsageLines intentionally omits the codeReview window before the next release

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/codex-reset.ts | new credit client; reuses isCodexAbortError/sanitizeCodexApiErrorMessage exports cleanly; timeout + AbortController pattern matches the existing usage client exactly; selectRedeemableCredit guards against expired/unavailable ids before any POST |
| lib/tools/codex-reset.ts | new tool; status path uses Promise.all; post-consume usage fetch is isolated in its own try/catch; buildUsageLines omits codeReview window — intentional for rate-limit context but undocumented; text-output path for usage-fetch-failure-after-redeem has no vitest coverage |
| lib/codex-usage.ts | mapUsageWindowMinutes correctly preserves 0 as the disabled marker; hasUsageWindow early-returns false on explicit zero; sanitizeCodexApiErrorMessage/isCodexAbortError promoted to exports for reuse |
| lib/tui-quota-cache.ts | isDisabledQuotaLimit exported for testability; hasUsefulLimit now gates on it; sanitizeTuiQuotaSnapshot filters poisoned cache entries on read without unnecessary allocations when nothing changes |
| test/tools-codex-reset.test.ts | good coverage of confirm gate, dry-run, no-credits, and partial-failure (JSON); text-output branch of the post-consume usage-failure path is not exercised |
| test/tui-quota-cache.test.ts | regression tests built from exact headers in issue #194; covers disabled primary+secondary, absent header kept, all-disabled → undefined, and poisoned-cache heal path |
| test/codex-usage.test.ts | new disabled-window regression block covers zero-length secondary dropped, absent primary kept as generic quota, and leftPercent math |
| test/codex-reset.test.ts | unit tests for parseCodexResetCredits, selectRedeemableCredit, fetch wiring, bearer-token scrubbing, and idempotency-key uniqueness |

<sub>Reviews (2): Last reviewed commit: ["fix(codex-reset): never report a spent c..."](https://github.com/ndycode/oc-codex-multi-auth/commit/87afebc12a0c08119f713003bebb9f1b914921d0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44085045)</sub>

<!-- /greptile_comment -->