### PR TITLE
fix(request): default gpt-5.6 tiers to the host (opencode) client identity (#196)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -310,8 +310,10 @@ override any config with env vars:
 | `CODEX_AUTH_DISABLE_GPT55_AUTO_FALLBACK=1` | disable automatic `gpt-5.5 -> gpt-5.4` fallback during rollout |
 | `CODEX_AUTH_DISABLE_CODEX_AUTO_FALLBACK=1` | disable automatic canonical Codex/GPT-5.4-family fallback |
 | `CODEX_AUTH_ACCOUNT_ID=acc_xxx` | force specific workspace id |
-| `CODEX_AUTH_DISABLE_CODEX_USER_AGENT=1` | keep the host runtime's `User-Agent` instead of the Codex CLI identity |
-| `CODEX_AUTH_CLIENT_VERSION=0.150.0` | override the Codex CLI version advertised in the `User-Agent` |
+| `CODEX_AUTH_CLIENT_IDENTITY=codex` | force one client identity for all models: `codex` (`originator: codex_cli_rs`) or `opencode` (`originator: opencode`). Default: `opencode` for the GPT-5.6 tiers, `codex` for everything else |
+| `CODEX_AUTH_DISABLE_CODEX_USER_AGENT=1` | keep the host runtime's `User-Agent` instead of the identity's `User-Agent` |
+| `CODEX_AUTH_CLIENT_VERSION=0.150.0` | override the Codex CLI version advertised in the `codex_cli_rs` `User-Agent` |
+| `CODEX_AUTH_HOST_VERSION=1.18.0` | override the opencode version advertised in the `opencode` `User-Agent` |
 | `CODEX_AUTH_SEND_ORGANIZATION_HEADER=1` | restore legacy `openai-organization` request pinning (off by default; upstream Codex never sends it) |
 | `CODEX_AUTH_FETCH_TIMEOUT_MS=120000` | override fetch timeout |
 | `CODEX_AUTH_STREAM_STALL_TIMEOUT_MS=60000` | override SSE stall timeout |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -310,10 +310,10 @@ override any config with env vars:
 | `CODEX_AUTH_DISABLE_GPT55_AUTO_FALLBACK=1` | disable automatic `gpt-5.5 -> gpt-5.4` fallback during rollout |
 | `CODEX_AUTH_DISABLE_CODEX_AUTO_FALLBACK=1` | disable automatic canonical Codex/GPT-5.4-family fallback |
 | `CODEX_AUTH_ACCOUNT_ID=acc_xxx` | force specific workspace id |
-| `CODEX_AUTH_CLIENT_IDENTITY=codex` | force one client identity for all models: `codex` (`originator: codex_cli_rs`) or `opencode` (`originator: opencode`). Default: `opencode` for the GPT-5.6 tiers, `codex` for everything else |
+| `CODEX_AUTH_CLIENT_IDENTITY=codex` | force one client identity for all models: `codex` (`originator: codex_cli_rs`) or `opencode` (alias `host`; `originator: opencode`). Default: `opencode` for the GPT-5.6 tiers, `codex` for everything else |
 | `CODEX_AUTH_DISABLE_CODEX_USER_AGENT=1` | keep the host runtime's `User-Agent` instead of the identity's `User-Agent` |
 | `CODEX_AUTH_CLIENT_VERSION=0.150.0` | override the Codex CLI version advertised in the `codex_cli_rs` `User-Agent` |
-| `CODEX_AUTH_HOST_VERSION=1.18.0` | override the opencode version advertised in the `opencode` `User-Agent` |
+| `CODEX_AUTH_HOST_VERSION=1.18.0` | override the opencode version advertised in the `opencode` `User-Agent` (default: the host runtime's own UA version when it injects one, else a baked-in fallback) |
 | `CODEX_AUTH_SEND_ORGANIZATION_HEADER=1` | restore legacy `openai-organization` request pinning (off by default; upstream Codex never sends it) |
 | `CODEX_AUTH_FETCH_TIMEOUT_MS=120000` | override fetch timeout |
 | `CODEX_AUTH_STREAM_STALL_TIMEOUT_MS=60000` | override SSE stall timeout |

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -362,10 +362,13 @@ resolvedConfig: { reasoningEffort: 'low', ... }  ← Should show your options
    opencode auth login
    ```
 2. Add another entitled account/workspace. The plugin tries remaining accounts/workspaces before model fallback.
-3. **Model works in the Codex CLI/TUI but not through this plugin** (typically the newest preview tier, e.g. `gpt-5.6-sol`): the plugin now sends the same client identity Codex does — a `codex_cli_rs/<version>` `User-Agent` (the backend gates preview tiers on the catalog's `minimal_client_version`, read from the UA) — and no longer pins `openai-organization` (upstream Codex never sends it; workspace routing is carried by `chatgpt-account-id`, and org pinning could shift entitlement evaluation to a workspace outside the preview). Escape hatches if your setup relied on the old behavior:
+3. **Model works in the Codex CLI/TUI or plain opencode but not through this plugin** (typically the newest preview tier, e.g. `gpt-5.6-sol`): the backend evaluates model entitlement per client identity (`originator` + `User-Agent`). The plugin defaults GPT-5.6 tiers to the host identity (`originator: opencode`, the one plain opencode passes sol with) and everything else to the Codex CLI identity (`codex_cli_rs/<version>`; the backend gates those tiers on the catalog's `minimal_client_version`, read from the UA). It never pins `openai-organization` (upstream clients don't send it; workspace routing is carried by `chatgpt-account-id`). Escape hatches:
    ```bash
+   CODEX_AUTH_CLIENT_IDENTITY=codex opencode        # force the Codex CLI identity for all models
+   CODEX_AUTH_CLIENT_IDENTITY=opencode opencode     # force the host identity for all models
    CODEX_AUTH_DISABLE_CODEX_USER_AGENT=1 opencode   # keep the host runtime's User-Agent
    CODEX_AUTH_CLIENT_VERSION=0.150.0 opencode       # advertise a different Codex CLI version
+   CODEX_AUTH_HOST_VERSION=1.18.0 opencode          # advertise a different opencode version
    CODEX_AUTH_SEND_ORGANIZATION_HEADER=1 opencode   # restore legacy openai-organization pinning
    ```
    If the model still fails only through the plugin, run `codex-health` and compare the failing pooled account ids against the account the Codex CLI uses (`~/.codex/auth.json`).

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -362,7 +362,7 @@ resolvedConfig: { reasoningEffort: 'low', ... }  ← Should show your options
    opencode auth login
    ```
 2. Add another entitled account/workspace. The plugin tries remaining accounts/workspaces before model fallback.
-3. **Model works in the Codex CLI/TUI or plain opencode but not through this plugin** (typically the newest preview tier, e.g. `gpt-5.6-sol`): the backend evaluates model entitlement per client identity (`originator` + `User-Agent`). The plugin defaults GPT-5.6 tiers to the host identity (`originator: opencode`, the one plain opencode passes sol with) and everything else to the Codex CLI identity (`codex_cli_rs/<version>`; the backend gates those tiers on the catalog's `minimal_client_version`, read from the UA). It never pins `openai-organization` (upstream clients don't send it; workspace routing is carried by `chatgpt-account-id`). Escape hatches:
+3. **Model works in the Codex CLI/TUI or plain opencode but not through this plugin** (typically the newest preview tier, e.g. `gpt-5.6-sol`): the backend evaluates model entitlement per client identity (`originator` + `User-Agent`). The plugin defaults GPT-5.6 tiers to the host identity (`originator: opencode`, the one plain opencode passes sol with) and everything else to the Codex CLI identity (`codex_cli_rs/<version>`; the backend gates those tiers on the catalog's `minimal_client_version`, read from the UA). By default it does not pin `openai-organization` (upstream clients don't send it; workspace routing is carried by `chatgpt-account-id`). Escape hatches:
    ```bash
    CODEX_AUTH_CLIENT_IDENTITY=codex opencode        # force the Codex CLI identity for all models
    CODEX_AUTH_CLIENT_IDENTITY=opencode opencode     # force the host identity for all models

--- a/lib/request/fetch-helpers.ts
+++ b/lib/request/fetch-helpers.ts
@@ -29,7 +29,7 @@ import {
 	shapeBodyForModel,
 	usesResponsesLite,
 } from "./helpers/responses-lite.js";
-import { buildCodexUserAgent } from "./helpers/user-agent.js";
+import { resolveClientIdentity } from "./helpers/client-identity.js";
 import { convertSseToJson, ensureContentType } from "./response-handler.js";
 import type { OAuthAuthDetails, UserConfig, RequestBody } from "../types.js";
 import { CodexAuthError } from "../errors.js";
@@ -829,7 +829,6 @@ export function createCodexHeaders(
 	headers.set("Authorization", `Bearer ${accessToken}`);
 	headers.set(OPENAI_HEADERS.ACCOUNT_ID, accountId);
 	headers.set(OPENAI_HEADERS.BETA, OPENAI_HEADER_VALUES.BETA_RESPONSES);
-	headers.set(OPENAI_HEADERS.ORIGINATOR, OPENAI_HEADER_VALUES.ORIGINATOR_CODEX);
 
 	// GPT-5.6 models are served over the responses-lite path.
 	if (usesResponsesLite(opts?.model)) {
@@ -838,13 +837,15 @@ export function createCodexHeaders(
 		headers.delete(RESPONSES_LITE_HEADER);
 	}
 
-	// The backend reads the client version from the User-Agent product token
-	// and gates preview tiers on the catalog's `minimal_client_version`
-	// (0.144.0 for gpt-5.6-*). The host runtime's UA fails that gate even
-	// though we already declare `originator: codex_cli_rs`, so send the Codex
-	// CLI identity the originator claims (#196).
+	// Originator and UA must agree: the backend evaluates model entitlement
+	// per originator and reads the client version from the UA product token.
+	// gpt-5.6 tiers default to the host (opencode) identity — the one plain
+	// opencode passes sol with on accounts that reject `codex_cli_rs` (#196);
+	// everything else keeps the Codex CLI identity from PR #199.
+	const identity = resolveClientIdentity(opts?.model);
+	headers.set(OPENAI_HEADERS.ORIGINATOR, identity.originator);
 	if (process.env.CODEX_AUTH_DISABLE_CODEX_USER_AGENT !== "1") {
-		headers.set("user-agent", buildCodexUserAgent());
+		headers.set("user-agent", identity.userAgent);
 	}
 
     const cacheKey = opts?.promptCacheKey;

--- a/lib/request/fetch-helpers.ts
+++ b/lib/request/fetch-helpers.ts
@@ -841,8 +841,11 @@ export function createCodexHeaders(
 	// per originator and reads the client version from the UA product token.
 	// gpt-5.6 tiers default to the host (opencode) identity — the one plain
 	// opencode passes sol with on accounts that reject `codex_cli_rs` (#196);
-	// everything else keeps the Codex CLI identity from PR #199.
-	const identity = resolveClientIdentity(opts?.model);
+	// everything else keeps the Codex CLI identity from PR #199. The host's
+	// own UA (when the runtime injected one) keeps the advertised opencode
+	// version in sync with the real host build.
+	const hostUserAgent = headers.get("user-agent") ?? undefined;
+	const identity = resolveClientIdentity(opts?.model, hostUserAgent);
 	headers.set(OPENAI_HEADERS.ORIGINATOR, identity.originator);
 	if (process.env.CODEX_AUTH_DISABLE_CODEX_USER_AGENT !== "1") {
 		headers.set("user-agent", identity.userAgent);

--- a/lib/request/helpers/client-identity.ts
+++ b/lib/request/helpers/client-identity.ts
@@ -1,0 +1,81 @@
+/**
+ * Client-identity selection for backend requests (#196 follow-up).
+ *
+ * PR #199 made the plugin claim the Codex CLI identity (`originator:
+ * codex_cli_rs` + a matching UA) so the backend's `minimal_client_version`
+ * gate would pass for the gpt-5.6 tiers. nxtkofi's accounts still reject
+ * `gpt-5.6-sol` under that identity while accepting it from plain opencode —
+ * whose native ChatGPT-Codex path sends `originator: "opencode"` with a
+ * `opencode/<version> (<platform> <release>; <arch>)` UA to the same
+ * `/backend-api/codex/responses` endpoint. Sol's catalog entry is identical to
+ * terra/luna (`minimal_client_version: 0.144.0`, `use_responses_lite: true`),
+ * so the sol-only rejection is a per-originator entitlement decision on the
+ * backend, not a version or payload problem.
+ *
+ * Policy: gpt-5.6 (responses-lite) models default to the host identity that
+ * plain opencode is proven to pass with; every other model keeps the Codex CLI
+ * identity from PR #199. `CODEX_AUTH_CLIENT_IDENTITY=codex|opencode` forces
+ * one identity for all models.
+ */
+import os from "node:os";
+import { buildCodexUserAgent } from "./user-agent.js";
+import { usesResponsesLite } from "./responses-lite.js";
+import { OPENAI_HEADER_VALUES } from "../../constants.js";
+
+export type ClientIdentityMode = "codex" | "opencode";
+
+export interface ClientIdentity {
+	originator: string;
+	userAgent: string;
+}
+
+export const OPENCODE_ORIGINATOR = "opencode";
+
+/**
+ * Version advertised in the host UA product token. The backend does not
+ * version-gate the `opencode` originator the way it gates `codex_cli_rs`, so
+ * this only needs to look like a plausible host build; override with
+ * CODEX_AUTH_HOST_VERSION if that ever changes.
+ */
+export const DEFAULT_OPENCODE_VERSION = "1.17.20";
+
+function sanitizeToken(value: string): string {
+	return value.replace(/[^\x20-\x7e]/g, "").trim();
+}
+
+function resolveHostVersion(): string {
+	const envVersion = process.env.CODEX_AUTH_HOST_VERSION;
+	return (envVersion ? sanitizeToken(envVersion) : "") || DEFAULT_OPENCODE_VERSION;
+}
+
+/** Mirrors opencode's own ChatGPT-Codex UA: `opencode/<v> (<platform> <release>; <arch>)`. */
+export function buildOpencodeUserAgent(): string {
+	return `opencode/${resolveHostVersion()} (${os.platform()} ${sanitizeToken(os.release())}; ${os.arch()})`;
+}
+
+function forcedMode(): ClientIdentityMode | undefined {
+	const raw = process.env.CODEX_AUTH_CLIENT_IDENTITY?.trim().toLowerCase();
+	if (raw === "codex") return "codex";
+	if (raw === "opencode" || raw === "host") return "opencode";
+	return undefined;
+}
+
+/**
+ * Resolve the identity to present for a request against `model`.
+ *
+ * Accepts raw selectors (`openai/gpt-5.6-sol-xhigh`) as well as canonical ids;
+ * `undefined` (usage/reset endpoints) resolves to the Codex CLI identity.
+ */
+export function resolveClientIdentity(model?: string): ClientIdentity {
+	const mode = forcedMode() ?? (usesResponsesLite(model) ? "opencode" : "codex");
+	if (mode === "opencode") {
+		return {
+			originator: OPENCODE_ORIGINATOR,
+			userAgent: buildOpencodeUserAgent(),
+		};
+	}
+	return {
+		originator: OPENAI_HEADER_VALUES.ORIGINATOR_CODEX,
+		userAgent: buildCodexUserAgent(),
+	};
+}

--- a/lib/request/helpers/client-identity.ts
+++ b/lib/request/helpers/client-identity.ts
@@ -6,7 +6,8 @@
  * gate would pass for the gpt-5.6 tiers. nxtkofi's accounts still reject
  * `gpt-5.6-sol` under that identity while accepting it from plain opencode —
  * whose native ChatGPT-Codex path sends `originator: "opencode"` with a
- * `opencode/<version> (<platform> <release>; <arch>)` UA to the same
+ * `opencode/<version> (<platform> <release>; <arch>)` UA (raw `os.platform()`,
+ * per the bundled `W.headers["User-Agent"]` assignment) to the same
  * `/backend-api/codex/responses` endpoint. Sol's catalog entry is identical to
  * terra/luna (`minimal_client_version: 0.144.0`, `use_responses_lite: true`),
  * so the sol-only rejection is a per-originator entitlement decision on the
@@ -14,11 +15,11 @@
  *
  * Policy: gpt-5.6 (responses-lite) models default to the host identity that
  * plain opencode is proven to pass with; every other model keeps the Codex CLI
- * identity from PR #199. `CODEX_AUTH_CLIENT_IDENTITY=codex|opencode` forces
- * one identity for all models.
+ * identity from PR #199. `CODEX_AUTH_CLIENT_IDENTITY=codex|opencode` (alias
+ * `host` for `opencode`) forces one identity for all models.
  */
 import os from "node:os";
-import { buildCodexUserAgent } from "./user-agent.js";
+import { buildCodexUserAgent, sanitizeVersionToken } from "./user-agent.js";
 import { usesResponsesLite } from "./responses-lite.js";
 import { OPENAI_HEADER_VALUES } from "../../constants.js";
 
@@ -32,25 +33,39 @@ export interface ClientIdentity {
 export const OPENCODE_ORIGINATOR = "opencode";
 
 /**
- * Version advertised in the host UA product token. The backend does not
- * version-gate the `opencode` originator the way it gates `codex_cli_rs`, so
- * this only needs to look like a plausible host build; override with
- * CODEX_AUTH_HOST_VERSION if that ever changes.
+ * Last-resort version for the host UA product token. The live host version is
+ * preferred whenever the runtime injects its own `opencode/<version>` UA on
+ * the incoming request (self-syncing, no release-time bump needed); the
+ * backend does not currently version-gate the `opencode` originator, so this
+ * constant only has to look like a plausible host build. Override order:
+ * CODEX_AUTH_HOST_VERSION > host-injected UA version > this constant.
  */
 export const DEFAULT_OPENCODE_VERSION = "1.17.20";
 
-function sanitizeToken(value: string): string {
-	return value.replace(/[^\x20-\x7e]/g, "").trim();
+/** Extract `<version>` from a host-injected `opencode/<version> ...` UA. */
+function hostVersionFromUserAgent(hostUserAgent: string | undefined): string {
+	if (!hostUserAgent) return "";
+	const match = /^opencode\/([0-9A-Za-z.+_-]+)/.exec(hostUserAgent.trim());
+	return match?.[1] ?? "";
 }
 
-function resolveHostVersion(): string {
+function resolveHostVersion(hostUserAgent?: string): string {
 	const envVersion = process.env.CODEX_AUTH_HOST_VERSION;
-	return (envVersion ? sanitizeToken(envVersion) : "") || DEFAULT_OPENCODE_VERSION;
+	return (
+		(envVersion ? sanitizeVersionToken(envVersion) : "") ||
+		hostVersionFromUserAgent(hostUserAgent) ||
+		DEFAULT_OPENCODE_VERSION
+	);
 }
 
-/** Mirrors opencode's own ChatGPT-Codex UA: `opencode/<v> (<platform> <release>; <arch>)`. */
-export function buildOpencodeUserAgent(): string {
-	return `opencode/${resolveHostVersion()} (${os.platform()} ${sanitizeToken(os.release())}; ${os.arch()})`;
+/**
+ * Mirrors opencode's own ChatGPT-Codex UA: `opencode/<v> (<platform>
+ * <release>; <arch>)` with the raw `os.platform()` value (`win32`/`linux`/
+ * `darwin`), exactly as the bundled host emits it.
+ */
+export function buildOpencodeUserAgent(hostUserAgent?: string): string {
+	const release = os.release().replace(/[^\x20-\x7e]/g, "").trim();
+	return `opencode/${resolveHostVersion(hostUserAgent)} (${os.platform()} ${release}; ${os.arch()})`;
 }
 
 function forcedMode(): ClientIdentityMode | undefined {
@@ -65,13 +80,19 @@ function forcedMode(): ClientIdentityMode | undefined {
  *
  * Accepts raw selectors (`openai/gpt-5.6-sol-xhigh`) as well as canonical ids;
  * `undefined` (usage/reset endpoints) resolves to the Codex CLI identity.
+ * `hostUserAgent` is the UA the host runtime put on the incoming request, if
+ * any — used to keep the advertised opencode version in sync with the real
+ * host build.
  */
-export function resolveClientIdentity(model?: string): ClientIdentity {
+export function resolveClientIdentity(
+	model?: string,
+	hostUserAgent?: string,
+): ClientIdentity {
 	const mode = forcedMode() ?? (usesResponsesLite(model) ? "opencode" : "codex");
 	if (mode === "opencode") {
 		return {
 			originator: OPENCODE_ORIGINATOR,
-			userAgent: buildOpencodeUserAgent(),
+			userAgent: buildOpencodeUserAgent(hostUserAgent),
 		};
 	}
 	return {

--- a/lib/request/helpers/user-agent.ts
+++ b/lib/request/helpers/user-agent.ts
@@ -33,10 +33,21 @@ function sanitizeToken(value: string): string {
 	return value.replace(/[^\x20-\x7e]/g, "").trim();
 }
 
+/**
+ * Versions live in the UA product token (`name/version`), where a space would
+ * split the token and break the backend's version parse. Keep only characters
+ * that are safe in a product-token version; an empty result falls back to the
+ * caller's default.
+ */
+export function sanitizeVersionToken(value: string): string {
+	return value.replace(/[^0-9A-Za-z.+_-]/g, "");
+}
+
 export function buildCodexUserAgent(): string {
 	const envVersion = process.env.CODEX_AUTH_CLIENT_VERSION;
 	const version =
-		(envVersion ? sanitizeToken(envVersion) : "") || DEFAULT_CODEX_CLIENT_VERSION;
+		(envVersion ? sanitizeVersionToken(envVersion) : "") ||
+		DEFAULT_CODEX_CLIENT_VERSION;
 	const platform = PLATFORM_LABELS[os.platform()] ?? os.platform();
 	const release = sanitizeToken(os.release());
 	const arch = os.arch();

--- a/test/fetch-helpers.test.ts
+++ b/test/fetch-helpers.test.ts
@@ -225,8 +225,15 @@ describe('Fetch Helpers Module', () => {
 
 		it('sends a Codex CLI user-agent by default, replacing the host user-agent', () => {
 			const init = { headers: { 'user-agent': 'opencode/1.17.20' } } as any;
-			const headers = createCodexHeaders(init, accountId, accessToken, { model: 'gpt-5.6-sol' });
+			const headers = createCodexHeaders(init, accountId, accessToken, { model: 'gpt-5.5' });
 			expect(headers.get('user-agent')).toMatch(/^codex_cli_rs\/\d+\.\d+\.\d+ \(/);
+		});
+
+		it('sends the host identity for gpt-5.6 models by default', () => {
+			const init = { headers: { 'user-agent': 'opencode/1.17.20' } } as any;
+			const headers = createCodexHeaders(init, accountId, accessToken, { model: 'gpt-5.6-sol' });
+			expect(headers.get('user-agent')).toMatch(/^opencode\/\d+\.\d+\.\d+ \(/);
+			expect(headers.get(OPENAI_HEADERS.ORIGINATOR)).toBe('opencode');
 		});
 
 		it('honors the CODEX_AUTH_DISABLE_CODEX_USER_AGENT opt-out', () => {
@@ -243,7 +250,7 @@ describe('Fetch Helpers Module', () => {
 		it('advertises CODEX_AUTH_CLIENT_VERSION when overridden', () => {
 			try {
 				vi.stubEnv('CODEX_AUTH_CLIENT_VERSION', '0.150.2');
-				const headers = createCodexHeaders(undefined, accountId, accessToken, { model: 'gpt-5.6-sol' });
+				const headers = createCodexHeaders(undefined, accountId, accessToken, { model: 'gpt-5.5' });
 				expect(headers.get('user-agent')).toMatch(/^codex_cli_rs\/0\.150\.2 \(/);
 			} finally {
 				vi.unstubAllEnvs();

--- a/test/fetch-helpers.test.ts
+++ b/test/fetch-helpers.test.ts
@@ -224,22 +224,39 @@ describe('Fetch Helpers Module', () => {
 		});
 
 		it('sends a Codex CLI user-agent by default, replacing the host user-agent', () => {
-			const init = { headers: { 'user-agent': 'opencode/1.17.20' } } as any;
+			const init = { headers: { 'user-agent': 'opencode/1.17.20' } } as RequestInit;
 			const headers = createCodexHeaders(init, accountId, accessToken, { model: 'gpt-5.5' });
 			expect(headers.get('user-agent')).toMatch(/^codex_cli_rs\/\d+\.\d+\.\d+ \(/);
 		});
 
 		it('sends the host identity for gpt-5.6 models by default', () => {
-			const init = { headers: { 'user-agent': 'opencode/1.17.20' } } as any;
+			const init = { headers: { 'user-agent': 'opencode/1.17.20' } } as RequestInit;
 			const headers = createCodexHeaders(init, accountId, accessToken, { model: 'gpt-5.6-sol' });
 			expect(headers.get('user-agent')).toMatch(/^opencode\/\d+\.\d+\.\d+ \(/);
 			expect(headers.get(OPENAI_HEADERS.ORIGINATOR)).toBe('opencode');
 		});
 
+		it('reuses the host-injected UA version for the host identity', () => {
+			const init = { headers: { 'user-agent': 'opencode/1.99.5 (linux 6.8.0; x64)' } } as RequestInit;
+			const headers = createCodexHeaders(init, accountId, accessToken, { model: 'gpt-5.6-sol' });
+			expect(headers.get('user-agent')).toMatch(/^opencode\/1\.99\.5 \(/);
+		});
+
+		it('prefers CODEX_AUTH_HOST_VERSION over the host-injected UA version', () => {
+			try {
+				vi.stubEnv('CODEX_AUTH_HOST_VERSION', '2.0.1');
+				const init = { headers: { 'user-agent': 'opencode/1.99.5' } } as RequestInit;
+				const headers = createCodexHeaders(init, accountId, accessToken, { model: 'gpt-5.6-sol' });
+				expect(headers.get('user-agent')).toMatch(/^opencode\/2\.0\.1 \(/);
+			} finally {
+				vi.unstubAllEnvs();
+			}
+		});
+
 		it('honors the CODEX_AUTH_DISABLE_CODEX_USER_AGENT opt-out', () => {
 			try {
 				vi.stubEnv('CODEX_AUTH_DISABLE_CODEX_USER_AGENT', '1');
-				const init = { headers: { 'user-agent': 'opencode/1.17.20' } } as any;
+				const init = { headers: { 'user-agent': 'opencode/1.17.20' } } as RequestInit;
 				const headers = createCodexHeaders(init, accountId, accessToken, { model: 'gpt-5.6-sol' });
 				expect(headers.get('user-agent')).toBe('opencode/1.17.20');
 			} finally {
@@ -252,6 +269,20 @@ describe('Fetch Helpers Module', () => {
 				vi.stubEnv('CODEX_AUTH_CLIENT_VERSION', '0.150.2');
 				const headers = createCodexHeaders(undefined, accountId, accessToken, { model: 'gpt-5.5' });
 				expect(headers.get('user-agent')).toMatch(/^codex_cli_rs\/0\.150\.2 \(/);
+			} finally {
+				vi.unstubAllEnvs();
+			}
+		});
+
+		it('strips whitespace from version overrides so the UA product token stays well-formed', () => {
+			try {
+				vi.stubEnv('CODEX_AUTH_CLIENT_VERSION', '0.150 rc2');
+				const codexHeaders = createCodexHeaders(undefined, accountId, accessToken, { model: 'gpt-5.5' });
+				expect(codexHeaders.get('user-agent')).toMatch(/^codex_cli_rs\/0\.150rc2 \(/);
+
+				vi.stubEnv('CODEX_AUTH_HOST_VERSION', '1.17 rc1');
+				const hostHeaders = createCodexHeaders(undefined, accountId, accessToken, { model: 'gpt-5.6-sol' });
+				expect(hostHeaders.get('user-agent')).toMatch(/^opencode\/1\.17rc1 \(/);
 			} finally {
 				vi.unstubAllEnvs();
 			}

--- a/test/gpt56-sol-wire-parity.test.ts
+++ b/test/gpt56-sol-wire-parity.test.ts
@@ -1,16 +1,21 @@
 /**
- * Wire-parity regression pin for the #196 follow-up (PR #199).
+ * Wire-parity regression pin for the #196 follow-ups (PR #199 + the
+ * client-identity policy change).
  *
- * nxtkofi reported gpt-5.6-sol working in the Codex TUI but rejected through
- * the plugin (`model_not_supported_with_chatgpt_account`) while terra/luna
- * passed. Root cause was request identity, not payload: no Codex CLI
- * `User-Agent` (the backend gates 5.6 tiers on the catalog's
- * `minimal_client_version`, read from the UA product token) and a pinned
- * `openai-organization` header upstream Codex never sends.
+ * nxtkofi reported gpt-5.6-sol working in the Codex TUI and in plain opencode
+ * but rejected through the plugin (`model_not_supported_with_chatgpt_account`)
+ * while terra/luna passed. PR #199 aligned the plugin with the Codex CLI
+ * identity (UA + no org pin); the rejection persisted. Sol's catalog entry is
+ * identical to terra/luna (`minimal_client_version: 0.144.0`), so the sol-only
+ * rejection is a per-originator entitlement decision — and the identity plain
+ * opencode passes with is `originator: opencode` + `opencode/<version>` UA.
+ *
+ * Policy under test: gpt-5.6 (responses-lite) tiers present the host
+ * (opencode) identity by default; all other models keep the Codex CLI
+ * identity; `CODEX_AUTH_CLIENT_IDENTITY` forces either globally.
  *
  * These tests drive the REAL production path — `createCodexHeaders` plus the
- * serialize-time responses-lite reshape — with no mocks, and assert the full
- * outgoing sol request matches what codex-rs puts on the wire.
+ * serialize-time responses-lite reshape — with no mocks.
  */
 import { describe, it, expect, vi } from "vitest";
 import { createCodexHeaders } from "../lib/request/fetch-helpers.js";
@@ -19,6 +24,10 @@ import {
 	DEFAULT_CODEX_CLIENT_VERSION,
 	buildCodexUserAgent,
 } from "../lib/request/helpers/user-agent.js";
+import {
+	DEFAULT_OPENCODE_VERSION,
+	buildOpencodeUserAgent,
+} from "../lib/request/helpers/client-identity.js";
 import { OPENAI_HEADERS } from "../lib/constants.js";
 import type { RequestBody } from "../lib/types.js";
 
@@ -44,10 +53,10 @@ function solBody(): RequestBody {
 	} as unknown as RequestBody;
 }
 
-describe("gpt-5.6-sol wire parity with codex-rs (#196 / PR #199)", () => {
-	it("sends the full Codex CLI request identity for a sol turn from an org-bearing account", () => {
+describe("gpt-5.6 client identity (#196)", () => {
+	it("sends the host (opencode) identity for a sol turn from an org-bearing account", () => {
 		// opencode's runtime injects its own UA; an earlier attempt may have
-		// left a stale org header on init. Both must be replaced/stripped.
+		// left a stale org header on init. UA is normalized, org stripped.
 		const init = {
 			headers: {
 				"user-agent": "opencode/1.17.20",
@@ -61,25 +70,39 @@ describe("gpt-5.6-sol wire parity with codex-rs (#196 / PR #199)", () => {
 			organizationId: "org-abc123", // account carries an org claim
 		});
 
-		// Client-version identity: the catalog gates 5.6 on 0.144.0, read from
-		// the UA product token. Format mirrors get_codex_user_agent().
+		// Host identity: originator and UA must agree, mirroring plain
+		// opencode's native ChatGPT-Codex path.
+		expect(headers.get(OPENAI_HEADERS.ORIGINATOR)).toBe("opencode");
+		expect(headers.get("user-agent")).toBe(buildOpencodeUserAgent());
+		expect(headers.get("user-agent")).toMatch(
+			new RegExp(
+				`^opencode/${DEFAULT_OPENCODE_VERSION.replace(/\./g, "\\.")} \\(.+; .+\\)`,
+			),
+		);
+
+		// Workspace identity: chatgpt-account-id only — neither upstream
+		// client sends openai-organization on ChatGPT-Codex requests.
+		expect(headers.get(OPENAI_HEADERS.ACCOUNT_ID)).toBe(ACCOUNT_ID);
+		expect(headers.get(OPENAI_HEADERS.ORGANIZATION_ID)).toBeNull();
+
+		// Codex conventions that were already correct and must stay.
+		expect(headers.get(OPENAI_HEADERS.BETA)).toBe("responses=experimental");
+		expect(headers.get("x-openai-internal-codex-responses-lite")).toBe("true");
+		expect(headers.get("Authorization")).toBe(`Bearer ${TOKEN}`);
+	});
+
+	it("keeps the Codex CLI identity for non-lite models", () => {
+		const headers = createCodexHeaders(undefined, ACCOUNT_ID, TOKEN, {
+			model: "gpt-5.5",
+		});
+		expect(headers.get(OPENAI_HEADERS.ORIGINATOR)).toBe("codex_cli_rs");
 		expect(headers.get("user-agent")).toBe(buildCodexUserAgent());
 		expect(headers.get("user-agent")).toMatch(
 			new RegExp(
 				`^codex_cli_rs/${DEFAULT_CODEX_CLIENT_VERSION.replace(/\./g, "\\.")} \\(.+; .+\\)`,
 			),
 		);
-
-		// Workspace identity: chatgpt-account-id only — upstream never sends
-		// openai-organization on ChatGPT-Codex requests.
-		expect(headers.get(OPENAI_HEADERS.ACCOUNT_ID)).toBe(ACCOUNT_ID);
-		expect(headers.get(OPENAI_HEADERS.ORGANIZATION_ID)).toBeNull();
-
-		// Codex conventions that were already correct and must stay.
-		expect(headers.get(OPENAI_HEADERS.ORIGINATOR)).toBe("codex_cli_rs");
-		expect(headers.get(OPENAI_HEADERS.BETA)).toBe("responses=experimental");
-		expect(headers.get("x-openai-internal-codex-responses-lite")).toBe("true");
-		expect(headers.get("Authorization")).toBe(`Bearer ${TOKEN}`);
+		expect(headers.get("x-openai-internal-codex-responses-lite")).toBeNull();
 	});
 
 	it("serializes the sol body in the responses-lite shape codex-rs sends", () => {
@@ -100,17 +123,67 @@ describe("gpt-5.6-sol wire parity with codex-rs (#196 / PR #199)", () => {
 		expect(wire.reasoning?.context).toBe("all_turns");
 	});
 
-	it("keeps the terra fallback attempt on the same client identity after a sol entitlement 400", () => {
+	it("keeps the terra fallback attempt on the host identity after a sol entitlement 400", () => {
 		// The reported failure mode: backend 400s sol; the rotation loop
 		// resolves terra and rebuilds headers for the retry. The retry must
-		// carry the same Codex identity (and still no org pin).
+		// carry the same host identity (and still no org pin).
 		const headers = createCodexHeaders(undefined, ACCOUNT_ID, TOKEN, {
 			model: "gpt-5.6-terra",
 			organizationId: "org-abc123",
 		});
-		expect(headers.get("user-agent")).toMatch(/^codex_cli_rs\//);
+		expect(headers.get(OPENAI_HEADERS.ORIGINATOR)).toBe("opencode");
+		expect(headers.get("user-agent")).toMatch(/^opencode\//);
 		expect(headers.get(OPENAI_HEADERS.ORGANIZATION_ID)).toBeNull();
 		expect(headers.get("x-openai-internal-codex-responses-lite")).toBe("true");
+	});
+
+	it("moves a non-lite fallback attempt back to the Codex CLI identity", () => {
+		// unsupportedCodexPolicy: "fallback" can degrade sol to gpt-5.5; that
+		// attempt is a classic-shape request and must present codex_cli_rs.
+		const headers = createCodexHeaders(undefined, ACCOUNT_ID, TOKEN, {
+			model: "gpt-5.5",
+			organizationId: "org-abc123",
+		});
+		expect(headers.get(OPENAI_HEADERS.ORIGINATOR)).toBe("codex_cli_rs");
+		expect(headers.get("user-agent")).toMatch(/^codex_cli_rs\//);
+	});
+
+	it("forces the Codex CLI identity for sol under CODEX_AUTH_CLIENT_IDENTITY=codex", () => {
+		try {
+			vi.stubEnv("CODEX_AUTH_CLIENT_IDENTITY", "codex");
+			const headers = createCodexHeaders(undefined, ACCOUNT_ID, TOKEN, {
+				model: "gpt-5.6-sol",
+			});
+			expect(headers.get(OPENAI_HEADERS.ORIGINATOR)).toBe("codex_cli_rs");
+			expect(headers.get("user-agent")).toBe(buildCodexUserAgent());
+		} finally {
+			vi.unstubAllEnvs();
+		}
+	});
+
+	it("forces the host identity for non-lite models under CODEX_AUTH_CLIENT_IDENTITY=opencode", () => {
+		try {
+			vi.stubEnv("CODEX_AUTH_CLIENT_IDENTITY", "opencode");
+			const headers = createCodexHeaders(undefined, ACCOUNT_ID, TOKEN, {
+				model: "gpt-5.5",
+			});
+			expect(headers.get(OPENAI_HEADERS.ORIGINATOR)).toBe("opencode");
+			expect(headers.get("user-agent")).toBe(buildOpencodeUserAgent());
+		} finally {
+			vi.unstubAllEnvs();
+		}
+	});
+
+	it("honors CODEX_AUTH_HOST_VERSION in the host UA product token", () => {
+		try {
+			vi.stubEnv("CODEX_AUTH_HOST_VERSION", "9.9.9");
+			const headers = createCodexHeaders(undefined, ACCOUNT_ID, TOKEN, {
+				model: "gpt-5.6-sol",
+			});
+			expect(headers.get("user-agent")).toMatch(/^opencode\/9\.9\.9 /);
+		} finally {
+			vi.unstubAllEnvs();
+		}
 	});
 
 	it("restores legacy org pinning only under the escape hatch", () => {

--- a/test/gpt56-sol-wire-parity.test.ts
+++ b/test/gpt56-sol-wire-parity.test.ts
@@ -156,6 +156,22 @@ describe("gpt-5.6 client identity (#196)", () => {
 			});
 			expect(headers.get(OPENAI_HEADERS.ORIGINATOR)).toBe("codex_cli_rs");
 			expect(headers.get("user-agent")).toBe(buildCodexUserAgent());
+			// Identity forcing changes who we claim to be, never the wire
+			// shape: sol is still a responses-lite model.
+			expect(headers.get("x-openai-internal-codex-responses-lite")).toBe("true");
+		} finally {
+			vi.unstubAllEnvs();
+		}
+	});
+
+	it("accepts `host` as an alias for the opencode identity", () => {
+		try {
+			vi.stubEnv("CODEX_AUTH_CLIENT_IDENTITY", "host");
+			const headers = createCodexHeaders(undefined, ACCOUNT_ID, TOKEN, {
+				model: "gpt-5.5",
+			});
+			expect(headers.get(OPENAI_HEADERS.ORIGINATOR)).toBe("opencode");
+			expect(headers.get("user-agent")).toBe(buildOpencodeUserAgent());
 		} finally {
 			vi.unstubAllEnvs();
 		}


### PR DESCRIPTION
## Problem

#196 persists after PR #199: nxtkofi's accounts still reject `gpt-5.6-sol` through the plugin (`model_not_supported_with_chatgpt_account`) while **terra/luna pass**, and sol works for them in the Codex TUI **and in plain opencode on the same accounts**.

## Diagnosis (live-tested)

- Upstream catalog (`codex-rs/models-manager/models.json`) lists **identical** gates for sol/terra/luna: `minimal_client_version: 0.144.0`, `use_responses_lite: true`. A version or payload problem cannot produce a sol-only failure — ruling out the remaining #199 theory.
- Plain opencode's native ChatGPT-Codex path (verified from the 1.17.13 binary) sends `originator: "opencode"` + `User-Agent: opencode/<version> (<platform> <release>; <arch>)` to the same `/backend-api/codex/responses` endpoint — it does **not** imitate the Codex CLI. That identity is the one proven to pass sol on the affected accounts.
- Conclusion: the backend evaluates sol entitlement **per originator**, and the `codex_cli_rs` claim from a non-Codex client fails it for some account cohorts.

## Fix

- New `lib/request/helpers/client-identity.ts`: responses-lite (gpt-5.6) tiers default to the host (opencode) identity; everything else keeps the Codex CLI identity from #199.
- `CODEX_AUTH_CLIENT_IDENTITY=codex|opencode` forces one identity for all models; `CODEX_AUTH_HOST_VERSION` overrides the advertised host version. Existing `CODEX_AUTH_DISABLE_CODEX_USER_AGENT` / `CODEX_AUTH_CLIENT_VERSION` escape hatches unchanged.
- Wire-parity test suite updated to pin the new policy (host identity for sol/terra, codex identity for non-lite models and fallback attempts, env forcing both ways).

## Verification

All live against the real backend on a sol-entitled Pro account:

- `createCodexHeaders` + `shapeBodyForModel` from the built dist → 200 OK for sol with the new identity (lite shape).
- Full E2E: `opencode run -m openai/gpt-5.6-sol` with this branch's build loaded as the plugin → model replied the requested token.
- Both identities return 200 for sol on this account (lite **and** classic shapes), so the flip cannot regress accounts where `codex_cli_rs` already works.
- `npx vitest run`: 113 files, 2802 passed / 1 skipped.

Caveat: the failing cohort can only be confirmed by the reporter — this ships the identity their own working configuration uses, plus env flags to bisect if it somehow still fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * GPT-5.6 models now use host-style identity handling by default, while other models retain Codex CLI identity.
  * Added configuration options to override client identity and advertised host version.
* **Bug Fixes**
  * Improved model entitlement handling and fallback behavior across supported model types.
* **Documentation**
  * Updated configuration and troubleshooting guidance for identity, user-agent, and entitlement settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

this PR changes the per-request client identity for gpt-5.6 (responses-lite) models from `codex_cli_rs` to `opencode`, matching the identity plain opencode sends and addressing persistent `model_not_supported_with_chatgpt_account` rejections on a subset of accounts even after PR #199. all other models keep the codex CLI identity from #199.

- `lib/request/helpers/client-identity.ts` is a clean new module: `resolveClientIdentity` selects identity per model (or via `CODEX_AUTH_CLIENT_IDENTITY` override), `buildOpencodeUserAgent` mirrors the host UA format, and `resolveHostVersion` chains env var → injected UA → hardcoded fallback with proper space-stripping.
- `CODEX_AUTH_DISABLE_CODEX_USER_AGENT=1` now silently changes the originator for gpt-5.6 to \"opencode\" (matching the new default) while still preserving the UA — a behavior improvement but currently untested in the assertion layer.
- the test suite is broadly thorough: forced-identity, alias, version-extraction priority, and whitespace-sanitization paths are all covered.

<h3>Confidence Score: 5/5</h3>

safe to merge; the identity-selection logic is correct, the env override chain is well-tested, and the change cannot regress accounts where codex_cli_rs already works.

the core switching logic in resolveClientIdentity is straightforward and the test suite covers all forced-identity paths, alias handling, version-extraction priority, and the whitespace-sanitization fix. the two findings are test-layer concerns only — one assertion coincidentally correct due to a shared constant value, one missing originator assertion for a pre-existing escape hatch whose behavior changed.

test/gpt56-sol-wire-parity.test.ts — the line 76 assertion will silently diverge if DEFAULT_OPENCODE_VERSION is bumped without updating the test fixture UA.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/request/helpers/client-identity.ts | new module implementing per-model identity selection; logic is correct, env override chain is clean, sanitization handled by imported sanitizeVersionToken |
| lib/request/fetch-helpers.ts | originator now model-driven via resolveClientIdentity; hostUserAgent captured before overwrite; DISABLE_CODEX_USER_AGENT respected for UA but originator silently changed for gpt-5.6 |
| lib/request/helpers/user-agent.ts | sanitizeVersionToken exported and wired in; closes the space-in-version UA breakage from the previous review thread |
| test/gpt56-sol-wire-parity.test.ts | good coverage of forced-identity paths and alias; one assertion coincidentally passes due to DEFAULT_OPENCODE_VERSION equaling the injected UA version in the test fixture |
| test/fetch-helpers.test.ts | new tests for host identity, version extraction priority, and space-stripping are correct; DISABLE_UA test doesn't assert originator for the new gpt-5.6 behavior |
| docs/configuration.md | new env var entries accurate and complete; host alias documented |
| docs/troubleshooting.md | escape-hatch section updated correctly to reflect the two-identity policy |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant HC as createCodexHeaders
    participant RCI as resolveClientIdentity
    participant FM as forcedMode
    participant URL as usesResponsesLite
    participant BOU as buildOpencodeUserAgent
    participant BCU as buildCodexUserAgent

    HC->>HC: read hostUserAgent from incoming headers
    HC->>RCI: resolveClientIdentity(model, hostUserAgent)
    RCI->>FM: read CODEX_AUTH_CLIENT_IDENTITY
    alt forced mode set
        FM-->>RCI: codex or opencode
    else no override
        RCI->>URL: usesResponsesLite(model)
        URL-->>RCI: true for gpt-5.6, false otherwise
    end
    alt mode is opencode
        RCI->>BOU: buildOpencodeUserAgent(hostUserAgent)
        note over BOU: version priority: CODEX_AUTH_HOST_VERSION > injected UA > DEFAULT_OPENCODE_VERSION
        BOU-->>RCI: opencode UA string
        RCI-->>HC: "originator=opencode"
    else mode is codex
        RCI->>BCU: buildCodexUserAgent()
        BCU-->>RCI: codex_cli_rs UA string
        RCI-->>HC: "originator=codex_cli_rs"
    end
    HC->>HC: set originator header unconditionally
    alt DISABLE_CODEX_USER_AGENT is not 1
        HC->>HC: replace user-agent header
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant HC as createCodexHeaders
    participant RCI as resolveClientIdentity
    participant FM as forcedMode
    participant URL as usesResponsesLite
    participant BOU as buildOpencodeUserAgent
    participant BCU as buildCodexUserAgent

    HC->>HC: read hostUserAgent from incoming headers
    HC->>RCI: resolveClientIdentity(model, hostUserAgent)
    RCI->>FM: read CODEX_AUTH_CLIENT_IDENTITY
    alt forced mode set
        FM-->>RCI: codex or opencode
    else no override
        RCI->>URL: usesResponsesLite(model)
        URL-->>RCI: true for gpt-5.6, false otherwise
    end
    alt mode is opencode
        RCI->>BOU: buildOpencodeUserAgent(hostUserAgent)
        note over BOU: version priority: CODEX_AUTH_HOST_VERSION > injected UA > DEFAULT_OPENCODE_VERSION
        BOU-->>RCI: opencode UA string
        RCI-->>HC: "originator=opencode"
    else mode is codex
        RCI->>BCU: buildCodexUserAgent()
        BCU-->>RCI: codex_cli_rs UA string
        RCI-->>HC: "originator=codex_cli_rs"
    end
    HC->>HC: set originator header unconditionally
    alt DISABLE_CODEX_USER_AGENT is not 1
        HC->>HC: replace user-agent header
    end
```

</a>

<sub>Reviews (2): Last reviewed commit: ["fix(request): address PR #201 review — v..."](https://github.com/ndycode/oc-codex-multi-auth/commit/9bc2d43fb30fd132fa63ead86eca94c548afaa95) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45192523)</sub>

<!-- /greptile_comment -->