### PR TITLE
fix(fallback): auto-degrade gpt-5.6 tiers under the default strict policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `gpt-5.6-sol` (and the other 5.6 tiers) no longer hard-fails with `model not supported` when the account is outside the GPT-5.6 preview. 6.7.0 documented that an account without access "degrades `gpt-5.6-sol` → `gpt-5.6-terra` → `gpt-5.6-luna` → `gpt-5.5` through the unsupported-model fallback chain", but the chain was only traversed under `unsupportedCodexPolicy: "fallback"`: the default-selector auto-fallback allowlist listed only `gpt-5.5` and `gpt-5-codex`, so under the default `strict` policy a Sol request burned through every pooled account and returned an entitlement error. The three 5.6 tiers are now on the same auto-fallback path as `gpt-5.5`/`gpt-5-codex`, so the documented degradation works out of the box; opt out with `CODEX_AUTH_DISABLE_GPT56_AUTO_FALLBACK=1`. Bare `gpt-5.6` is also canonicalized to `gpt-5.6-sol` inside the fallback resolver, matching the request path, so custom chains keyed as `gpt-5.6` resolve correctly. (#196)
+
 ## [6.8.0] - 2026-07-14
 
 ### Added

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -58,7 +58,7 @@ GPT-5.6 notes:
 - No 5.6 tier accepts `none` or `minimal`; both are raised to `low`.
 - `max` and `ultra` are new in 5.6. Requesting them on an older family steps down to `xhigh` (then `high` where xhigh is unsupported).
 - `ultra` is a client-side tier. Codex rewrites it to `max` before the request leaves the client, and the subagent orchestration that distinguishes ultra lives in the Codex client rather than the request body. This plugin is a proxy, so `-ultra` is accepted as an alias and sent on the wire as `max` — it does **not** spawn subagents.
-- 5.6 is opt-in: the legacy `gpt-5` alias and the plugin default still resolve to `gpt-5.5` / `gpt-5.4`. Because 5.6 shipped as a limited preview, an account without access falls back down the 5.6 tiers and then to `gpt-5.5`. The lite shape is applied per request attempt, so a request that falls back from `gpt-5.6-sol` to `gpt-5.5` is re-serialized into the classic shape and keeps its tools.
+- 5.6 is opt-in: the legacy `gpt-5` alias and the plugin default still resolve to `gpt-5.5` / `gpt-5.4`. Because 5.6 shipped as a limited preview, an account without access falls back down the 5.6 tiers and then to `gpt-5.5` automatically — this works under the default `strict` policy, like the `gpt-5.5`/`gpt-5-codex` auto-fallbacks, and can be disabled with `CODEX_AUTH_DISABLE_GPT56_AUTO_FALLBACK=1`. The lite shape is applied per request attempt, so a request that falls back from `gpt-5.6-sol` to `gpt-5.5` is re-serialized into the classic shape and keeps its tools.
 - Instructions for the 5.6 tiers come from the Codex model catalog — see "System instructions" below.
 
 ### System instructions
@@ -204,7 +204,7 @@ The sample above intentionally sets `"retryAllAccountsMaxRetries": 3` as a bound
 | `unsupportedCodexPolicy` | `strict` | unsupported-model behavior: `strict` (return entitlement error) or `fallback` (retry with configured fallback chain) |
 | `fallbackOnUnsupportedCodexModel` | `false` | legacy fallback toggle mapped to `unsupportedCodexPolicy` (prefer using `unsupportedCodexPolicy`) |
 | `fallbackToGpt52OnUnsupportedGpt53` | `true` | legacy compatibility toggle for the `gpt-5.3-codex -> gpt-5.2-codex` edge when generic fallback is enabled |
-| `unsupportedCodexFallbackChain` | `{}` | optional per-model fallback-chain override (map of `model -> [fallback1, fallback2, ...]`; default includes `gpt-5.5` and `gpt-5-codex` through the GPT-5.4 family). `gpt-5.5` and canonical Codex auto-fallbacks are on by default for common entitlement gates; set `CODEX_AUTH_DISABLE_GPT55_AUTO_FALLBACK=1` or `CODEX_AUTH_DISABLE_CODEX_AUTO_FALLBACK=1` to opt out. GPT-5.5 Pro is not mapped: it is ChatGPT-only per OpenAI's 2026-04-23 launch. |
+| `unsupportedCodexFallbackChain` | `{}` | optional per-model fallback-chain override (map of `model -> [fallback1, fallback2, ...]`; default includes the 5.6 tiers down to `gpt-5.5`, and `gpt-5.5`/`gpt-5-codex` through the GPT-5.4 family). The 5.6 tier, `gpt-5.5`, and canonical Codex auto-fallbacks are on by default for common entitlement gates; set `CODEX_AUTH_DISABLE_GPT56_AUTO_FALLBACK=1`, `CODEX_AUTH_DISABLE_GPT55_AUTO_FALLBACK=1`, or `CODEX_AUTH_DISABLE_CODEX_AUTO_FALLBACK=1` to opt out. GPT-5.5 Pro is not mapped: it is ChatGPT-only per OpenAI's 2026-04-23 launch. |
 | `sessionRecovery` | `true` | auto-recover from common api errors |
 | `autoResume` | `true` | auto-resume after thinking block recovery |
 | `tokenRefreshSkewMs` | `60000` | refresh tokens this many ms before expiry |
@@ -290,6 +290,7 @@ override any config with env vars:
 | `CODEX_AUTH_UNSUPPORTED_MODEL_POLICY=fallback` | enable generic unsupported-model fallback policy |
 | `CODEX_AUTH_FALLBACK_UNSUPPORTED_MODEL=1` | legacy fallback toggle (prefer policy variable above) |
 | `CODEX_AUTH_FALLBACK_GPT53_TO_GPT52=0` | disable only the legacy `gpt-5.3-codex -> gpt-5.2-codex` edge |
+| `CODEX_AUTH_DISABLE_GPT56_AUTO_FALLBACK=1` | disable automatic `gpt-5.6-sol -> gpt-5.6-terra -> gpt-5.6-luna -> gpt-5.5` preview fallback |
 | `CODEX_AUTH_DISABLE_GPT55_AUTO_FALLBACK=1` | disable automatic `gpt-5.5 -> gpt-5.4` fallback during rollout |
 | `CODEX_AUTH_DISABLE_CODEX_AUTO_FALLBACK=1` | disable automatic canonical Codex/GPT-5.4-family fallback |
 | `CODEX_AUTH_ACCOUNT_ID=acc_xxx` | force specific workspace id |

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -362,12 +362,13 @@ resolvedConfig: { reasoningEffort: 'low', ... }  ← Should show your options
    opencode auth login
    ```
 2. Add another entitled account/workspace. The plugin tries remaining accounts/workspaces before model fallback.
-3. Default public selectors that are commonly entitlement-gated (`gpt-5.5` and canonical `gpt-5-codex`) can auto-fallback through `gpt-5.4`, `gpt-5.4-mini`, then `gpt-5.4-nano`.
+3. Default public selectors that are commonly entitlement-gated can auto-fallback: the GPT-5.6 preview tiers (`gpt-5.6-sol`/`gpt-5.6-terra`/`gpt-5.6-luna`) degrade down the tier chain to `gpt-5.5`, and `gpt-5.5`/canonical `gpt-5-codex` degrade through `gpt-5.4`, `gpt-5.4-mini`, then `gpt-5.4-nano`.
 4. Enable fallback policy if you also want automatic downgrades for manual/legacy selectors:
    ```bash
    CODEX_AUTH_UNSUPPORTED_MODEL_POLICY=fallback opencode
    ```
-5. Default fallback chain (auto-fallback for `gpt-5.5`/`gpt-5-codex` through the GPT-5.4 family; full chain when policy is `fallback` and not overridden):
+5. Default fallback chain (auto-fallback for the 5.6 tiers and `gpt-5.5`/`gpt-5-codex`; full chain when policy is `fallback` and not overridden):
+   - `gpt-5.6-sol -> gpt-5.6-terra -> gpt-5.6-luna -> gpt-5.5` (then the `gpt-5.5` chain below)
    - `gpt-5.5 -> gpt-5.4 -> gpt-5.4-mini -> gpt-5.4-nano`
    - `gpt-5-codex -> gpt-5.4 -> gpt-5.4-mini -> gpt-5.4-nano`
    - `gpt-5.4-pro -> gpt-5.4` (if `gpt-5.4-pro` is selected manually)
@@ -396,10 +397,11 @@ resolvedConfig: { reasoningEffort: 'low', ... }  ← Should show your options
    ```
 8. Disable default-selector auto-fallbacks when you need strict entitlement failures for those selectors:
    ```bash
+   CODEX_AUTH_DISABLE_GPT56_AUTO_FALLBACK=1 opencode
    CODEX_AUTH_DISABLE_GPT55_AUTO_FALLBACK=1 opencode
    CODEX_AUTH_DISABLE_CODEX_AUTO_FALLBACK=1 opencode
    ```
-   `CODEX_AUTH_DISABLE_CODEX_AUTO_FALLBACK=1` only disables the automatic canonical Codex/GPT-5.4-family fallback path; explicit `unsupportedCodexPolicy: "fallback"` chains still apply.
+   Each variable only disables its own automatic default-selector fallback path (`GPT56` covers all three 5.6 tiers); explicit `unsupportedCodexPolicy: "fallback"` chains still apply.
 9. Legacy compatibility toggle (only controls `gpt-5.3-codex -> gpt-5.2-codex`):
    ```bash
    CODEX_AUTH_FALLBACK_GPT53_TO_GPT52=0 opencode

--- a/index.ts
+++ b/index.ts
@@ -2886,7 +2886,7 @@ while (attempted.size < Math.max(1, accountCount)) {
 										: waitMs > 0
 											? `All ${count} account(s) are rate-limited. Try again in ${waitLabel} or add another account with \`opencode auth login\`.`
 											: wasEntitlementExhaustion
-												? `All ${count} account(s) returned 'model not supported' for the requested model.${entitlementDetail} Codex model access is account/workspace gated; default gpt-5.5/gpt-5-codex selectors auto-fallback through the GPT-5.4 family when possible. Set \`unsupportedCodexPolicy: "fallback"\` for the full manual fallback chain, or see \`codex-health\` for per-account details.`
+												? `All ${count} account(s) returned 'model not supported' for the requested model.${entitlementDetail} Codex model access is account/workspace gated; default gpt-5.6-sol/terra/luna selectors auto-fallback down the 5.6 tiers to gpt-5.5, and gpt-5.5/gpt-5-codex through the GPT-5.4 family when possible. Set \`unsupportedCodexPolicy: "fallback"\` for the full manual fallback chain, or see \`codex-health\` for per-account details.`
 												: `All ${count} account(s) failed (server errors or auth issues). Check account health with \`codex-health\`.`;
 								runtimeMetrics.failedRequests++;
 								runtimeMetrics.lastError = message;

--- a/lib/request/fetch-helpers.ts
+++ b/lib/request/fetch-helpers.ts
@@ -125,6 +125,13 @@ export const DEFAULT_UNSUPPORTED_CODEX_FALLBACK_CHAIN: Record<string, string[]> 
 const DEFAULT_AUTO_FALLBACK_ENTRY_OPT_OUT_ENV: Record<string, string> = {
 	[GPT_55_MODEL_ID]: "CODEX_AUTH_DISABLE_GPT55_AUTO_FALLBACK",
 	"gpt-5-codex": "CODEX_AUTH_DISABLE_CODEX_AUTO_FALLBACK",
+	// GPT-5.6 shipped as a limited preview, so entitlement 400s on these
+	// default selectors are expected for most accounts. Auto-degrading down the
+	// tier chain (sol -> terra -> luna -> gpt-5.5) keeps the documented preview
+	// behavior without requiring `unsupportedCodexPolicy: "fallback"` (#196).
+	[GPT_56_SOL_MODEL_ID]: "CODEX_AUTH_DISABLE_GPT56_AUTO_FALLBACK",
+	[GPT_56_TERRA_MODEL_ID]: "CODEX_AUTH_DISABLE_GPT56_AUTO_FALLBACK",
+	[GPT_56_LUNA_MODEL_ID]: "CODEX_AUTH_DISABLE_GPT56_AUTO_FALLBACK",
 };
 
 const DEFAULT_AUTO_FALLBACK_CONTINUATION_MODELS = new Set([
@@ -188,6 +195,13 @@ function canonicalizeModelName(model: string | undefined): string | undefined {
 		withoutEffort === "gpt-5.5-pro-20260423"
 	) {
 		return GPT_55_MODEL_ID;
+	}
+
+	// Bare `gpt-5.6` is the Sol flagship alias (see MODEL_MAP). The request path
+	// normalizes it before dispatch, but direct helper callers and custom chains
+	// keyed as `gpt-5.6` need the same collapse for chain lookups to work.
+	if (withoutEffort === "gpt-5.6") {
+		return GPT_56_SOL_MODEL_ID;
 	}
 
 	return withoutEffort;
@@ -1095,6 +1109,8 @@ function normalizeErrorPayload(
 								message:
 										`The model '${unsupportedModel}' is not currently available for this ChatGPT account when using Codex OAuth. ` +
 										"This is an account/workspace entitlement gate, not a temporary rate limit. " +
+										"Default gpt-5.6 tiers, gpt-5.5, and gpt-5-codex selectors auto-degrade down their fallback chains " +
+										"(opt out via CODEX_AUTH_DISABLE_GPT56_AUTO_FALLBACK/GPT55/CODEX=1). " +
 										"Try 'gpt-5.5' (latest general), 'gpt-5-codex' (canonical), or legacy aliases like 'gpt-5.3-codex'/'gpt-5.2-codex', or enable automatic fallback via " +
 										'unsupportedCodexPolicy: "fallback" (or CODEX_AUTH_UNSUPPORTED_MODEL_POLICY=fallback). ' +
 										"(Legacy: CODEX_AUTH_FALLBACK_UNSUPPORTED_MODEL=1 or fallbackOnUnsupportedCodexModel).",

--- a/test/fetch-helpers.test.ts
+++ b/test/fetch-helpers.test.ts
@@ -631,6 +631,118 @@ describe('Fetch Helpers Module', () => {
 			}
 		});
 
+		it('auto-fallbacks gpt-5.6 tiers down the chain when fallback policy is disabled', () => {
+			const unsupportedBody = (model: string) => ({
+				error: {
+					code: 'model_not_supported_with_chatgpt_account',
+					message: `The '${model}' model is not supported when using Codex with a ChatGPT account.`,
+				},
+			});
+
+			const solFallback = resolveUnsupportedCodexFallbackModel({
+				requestedModel: 'gpt-5.6-sol',
+				errorBody: unsupportedBody('gpt-5.6-sol'),
+				attemptedModels: ['gpt-5.6-sol'],
+				fallbackOnUnsupportedCodexModel: false,
+				fallbackToGpt52OnUnsupportedGpt53: true,
+			});
+			expect(solFallback).toBe('gpt-5.6-terra');
+
+			const terraFallback = resolveUnsupportedCodexFallbackModel({
+				requestedModel: 'gpt-5.6-terra',
+				errorBody: unsupportedBody('gpt-5.6-terra'),
+				attemptedModels: ['gpt-5.6-sol', 'gpt-5.6-terra'],
+				fallbackOnUnsupportedCodexModel: false,
+				fallbackToGpt52OnUnsupportedGpt53: true,
+			});
+			expect(terraFallback).toBe('gpt-5.6-luna');
+
+			const lunaFallback = resolveUnsupportedCodexFallbackModel({
+				requestedModel: 'gpt-5.6-luna',
+				errorBody: unsupportedBody('gpt-5.6-luna'),
+				attemptedModels: ['gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna'],
+				fallbackOnUnsupportedCodexModel: false,
+				fallbackToGpt52OnUnsupportedGpt53: true,
+			});
+			expect(lunaFallback).toBe('gpt-5.5');
+
+			// The chain keeps degrading through the GPT-5.4 family once it lands
+			// on gpt-5.5, matching the existing default-selector behavior.
+			const gpt55Fallback = resolveUnsupportedCodexFallbackModel({
+				requestedModel: 'gpt-5.5',
+				errorBody: unsupportedBody('gpt-5.5'),
+				attemptedModels: [
+					'gpt-5.6-sol',
+					'gpt-5.6-terra',
+					'gpt-5.6-luna',
+					'gpt-5.5',
+				],
+				fallbackOnUnsupportedCodexModel: false,
+				fallbackToGpt52OnUnsupportedGpt53: true,
+			});
+			expect(gpt55Fallback).toBe('gpt-5.4');
+		});
+
+		it('treats the bare gpt-5.6 alias as the Sol tier for auto-fallback', () => {
+			const fallback = resolveUnsupportedCodexFallbackModel({
+				requestedModel: 'gpt-5.6',
+				errorBody: {
+					error: {
+						code: 'model_not_supported_with_chatgpt_account',
+						message:
+							"The 'gpt-5.6-sol' model is not supported when using Codex with a ChatGPT account.",
+					},
+				},
+				attemptedModels: ['gpt-5.6'],
+				fallbackOnUnsupportedCodexModel: false,
+				fallbackToGpt52OnUnsupportedGpt53: true,
+			});
+			expect(fallback).toBe('gpt-5.6-terra');
+		});
+
+		it('honors the gpt-5.6 auto-fallback opt-out', () => {
+			const previous = process.env.CODEX_AUTH_DISABLE_GPT56_AUTO_FALLBACK;
+			try {
+				process.env.CODEX_AUTH_DISABLE_GPT56_AUTO_FALLBACK = '1';
+				const strictFallback = resolveUnsupportedCodexFallbackModel({
+					requestedModel: 'gpt-5.6-sol',
+					errorBody: {
+						error: {
+							code: 'model_not_supported_with_chatgpt_account',
+							message:
+								"The 'gpt-5.6-sol' model is not supported when using Codex with a ChatGPT account.",
+						},
+					},
+					attemptedModels: ['gpt-5.6-sol'],
+					fallbackOnUnsupportedCodexModel: false,
+					fallbackToGpt52OnUnsupportedGpt53: true,
+				});
+				expect(strictFallback).toBeUndefined();
+
+				// The explicit fallback policy still applies when opted out.
+				const policyFallback = resolveUnsupportedCodexFallbackModel({
+					requestedModel: 'gpt-5.6-sol',
+					errorBody: {
+						error: {
+							code: 'model_not_supported_with_chatgpt_account',
+							message:
+								"The 'gpt-5.6-sol' model is not supported when using Codex with a ChatGPT account.",
+						},
+					},
+					attemptedModels: ['gpt-5.6-sol'],
+					fallbackOnUnsupportedCodexModel: true,
+					fallbackToGpt52OnUnsupportedGpt53: true,
+				});
+				expect(policyFallback).toBe('gpt-5.6-terra');
+			} finally {
+				if (previous === undefined) {
+					delete process.env.CODEX_AUTH_DISABLE_GPT56_AUTO_FALLBACK;
+				} else {
+					process.env.CODEX_AUTH_DISABLE_GPT56_AUTO_FALLBACK = previous;
+				}
+			}
+		});
+
 		it('keeps manual gpt-5.4-pro strict when fallback policy is disabled', () => {
 			const fallback = resolveUnsupportedCodexFallbackModel({
 				requestedModel: 'gpt-5.4-pro',

--- a/test/fetch-helpers.test.ts
+++ b/test/fetch-helpers.test.ts
@@ -590,9 +590,8 @@ describe('Fetch Helpers Module', () => {
 		});
 
 		it('honors the default selector auto-fallback opt-out', () => {
-			const previous = process.env.CODEX_AUTH_DISABLE_CODEX_AUTO_FALLBACK;
 			try {
-				process.env.CODEX_AUTH_DISABLE_CODEX_AUTO_FALLBACK = '1';
+				vi.stubEnv('CODEX_AUTH_DISABLE_CODEX_AUTO_FALLBACK', '1');
 				const codexFallback = resolveUnsupportedCodexFallbackModel({
 					requestedModel: 'gpt-5-codex',
 					errorBody: {
@@ -623,11 +622,7 @@ describe('Fetch Helpers Module', () => {
 				});
 				expect(gpt54Fallback).toBeUndefined();
 			} finally {
-				if (previous === undefined) {
-					delete process.env.CODEX_AUTH_DISABLE_CODEX_AUTO_FALLBACK;
-				} else {
-					process.env.CODEX_AUTH_DISABLE_CODEX_AUTO_FALLBACK = previous;
-				}
+				vi.unstubAllEnvs();
 			}
 		});
 
@@ -700,46 +695,40 @@ describe('Fetch Helpers Module', () => {
 			expect(fallback).toBe('gpt-5.6-terra');
 		});
 
-		it('honors the gpt-5.6 auto-fallback opt-out', () => {
-			const previous = process.env.CODEX_AUTH_DISABLE_GPT56_AUTO_FALLBACK;
+		it('honors the gpt-5.6 auto-fallback opt-out for every 5.6 tier', () => {
+			const unsupportedBody = (model: string) => ({
+				error: {
+					code: 'model_not_supported_with_chatgpt_account',
+					message: `The '${model}' model is not supported when using Codex with a ChatGPT account.`,
+				},
+			});
 			try {
-				process.env.CODEX_AUTH_DISABLE_GPT56_AUTO_FALLBACK = '1';
-				const strictFallback = resolveUnsupportedCodexFallbackModel({
-					requestedModel: 'gpt-5.6-sol',
-					errorBody: {
-						error: {
-							code: 'model_not_supported_with_chatgpt_account',
-							message:
-								"The 'gpt-5.6-sol' model is not supported when using Codex with a ChatGPT account.",
-						},
-					},
-					attemptedModels: ['gpt-5.6-sol'],
-					fallbackOnUnsupportedCodexModel: false,
-					fallbackToGpt52OnUnsupportedGpt53: true,
-				});
-				expect(strictFallback).toBeUndefined();
+				vi.stubEnv('CODEX_AUTH_DISABLE_GPT56_AUTO_FALLBACK', '1');
+
+				// Each tier is its own entry in the opt-out map; the flag must
+				// disable auto-fallback for all three, not just the Sol flagship.
+				for (const tier of ['gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna']) {
+					const strictFallback = resolveUnsupportedCodexFallbackModel({
+						requestedModel: tier,
+						errorBody: unsupportedBody(tier),
+						attemptedModels: [tier],
+						fallbackOnUnsupportedCodexModel: false,
+						fallbackToGpt52OnUnsupportedGpt53: true,
+					});
+					expect(strictFallback).toBeUndefined();
+				}
 
 				// The explicit fallback policy still applies when opted out.
 				const policyFallback = resolveUnsupportedCodexFallbackModel({
 					requestedModel: 'gpt-5.6-sol',
-					errorBody: {
-						error: {
-							code: 'model_not_supported_with_chatgpt_account',
-							message:
-								"The 'gpt-5.6-sol' model is not supported when using Codex with a ChatGPT account.",
-						},
-					},
+					errorBody: unsupportedBody('gpt-5.6-sol'),
 					attemptedModels: ['gpt-5.6-sol'],
 					fallbackOnUnsupportedCodexModel: true,
 					fallbackToGpt52OnUnsupportedGpt53: true,
 				});
 				expect(policyFallback).toBe('gpt-5.6-terra');
 			} finally {
-				if (previous === undefined) {
-					delete process.env.CODEX_AUTH_DISABLE_GPT56_AUTO_FALLBACK;
-				} else {
-					process.env.CODEX_AUTH_DISABLE_GPT56_AUTO_FALLBACK = previous;
-				}
+				vi.unstubAllEnvs();
 			}
 		});
 


### PR DESCRIPTION
## Summary

- What changed? Added the three GPT-5.6 tiers (`gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`) to the default-selector auto-fallback allowlist in `lib/request/fetch-helpers.ts`, behind a shared `CODEX_AUTH_DISABLE_GPT56_AUTO_FALLBACK=1` opt-out — the same mechanism `gpt-5.5` and canonical `gpt-5-codex` already use. Also canonicalized bare `gpt-5.6` to `gpt-5.6-sol` inside the fallback resolver (matching `MODEL_MAP` on the request path, so custom chains keyed `gpt-5.6` resolve), refreshed the account-exhaustion and entitlement error messages, and aligned `docs/configuration.md`, `docs/troubleshooting.md`, and the changelog.
- Why is this needed? Since 6.7.0 the changelog and `docs/configuration.md` promise that an account outside the GPT-5.6 limited preview degrades `gpt-5.6-sol` → `gpt-5.6-terra` → `gpt-5.6-luna` → `gpt-5.5` automatically, but that chain was only traversed under `unsupportedCodexPolicy: "fallback"`. Under the default `strict` policy a Sol request burned through every pooled account and hard-failed with `model_not_supported_with_chatgpt_account` (the failure reported in #196: Terra and Luna work, Sol errors out on all 3 accounts). The static chain map was already correct; only the allowlist gate was missing. Regression tests now cover the 5.6 chain hops, the bare `gpt-5.6` alias, and the opt-out (with env restoration in teardown), closing the coverage gap that let this ship.

## Testing

- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm test` (2729 passed, 1 skipped)

## Compliance Confirmation

- [x] This change stays within the repository scope and OpenAI Terms of Service expectations.
- [x] This change uses official authentication flows only and does not add bypass, scraping, or credential-sharing behavior.
- [x] I updated tests and documentation when the change affected users, maintainers, or repository behavior.

## Notes

- Linked issue: Fixes #196
- Follow-up work or rollout notes: users who relied on Sol failing strictly (to detect missing entitlement) can restore that behavior with `CODEX_AUTH_DISABLE_GPT56_AUTO_FALLBACK=1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * GPT-5.6 models now automatically fall back through available tiers instead of failing with “model not supported” when preview access is unavailable.
  * Bare `gpt-5.6` requests now resolve correctly to the Sol tier.
  * Updated error messages provide clearer fallback and troubleshooting guidance.

* **Documentation**
  * Added configuration and troubleshooting guidance for GPT-5.6 fallback behavior and opt-out controls.
  * Documented `CODEX_AUTH_DISABLE_GPT56_AUTO_FALLBACK=1` for disabling automatic GPT-5.6 fallback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

adds the three gpt-5.6 tiers (`gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`) to the `DEFAULT_AUTO_FALLBACK_ENTRY_OPT_OUT_ENV` map and canonicalizes the bare `gpt-5.6` alias to sol inside `canonicalizeModelName`. the fallback chain entries in `DEFAULT_UNSUPPORTED_CODEX_FALLBACK_CHAIN` were already present since 6.7.0; what was missing was the allowlist gate that lets the default strict policy walk that chain.

- **core fix** (`lib/request/fetch-helpers.ts`): registers sol/terra/luna as first-class auto-fallback entry points sharing `CODEX_AUTH_DISABLE_GPT56_AUTO_FALLBACK`.
- **alias canonicalization**: `gpt-5.6` collapsed to sol in `canonicalizeModelName`.
- **test coverage**: three new test cases; both opt-out tests use `vi.stubEnv`/`vi.unstubAllEnvs`.

<h3>Confidence Score: 5/5</h3>

safe to merge — minimal targeted allowlist addition backed by full chain tests and consistent opt-out semantics

the fix is narrow: three lines added to the opt-out map plus a canonicalization guard in canonicalizeModelName. fallback chain entries were already correct; only the allowlist gate was missing. new tests cover every hop in the 5.6 chain, the bare alias, and all three tier opt-outs using vi.stubEnv — no raw process.env mutations remain.

no files require special attention

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/request/fetch-helpers.ts | adds sol/terra/luna to the auto-fallback opt-out map and gpt-5.6 → sol canonicalization; logic is self-consistent with the existing entry-point/continuation model design |
| test/fetch-helpers.test.ts | three new test cases cover full 5.6 chain, bare alias, and per-tier opt-out; both env-stub tests now use vi.stubEnv/vi.unstubAllEnvs (previous raw process.env mutation addressed) |
| index.ts | error message updated to mention 5.6 tiers alongside gpt-5.5/gpt-5-codex; no logic changes |
| docs/configuration.md | env var table and 5.6 notes updated to reflect that the degradation chain works under the default strict policy; CODEX_AUTH_DISABLE_GPT56_AUTO_FALLBACK documented |
| docs/troubleshooting.md | fallback chain list and opt-out section expanded to cover all three 5.6 tiers; accurate and consistent with the code change |
| CHANGELOG.md | unreleased fixed entry accurately describes the root cause, the prior gap, and the opt-out mechanism |

<sub>Reviews (2): Last reviewed commit: ["test(review): scope auto-fallback opt-ou..."](https://github.com/ndycode/oc-codex-multi-auth/commit/2d54aa17ce276a4d15ce54207f0b78645a52230d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44461343)</sub>

<!-- /greptile_comment -->