### PR TITLE
fix(request): send Codex CLI client identity; stop pinning openai-organization (#196)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **`gpt-5.6-sol` rejected through the plugin while working in the Codex CLI/TUI for the same account**: two request-identity mismatches versus upstream Codex could make the backend evaluate a sol request against the wrong client or workspace context and return `model_not_supported_with_chatgpt_account` for an entitled account. First, the plugin declared `originator: codex_cli_rs` but sent the host runtime's `User-Agent`, while the backend reads the client version from the UA product token and the model catalog gates the 5.6 tiers on `minimal_client_version: 0.144.0`; requests now carry a Codex CLI `User-Agent` (`codex_cli_rs/<version> (<os>; <arch>)`), with `CODEX_AUTH_DISABLE_CODEX_USER_AGENT=1` to opt out and `CODEX_AUTH_CLIENT_VERSION` to override the advertised version. Second, the plugin pinned `openai-organization` on every request for accounts whose token carries an organization claim — a header upstream Codex never sends on ChatGPT-Codex requests (workspace routing is carried entirely by `chatgpt-account-id`), and one that can shift the backend's entitlement evaluation to a workspace outside the narrow sol preview while the broader terra/luna preview still passes. The header is no longer sent by default; multi-org setups that relied on it can restore it with `CODEX_AUTH_SEND_ORGANIZATION_HEADER=1`. Follow-up to the #196 auto-fallback fix in 6.8.1, prompted by the report that sol works in the Codex TUI and in opencode without the plugin but not through it; needs verification by an affected preview account. (#196)
+
 ## [6.8.1] - 2026-07-15
 
 ### Fixed

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -294,6 +294,9 @@ override any config with env vars:
 | `CODEX_AUTH_DISABLE_GPT55_AUTO_FALLBACK=1` | disable automatic `gpt-5.5 -> gpt-5.4` fallback during rollout |
 | `CODEX_AUTH_DISABLE_CODEX_AUTO_FALLBACK=1` | disable automatic canonical Codex/GPT-5.4-family fallback |
 | `CODEX_AUTH_ACCOUNT_ID=acc_xxx` | force specific workspace id |
+| `CODEX_AUTH_DISABLE_CODEX_USER_AGENT=1` | keep the host runtime's `User-Agent` instead of the Codex CLI identity |
+| `CODEX_AUTH_CLIENT_VERSION=0.150.0` | override the Codex CLI version advertised in the `User-Agent` |
+| `CODEX_AUTH_SEND_ORGANIZATION_HEADER=1` | restore legacy `openai-organization` request pinning (off by default; upstream Codex never sends it) |
 | `CODEX_AUTH_FETCH_TIMEOUT_MS=120000` | override fetch timeout |
 | `CODEX_AUTH_STREAM_STALL_TIMEOUT_MS=60000` | override SSE stall timeout |
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -362,12 +362,19 @@ resolvedConfig: { reasoningEffort: 'low', ... }  ← Should show your options
    opencode auth login
    ```
 2. Add another entitled account/workspace. The plugin tries remaining accounts/workspaces before model fallback.
-3. Default public selectors that are commonly entitlement-gated can auto-fallback: the GPT-5.6 preview tiers (`gpt-5.6-sol`/`gpt-5.6-terra`/`gpt-5.6-luna`) degrade down the tier chain to `gpt-5.5`, and `gpt-5.5`/canonical `gpt-5-codex` degrade through `gpt-5.4`, `gpt-5.4-mini`, then `gpt-5.4-nano`.
-4. Enable fallback policy if you also want automatic downgrades for manual/legacy selectors:
+3. **Model works in the Codex CLI/TUI but not through this plugin** (typically the newest preview tier, e.g. `gpt-5.6-sol`): the plugin now sends the same client identity Codex does — a `codex_cli_rs/<version>` `User-Agent` (the backend gates preview tiers on the catalog's `minimal_client_version`, read from the UA) — and no longer pins `openai-organization` (upstream Codex never sends it; workspace routing is carried by `chatgpt-account-id`, and org pinning could shift entitlement evaluation to a workspace outside the preview). Escape hatches if your setup relied on the old behavior:
+   ```bash
+   CODEX_AUTH_DISABLE_CODEX_USER_AGENT=1 opencode   # keep the host runtime's User-Agent
+   CODEX_AUTH_CLIENT_VERSION=0.150.0 opencode       # advertise a different Codex CLI version
+   CODEX_AUTH_SEND_ORGANIZATION_HEADER=1 opencode   # restore legacy openai-organization pinning
+   ```
+   If the model still fails only through the plugin, run `codex-health` and compare the failing pooled account ids against the account the Codex CLI uses (`~/.codex/auth.json`).
+4. Default public selectors that are commonly entitlement-gated can auto-fallback: the GPT-5.6 preview tiers (`gpt-5.6-sol`/`gpt-5.6-terra`/`gpt-5.6-luna`) degrade down the tier chain to `gpt-5.5`, and `gpt-5.5`/canonical `gpt-5-codex` degrade through `gpt-5.4`, `gpt-5.4-mini`, then `gpt-5.4-nano`.
+5. Enable fallback policy if you also want automatic downgrades for manual/legacy selectors:
    ```bash
    CODEX_AUTH_UNSUPPORTED_MODEL_POLICY=fallback opencode
    ```
-5. Default fallback chain (auto-fallback for the 5.6 tiers and `gpt-5.5`/`gpt-5-codex`; full chain when policy is `fallback` and not overridden):
+6. Default fallback chain (auto-fallback for the 5.6 tiers and `gpt-5.5`/`gpt-5-codex`; full chain when policy is `fallback` and not overridden):
    - `gpt-5.6-sol -> gpt-5.6-terra -> gpt-5.6-luna -> gpt-5.5` (then the `gpt-5.5` chain below)
    - `gpt-5.5 -> gpt-5.4 -> gpt-5.4-mini -> gpt-5.4-nano`
    - `gpt-5-codex -> gpt-5.4 -> gpt-5.4-mini -> gpt-5.4-nano`
@@ -376,7 +383,7 @@ resolvedConfig: { reasoningEffort: 'low', ... }  ← Should show your options
    - `gpt-5.3-codex-spark -> gpt-5-codex -> gpt-5.3-codex -> gpt-5.2-codex` (if Spark IDs are selected manually)
    - `gpt-5.2-codex -> gpt-5-codex`
    - `gpt-5.1-codex -> gpt-5-codex`
-6. Configure a custom fallback chain in `~/.opencode/openai-codex-auth-config.json`:
+7. Configure a custom fallback chain in `~/.opencode/openai-codex-auth-config.json`:
    ```json
    {
    "unsupportedCodexPolicy": "fallback",
@@ -391,26 +398,26 @@ resolvedConfig: { reasoningEffort: 'low', ... }  ← Should show your options
      }
    }
    ```
-7. Use strict mode for explicit entitlement failures outside the default public selector auto-fallbacks:
+8. Use strict mode for explicit entitlement failures outside the default public selector auto-fallbacks:
    ```bash
    CODEX_AUTH_UNSUPPORTED_MODEL_POLICY=strict opencode
    ```
-8. Disable default-selector auto-fallbacks when you need strict entitlement failures for those selectors:
+9. Disable default-selector auto-fallbacks when you need strict entitlement failures for those selectors:
    ```bash
    CODEX_AUTH_DISABLE_GPT56_AUTO_FALLBACK=1 opencode
    CODEX_AUTH_DISABLE_GPT55_AUTO_FALLBACK=1 opencode
    CODEX_AUTH_DISABLE_CODEX_AUTO_FALLBACK=1 opencode
    ```
    Each variable only disables its own automatic default-selector fallback path (`GPT56` covers all three 5.6 tiers); explicit `unsupportedCodexPolicy: "fallback"` chains still apply.
-9. Legacy compatibility toggle (only controls `gpt-5.3-codex -> gpt-5.2-codex`):
+10. Legacy compatibility toggle (only controls `gpt-5.3-codex -> gpt-5.2-codex`):
    ```bash
    CODEX_AUTH_FALLBACK_GPT53_TO_GPT52=0 opencode
    ```
-10. Legacy generic fallback toggle compatibility:
+11. Legacy generic fallback toggle compatibility:
    ```bash
    CODEX_AUTH_FALLBACK_UNSUPPORTED_MODEL=1 opencode
    ```
-11. Verify effective upstream model when debugging Spark/fallback behavior:
+12. Verify effective upstream model when debugging Spark/fallback behavior:
    ```bash
    ENABLE_PLUGIN_REQUEST_LOGGING=1 CODEX_PLUGIN_LOG_BODIES=1 opencode run "ping" --model=openai/gpt-5.3-codex-spark
    ```

--- a/lib/request/fetch-helpers.ts
+++ b/lib/request/fetch-helpers.ts
@@ -29,6 +29,7 @@ import {
 	shapeBodyForModel,
 	usesResponsesLite,
 } from "./helpers/responses-lite.js";
+import { buildCodexUserAgent } from "./helpers/user-agent.js";
 import { convertSseToJson, ensureContentType } from "./response-handler.js";
 import type { OAuthAuthDetails, UserConfig, RequestBody } from "../types.js";
 import { CodexAuthError } from "../errors.js";
@@ -837,6 +838,15 @@ export function createCodexHeaders(
 		headers.delete(RESPONSES_LITE_HEADER);
 	}
 
+	// The backend reads the client version from the User-Agent product token
+	// and gates preview tiers on the catalog's `minimal_client_version`
+	// (0.144.0 for gpt-5.6-*). The host runtime's UA fails that gate even
+	// though we already declare `originator: codex_cli_rs`, so send the Codex
+	// CLI identity the originator claims (#196).
+	if (process.env.CODEX_AUTH_DISABLE_CODEX_USER_AGENT !== "1") {
+		headers.set("user-agent", buildCodexUserAgent());
+	}
+
     const cacheKey = opts?.promptCacheKey;
     if (cacheKey) {
         headers.set(OPENAI_HEADERS.CONVERSATION_ID, cacheKey);
@@ -846,9 +856,20 @@ export function createCodexHeaders(
         headers.delete(OPENAI_HEADERS.SESSION_ID);
     }
 
+    // Upstream Codex never sends `openai-organization` on ChatGPT-Codex
+    // requests — workspace routing is carried entirely by `chatgpt-account-id`.
+    // Pinning an org can shift the backend's entitlement evaluation to a
+    // workspace outside a limited preview and 400 an otherwise-entitled
+    // account (gpt-5.6-sol, #196). Legacy behavior stays opt-in for multi-org
+    // setups that relied on it.
     const organizationId = opts?.organizationId;
-    if (organizationId) {
+    if (
+        organizationId &&
+        process.env.CODEX_AUTH_SEND_ORGANIZATION_HEADER === "1"
+    ) {
         headers.set(OPENAI_HEADERS.ORGANIZATION_ID, organizationId);
+    } else {
+        headers.delete(OPENAI_HEADERS.ORGANIZATION_ID);
     }
 
     headers.set("accept", "text/event-stream");

--- a/lib/request/helpers/user-agent.ts
+++ b/lib/request/helpers/user-agent.ts
@@ -1,0 +1,44 @@
+/**
+ * Codex CLI client-identity parity for backend requests.
+ *
+ * The ChatGPT Codex backend derives the client version from the `User-Agent`
+ * product token (codex-rs `login/src/auth/default_client.rs`,
+ * `get_codex_user_agent()`), and model catalog entries carry a
+ * `minimal_client_version` gate — `0.144.0` for the gpt-5.6 tiers. We already
+ * declare `originator: codex_cli_rs`; without a matching UA the backend sees a
+ * versionless client and can reject preview-gated models with
+ * `model_not_supported_with_chatgpt_account` even for entitled accounts (#196).
+ *
+ * Upstream format:
+ *   codex_cli_rs/<version> (<os> <os version>; <arch>) <terminal>
+ */
+import os from "node:os";
+
+/**
+ * Version advertised in the User-Agent product token. Tracks the highest
+ * `minimal_client_version` in the upstream model catalog (gpt-5.6 tiers);
+ * override with CODEX_AUTH_CLIENT_VERSION if the backend gate moves before a
+ * plugin release does.
+ */
+export const DEFAULT_CODEX_CLIENT_VERSION = "0.144.0";
+
+const PLATFORM_LABELS: Record<string, string> = {
+	win32: "Windows",
+	darwin: "Mac OS",
+	linux: "Linux",
+};
+
+/** Upstream sanitizes the UA to printable ASCII; mirror that. */
+function sanitizeToken(value: string): string {
+	return value.replace(/[^\x20-\x7e]/g, "").trim();
+}
+
+export function buildCodexUserAgent(): string {
+	const envVersion = process.env.CODEX_AUTH_CLIENT_VERSION;
+	const version =
+		(envVersion ? sanitizeToken(envVersion) : "") || DEFAULT_CODEX_CLIENT_VERSION;
+	const platform = PLATFORM_LABELS[os.platform()] ?? os.platform();
+	const release = sanitizeToken(os.release());
+	const arch = os.arch();
+	return `codex_cli_rs/${version} (${platform} ${release}; ${arch}) unknown`;
+}

--- a/test/accounts-warm-request.test.ts
+++ b/test/accounts-warm-request.test.ts
@@ -108,11 +108,24 @@ describe("warmAccountWindow (#182)", () => {
 		await expect(warmAccountWindow({ ...PARAMS, fetchImpl })).rejects.toThrow(/ECONNRESET/);
 	});
 
-	it("passes organizationId into the request headers when present", async () => {
+	it("does not pin openai-organization by default (Codex CLI parity, #196)", async () => {
 		const fetchImpl = vi.fn(async () => fakeResponse(200));
 		await warmAccountWindow({ ...PARAMS, organizationId: "org-9", fetchImpl });
 		const [, init] = fetchImpl.mock.calls[0] as [string, RequestInit];
 		const headers = init.headers as Headers;
-		expect(headers.get("openai-organization")).toBe("org-9");
+		expect(headers.get("openai-organization")).toBeNull();
+	});
+
+	it("passes organizationId into the request headers when CODEX_AUTH_SEND_ORGANIZATION_HEADER=1", async () => {
+		try {
+			vi.stubEnv("CODEX_AUTH_SEND_ORGANIZATION_HEADER", "1");
+			const fetchImpl = vi.fn(async () => fakeResponse(200));
+			await warmAccountWindow({ ...PARAMS, organizationId: "org-9", fetchImpl });
+			const [, init] = fetchImpl.mock.calls[0] as [string, RequestInit];
+			const headers = init.headers as Headers;
+			expect(headers.get("openai-organization")).toBe("org-9");
+		} finally {
+			vi.unstubAllEnvs();
+		}
 	});
 });

--- a/test/fetch-helpers.test.ts
+++ b/test/fetch-helpers.test.ts
@@ -223,6 +223,54 @@ describe('Fetch Helpers Module', () => {
 			expect(headers.get(OPENAI_HEADERS.SESSION_ID)).toBeNull();
 		});
 
+		it('sends a Codex CLI user-agent by default, replacing the host user-agent', () => {
+			const init = { headers: { 'user-agent': 'opencode/1.17.20' } } as any;
+			const headers = createCodexHeaders(init, accountId, accessToken, { model: 'gpt-5.6-sol' });
+			expect(headers.get('user-agent')).toMatch(/^codex_cli_rs\/\d+\.\d+\.\d+ \(/);
+		});
+
+		it('honors the CODEX_AUTH_DISABLE_CODEX_USER_AGENT opt-out', () => {
+			try {
+				vi.stubEnv('CODEX_AUTH_DISABLE_CODEX_USER_AGENT', '1');
+				const init = { headers: { 'user-agent': 'opencode/1.17.20' } } as any;
+				const headers = createCodexHeaders(init, accountId, accessToken, { model: 'gpt-5.6-sol' });
+				expect(headers.get('user-agent')).toBe('opencode/1.17.20');
+			} finally {
+				vi.unstubAllEnvs();
+			}
+		});
+
+		it('advertises CODEX_AUTH_CLIENT_VERSION when overridden', () => {
+			try {
+				vi.stubEnv('CODEX_AUTH_CLIENT_VERSION', '0.150.2');
+				const headers = createCodexHeaders(undefined, accountId, accessToken, { model: 'gpt-5.6-sol' });
+				expect(headers.get('user-agent')).toMatch(/^codex_cli_rs\/0\.150\.2 \(/);
+			} finally {
+				vi.unstubAllEnvs();
+			}
+		});
+
+		it('does not send openai-organization by default (Codex CLI parity, #196)', () => {
+			const headers = createCodexHeaders(undefined, accountId, accessToken, { model: 'gpt-5.6-sol', organizationId: 'org-123' });
+			expect(headers.get(OPENAI_HEADERS.ORGANIZATION_ID)).toBeNull();
+		});
+
+		it('strips an inherited openai-organization header by default', () => {
+			const init = { headers: { [OPENAI_HEADERS.ORGANIZATION_ID]: 'org-stale' } } as any;
+			const headers = createCodexHeaders(init, accountId, accessToken, { model: 'gpt-5' });
+			expect(headers.get(OPENAI_HEADERS.ORGANIZATION_ID)).toBeNull();
+		});
+
+		it('sends openai-organization when CODEX_AUTH_SEND_ORGANIZATION_HEADER=1', () => {
+			try {
+				vi.stubEnv('CODEX_AUTH_SEND_ORGANIZATION_HEADER', '1');
+				const headers = createCodexHeaders(undefined, accountId, accessToken, { model: 'gpt-5.6-sol', organizationId: 'org-123' });
+				expect(headers.get(OPENAI_HEADERS.ORGANIZATION_ID)).toBe('org-123');
+			} finally {
+				vi.unstubAllEnvs();
+			}
+		});
+
 		it('maps usage_not_included 404 to 403 entitlement error, not rate limit', async () => {
 			const body = {
 				error: {

--- a/test/helper-utils.test.ts
+++ b/test/helper-utils.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import {
 	rewriteUrlForCodex,
 	extractRequestUrl,
@@ -207,12 +207,25 @@ describe("Helper Utilities", () => {
 			expect(headers.get("X-Custom-Header")).toBe("custom-value");
 		});
 
-		it("should set organization_id when provided", () => {
+		it("should not set organization_id by default even when provided (Codex CLI parity, #196)", () => {
 			const headers = createCodexHeaders(undefined, accountId, accessToken, {
 				organizationId: "org-123",
 			});
 
-			expect(headers.get(OPENAI_HEADERS.ORGANIZATION_ID)).toBe("org-123");
+			expect(headers.get(OPENAI_HEADERS.ORGANIZATION_ID)).toBeNull();
+		});
+
+		it("should set organization_id when provided and CODEX_AUTH_SEND_ORGANIZATION_HEADER=1", () => {
+			try {
+				vi.stubEnv("CODEX_AUTH_SEND_ORGANIZATION_HEADER", "1");
+				const headers = createCodexHeaders(undefined, accountId, accessToken, {
+					organizationId: "org-123",
+				});
+
+				expect(headers.get(OPENAI_HEADERS.ORGANIZATION_ID)).toBe("org-123");
+			} finally {
+				vi.unstubAllEnvs();
+			}
 		});
 
 		it("should not set organization_id when not provided", () => {


### PR DESCRIPTION
## Summary

Follow-up to #197 / 6.8.1, prompted by [nxtkofi's reply on #196](https://github.com/ndycode/oc-codex-multi-auth/issues/196#issuecomment-4984558891): `gpt-5.6-sol` works in the Codex TUI (and in opencode with the plugin uninstalled) but is rejected through the plugin with `model_not_supported_with_chatgpt_account` on every pooled account — while terra/luna work fine through the plugin. The 6.8.1 auto-fallback fix only made sol degrade gracefully; this PR addresses the rejection itself.

## Root cause analysis

Diffing our request against upstream `openai/codex` (codex-rs) found two identity mismatches, both consistent with a sol-only failure while terra/luna pass:

1. **No Codex `User-Agent`.** We declare `originator: codex_cli_rs` but send the host runtime's UA. The backend reads the client version from the UA product token (`get_codex_user_agent()` in `codex-rs/login/src/auth/default_client.rs`), and the model catalog gates the 5.6 tiers on `minimal_client_version: 0.144.0` (`codex-rs/models-manager/models.json`). A versionless client identity fails that gate.
2. **Non-upstream `openai-organization` pinning.** Since 9508791 we set `openai-organization` on every request whenever the token carries an organization claim — pinned to `organizations[0]` from the id token, which is not necessarily the workspace `chatgpt-account-id` points at. Upstream Codex never sends this header on ChatGPT-Codex requests; workspace routing is carried entirely by `chatgpt-account-id`. Pinning an org can shift the backend's entitlement evaluation to a workspace outside the narrow sol preview while the broader terra/luna preview still passes. The local org-variant dedup from 9508791 is untouched.

`model_not_supported_with_chatgpt_account` appears nowhere in the upstream client — it is a pure backend entitlement decision, so misclassification on our side is ruled out (detection requires HTTP 400 + the exact backend code/message).

## Changes

- New `lib/request/helpers/user-agent.ts`: builds `codex_cli_rs/<version> (<os> <osver>; <arch>) unknown` (verified output on Windows: `codex_cli_rs/0.144.0 (Windows 10.0.26100; x64) unknown`). Version tracks the catalog's highest `minimal_client_version`; override with `CODEX_AUTH_CLIENT_VERSION`, opt out with `CODEX_AUTH_DISABLE_CODEX_USER_AGENT=1`.
- `createCodexHeaders` now sets that UA by default and sends `openai-organization` only when `CODEX_AUTH_SEND_ORGANIZATION_HEADER=1` (legacy behavior, opt-in); an inherited org header is stripped otherwise.
- Docs: troubleshooting step for "works in Codex CLI but not through the plugin", env-var table entries; CHANGELOG entry under Unreleased.

Each change has its own escape hatch so the reporter can bisect which one matters if needed.

## Testing

- TDD: 6 new unit tests written first (red), then implementation (green) — UA default/opt-out/version override, org header default-absent/inherited-strip/opt-in; 2 legacy tests asserting the old org-pinning default updated, with opt-in coverage retained (`vi.stubEnv` per suite convention).
- Full suite: **2765 passed, 1 skipped**; `tsc --noEmit` clean; `eslint --max-warnings=0` clean.
- ⚠️ Cannot be verified against the live backend from here — sol is a limited preview and requires an enrolled account. Needs confirmation from @nxtkofi (or another sol-entitled account) before release.

Closes #196 pending reporter verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility for preview models when using the plugin through the Codex CLI or TUI.
  * Requests now better match Codex CLI client identification and no longer send organization routing information by default.
  * Added configuration options to customize client version reporting, disable Codex identification, or restore organization header behavior.

* **Documentation**
  * Expanded authentication troubleshooting guidance, fallback configuration details, and debugging steps for entitlement-related model errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

fixes `gpt-5.6-sol` backend rejections by aligning the plugin's request identity with upstream codex-rs: the plugin now sends a `codex_cli_rs/<version>` `User-Agent` (required by the backend's `minimal_client_version` gate) and stops pinning `openai-organization` by default (upstream codex never sends it; org pinning can shift entitlement evaluation to the wrong workspace).

- `lib/request/helpers/user-agent.ts` — new module builds the codex cli ua string from `os` metadata with sanitization; version is env-overridable via `CODEX_AUTH_CLIENT_VERSION`, feature is opt-out via `CODEX_AUTH_DISABLE_CODEX_USER_AGENT=1`.
- `createCodexHeaders` in `fetch-helpers.ts` — ua injection added before the org-header block; org header now suppressed by default with an unconditional `headers.delete` in the else branch (correctly evicts inherited headers from `init`); legacy pinning restored with `CODEX_AUTH_SEND_ORGANIZATION_HEADER=1`.
- 6 new unit tests cover all new env-var branches; 2 legacy org-pinning tests updated; `vi.stubEnv`/`vi.unstubAllEnvs()` used consistently throughout.

<h3>Confidence Score: 4/5</h3>

safe to merge; the two behavior changes are both gated behind env-var escape hatches so existing deployments can opt out, and the new default aligns with upstream codex behavior

the core logic is correct and well-tested. the only issues are in `user-agent.ts`: `os.arch()` skips sanitization (inconsistency, not an exploitable risk), `sanitizeToken` preserves internal spaces so a version env var with embedded whitespace produces a malformed ua product token, and `buildCodexUserAgent` has no direct unit tests covering its edge cases. none of these affect the correctness of the primary fix.

lib/request/helpers/user-agent.ts — `os.arch()` sanitization inconsistency and internal-space handling in `sanitizeToken`; no dedicated unit tests for `buildCodexUserAgent` edge cases

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/request/helpers/user-agent.ts | new module that builds the codex cli user-agent string; logic is sound but `os.arch()` is not sanitized (inconsistency vs `os.release()`), and internal spaces in `CODEX_AUTH_CLIENT_VERSION` produce a malformed product token |
| lib/request/fetch-helpers.ts | adds codex ua injection and strips `openai-organization` by default; both changes are gated cleanly behind env vars, and the unconditional `headers.delete` in the else branch correctly evicts any inherited org header from the incoming init |
| test/fetch-helpers.test.ts | 6 new tests covering ua default/opt-out/version-override and org-header default-absent/inherited-strip/opt-in; all use `vi.stubEnv` + `vi.unstubAllEnvs()` per suite convention, no leaked env state |
| test/helper-utils.test.ts | existing org-pinning tests correctly updated to assert new default-off behavior, opt-in path retained with stubbed env; consistent with suite conventions |
| test/accounts-warm-request.test.ts | warm-request org-header test split into default-off and opt-in cases; env teardown handled correctly via try/finally |
| docs/configuration.md | three new env-var table entries added correctly; ordering is consistent with the surrounding entries |
| docs/troubleshooting.md | new step 3 covers the 'works in codex cli but not plugin' scenario with escape hatches; numbering renumbered correctly throughout |
| CHANGELOG.md | unreleased entry is detailed and accurately describes both root causes and both escape hatches; no issues |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Host as host runtime
    participant CH as createCodexHeaders
    participant UA as buildCodexUserAgent
    participant BE as Codex backend

    Host->>CH: init with possible host UA and org header
    CH->>CH: strip x-api-key, set Authorization and originator
    alt UA injection enabled
        CH->>UA: buildCodexUserAgent
        UA-->>CH: codex_cli_rs version string
        CH->>CH: set user-agent to codex UA
    end
    alt organizationId present and opt-in env set
        CH->>CH: set openai-organization header
    else default
        CH->>CH: delete openai-organization header
    end
    CH-->>Host: Headers with codex identity
    Host->>BE: POST with chatgpt-account-id and codex UA
    BE->>BE: check minimal_client_version gate for gpt-5.6
    BE-->>Host: 200 OK
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Host as host runtime
    participant CH as createCodexHeaders
    participant UA as buildCodexUserAgent
    participant BE as Codex backend

    Host->>CH: init with possible host UA and org header
    CH->>CH: strip x-api-key, set Authorization and originator
    alt UA injection enabled
        CH->>UA: buildCodexUserAgent
        UA-->>CH: codex_cli_rs version string
        CH->>CH: set user-agent to codex UA
    end
    alt organizationId present and opt-in env set
        CH->>CH: set openai-organization header
    else default
        CH->>CH: delete openai-organization header
    end
    CH-->>Host: Headers with codex identity
    Host->>BE: POST with chatgpt-account-id and codex UA
    BE->>BE: check minimal_client_version gate for gpt-5.6
    BE-->>Host: 200 OK
```

</a>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Foc-codex-multi-auth%22%20on%20the%20existing%20branch%20%22fix%2Fgpt56-sol-client-identity%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fgpt56-sol-client-identity%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Alib%2Frequest%2Fhelpers%2Fuser-agent.ts%3A42-43%0A%60os.arch%28%29%60%20not%20passed%20through%20%60sanitizeToken%60%20%E2%80%94%20inconsistency%20with%20%60os.release%28%29%60%0A%0A%60os.release%28%29%60%20is%20sanitized%20but%20%60os.arch%28%29%60%20is%20injected%20raw.%20node's%20%60os.arch%28%29%60%20always%20returns%20well-constrained%20ascii%20strings%20%28%60x64%60%2C%20%60arm64%60%2C%20etc.%29%20so%20there's%20no%20practical%20injection%20risk%20today%2C%20but%20the%20inconsistency%20leaves%20the%20door%20open%20if%20a%20future%20version%20of%20node%20or%20a%20non-standard%20runtime%20returns%20something%20unexpected.%20on%20windows%2C%20both%20values%20are%20user-controlled%20at%20the%20os%20level%2C%20so%20applying%20the%20same%20sanitization%20pattern%20to%20%60arch%60%20would%20keep%20the%20contract%20consistent.%0A%0A%23%23%23%20Issue%202%20of%203%0Alib%2Frequest%2Fhelpers%2Fuser-agent.ts%3A32-34%0A%60sanitizeToken%60%20keeps%20internal%20spaces%20%280x20%20is%20in%20%60%5Cx20-%5Cx7e%60%29%2C%20so%20%60CODEX_AUTH_CLIENT_VERSION%3D1.0.0%20custom%60%20produces%20%60codex_cli_rs%2F1.0.0%20custom%20%28...%29%60%20%E2%80%94%20a%20malformed%20product%20token%20per%20rfc%207230.%20%60trim%28%29%60%20only%20strips%20leading%2Ftrailing%20spaces%2C%20not%20internal%20ones.%20a%20user%20who%20sets%20%60CODEX_AUTH_CLIENT_VERSION%60%20to%20a%20semver%20with%20embedded%20whitespace%20%28unlikely%20but%20possible%20on%20some%20config%20injection%20paths%20on%20windows%29%20would%20silently%20advertise%20a%20broken%20ua%20that%20the%20backend%20may%20not%20parse.%20consider%20replacing%20internal%20whitespace%20with%20an%20empty%20string%20or%20rejecting%20the%20value%20when%20it%20doesn't%20look%20like%20a%20semver%20token.%0A%0A%23%23%23%20Issue%203%20of%203%0Alib%2Frequest%2Fhelpers%2Fuser-agent.ts%3A36-44%0Amissing%20direct%20vitest%20coverage%20for%20%60buildCodexUserAgent%60%0A%0Athe%20function%20is%20only%20exercised%20indirectly%20via%20%60createCodexHeaders%60.%20the%20following%20cases%20aren't%20covered%3A%20%28a%29%20all-whitespace%20%60CODEX_AUTH_CLIENT_VERSION%60%20%28should%20fall%20back%20to%20%60DEFAULT_CODEX_CLIENT_VERSION%60%20%E2%80%94%20the%20logic%20is%20correct%20but%20untested%29%2C%20%28b%29%20non-ascii%20bytes%20in%20%60CODEX_AUTH_CLIENT_VERSION%60%20%28sanitization%20path%29%2C%20%28c%29%20unknown%20platform%20fallback%20%28when%20%60os.platform%28%29%60%20returns%20something%20not%20in%20%60PLATFORM_LABELS%60%29.%20a%20dedicated%20%60user-agent.test.ts%60%20%28or%20added%20cases%20in%20%60helper-utils.test.ts%60%29%20would%20lock%20these%20in.%0A%0A&repo=ndycode%2Foc-codex-multi-auth&pr=199&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
lib/request/helpers/user-agent.ts:42-43
`os.arch()` not passed through `sanitizeToken` — inconsistency with `os.release()`

`os.release()` is sanitized but `os.arch()` is injected raw. node's `os.arch()` always returns well-constrained ascii strings (`x64`, `arm64`, etc.) so there's no practical injection risk today, but the inconsistency leaves the door open if a future version of node or a non-standard runtime returns something unexpected. on windows, both values are user-controlled at the os level, so applying the same sanitization pattern to `arch` would keep the contract consistent.

### Issue 2 of 3
lib/request/helpers/user-agent.ts:32-34
`sanitizeToken` keeps internal spaces (0x20 is in `\x20-\x7e`), so `CODEX_AUTH_CLIENT_VERSION=1.0.0 custom` produces `codex_cli_rs/1.0.0 custom (...)` — a malformed product token per rfc 7230. `trim()` only strips leading/trailing spaces, not internal ones. a user who sets `CODEX_AUTH_CLIENT_VERSION` to a semver with embedded whitespace (unlikely but possible on some config injection paths on windows) would silently advertise a broken ua that the backend may not parse. consider replacing internal whitespace with an empty string or rejecting the value when it doesn't look like a semver token.

### Issue 3 of 3
lib/request/helpers/user-agent.ts:36-44
missing direct vitest coverage for `buildCodexUserAgent`

the function is only exercised indirectly via `createCodexHeaders`. the following cases aren't covered: (a) all-whitespace `CODEX_AUTH_CLIENT_VERSION` (should fall back to `DEFAULT_CODEX_CLIENT_VERSION` — the logic is correct but untested), (b) non-ascii bytes in `CODEX_AUTH_CLIENT_VERSION` (sanitization path), (c) unknown platform fallback (when `os.platform()` returns something not in `PLATFORM_LABELS`). a dedicated `user-agent.test.ts` (or added cases in `helper-utils.test.ts`) would lock these in.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(request): send Codex CLI client iden..."](https://github.com/ndycode/oc-codex-multi-auth/commit/def180f1b000da1127d7c249302de7038a09688f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44757619)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->