### PR TITLE
docs: rewrite guides for v6.9.1 architecture

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,12 +1,12 @@
 # PROJECT KNOWLEDGE BASE
 
-Generated: 2026-05-03
+Generated: 2026-07-18
 Branch: main
-Package version: 6.1.8
+Package version: 6.9.1
 
 ## OVERVIEW
 
-`oc-codex-multi-auth` is an OpenCode plugin for ChatGPT Plus/Pro OAuth, Codex/GPT-5 request routing, multi-account rotation, account switching, health checks, quota status, diagnostics, and recovery tools. The npm bin is an installer that manages OpenCode provider/TUI config; OpenCode loads `index.ts` as the provider plugin and `tui.ts` as the prompt quota status plugin. Runtime account state stays local under `~/.opencode` with per-project pools enabled by default.
+`oc-codex-multi-auth` is an OpenCode plugin for ChatGPT Plus/Pro OAuth, Codex/GPT-5 request routing (including GPT-5.6 Sol/Terra/Luna responses-lite), multi-account rotation, account switching, health checks, quota status, diagnostics, and recovery tools. The npm bin is an installer that manages OpenCode provider/TUI config and also runs standalone CLI commands (`doctor`, `status`, `list`, `limits`, `dashboard`, `health`, `diag`, `warm`). OpenCode loads `index.ts` as the provider plugin and `tui.ts` as the prompt quota status plugin. Runtime account state stays local under `~/.opencode` with per-project pools enabled by default.
 
 ## STRUCTURE
 
@@ -16,7 +16,7 @@ Package version: 6.1.8
 ├── tui.ts                # OpenCode TUI plugin: prompt quota status and quota details
 ├── lib/                  # core runtime logic (see lib/AGENTS.md)
 ├── test/                 # vitest suites (see test/AGENTS.md)
-├── scripts/              # installer, build, audit, and validation helpers
+├── scripts/              # installer, standalone CLI, build, audit, and validation helpers
 ├── config/               # opencode.json examples (modern/full/legacy/minimal)
 ├── docs/                 # public docs, architecture, audits, maintainer guides
 ├── skills/               # repo-local setup skill
@@ -29,20 +29,22 @@ Package version: 6.1.8
 
 | Task | Location | Notes |
 | --- | --- | --- |
-| Installer behavior | `scripts/install-oc-codex-multi-auth.js`, `scripts/install-oc-codex-multi-auth-core.js` | npm bin, config merge, cache cleanup, TUI config enablement |
+| Installer + standalone CLI | `scripts/install-oc-codex-multi-auth.js`, `scripts/install-oc-codex-multi-auth-core.js` | npm bin, config merge, cache cleanup, TUI enablement; standalone doctor/status/list/limits/dashboard/health/diag/warm |
 | Plugin orchestration | `index.ts` | OAuth loader, request pipeline, metrics, recovery, `ToolContext` assembly |
 | TUI quota status | `tui.ts`, `lib/tui-status.ts`, `lib/tui-quota-cache.ts`, `lib/codex-usage.ts` | prompt quota status, quota details, shared quota cache |
 | Tool registry | `lib/tools/index.ts` + `lib/tools/codex-*.ts` | 24 registered `codex-*` tools |
 | OAuth flow + PKCE | `lib/auth/auth.ts`, `lib/auth/server.ts`, `lib/auth/device-code.ts`, `lib/auth/login-runner.ts` | browser/device/manual login, token refresh, workspace selection |
 | OAuth scopes | `lib/auth/scopes.ts` | connector scope validation and re-auth checks |
-| Multi-account rotation | `lib/accounts.ts`, `lib/accounts/`, `lib/rotation.ts` | health scoring, cooldowns, token bucket, recovery |
+| Multi-account rotation | `lib/accounts.ts`, `lib/accounts/`, `lib/rotation.ts` | `rotationStrategy` hybrid/sticky/round-robin, health scoring, cooldowns, token bucket, recovery |
 | Account storage | `lib/storage.ts`, `lib/storage/` | V3 facade, per-project/global paths, keychain, backup/import/export |
 | Request transformation | `lib/request/request-transformer.ts` | model normalization, prompt injection, stateless compatibility |
+| Responses-lite (GPT-5.6) | `lib/request/helpers/responses-lite.ts` | lite body reshape + header for Sol/Terra/Luna |
+| Client identity | `lib/request/helpers/client-identity.ts` | default `opencode` for 5.6, `codex_cli_rs` otherwise |
 | Headers + rate limits | `lib/request/fetch-helpers.ts` | Codex headers, error mapping, fallback, token refresh |
 | Retry budgets | `lib/request/retry-budget.ts`, `lib/request/rate-limit-backoff.ts` | bounded retry classes, exponential backoff |
 | SSE to JSON | `lib/request/response-handler.ts` | stream parsing and empty-response detection |
 | Prompt templates | `lib/prompts/codex.ts`, `lib/prompts/opencode-codex.ts`, `lib/prompts/codex-opencode-bridge.ts` | model-family detection, Codex prompt cache, bridge prompts |
-| Config parsing | `lib/config.ts`, `lib/schemas.ts` | plugin config and environment overrides |
+| Config parsing | `lib/config.ts`, `lib/schemas.ts` | plugin config and environment overrides (bool env truthy only `"1"`) |
 | Session recovery | `lib/recovery/`, `lib/recovery.ts` | recoverable error handling and auto-resume |
 | Health monitoring | `lib/health.ts`, `lib/parallel-probe.ts` | account health status and concurrent probes |
 | Circuit breaker | `lib/circuit-breaker.ts` | failure isolation |
@@ -57,10 +59,12 @@ Package version: 6.1.8
 - ESLint flat config: `no-explicit-any` enforced, unused args prefixed `_`.
 - ESM only (`"type": "module"`), Node >= 18.
 - Canonical package/plugin name is `oc-codex-multi-auth`.
-- The npm bin is an installer, not a long-running runtime command.
+- The npm bin is an installer and thin standalone CLI, not a long-running runtime daemon.
 - OpenCode loads the provider plugin and TUI plugin from built package exports.
-- Default installer mode writes compact modern OpenCode config; `--full` adds explicit selector IDs; `--legacy` writes legacy explicit-only config.
+- Default installer mode writes compact modern OpenCode config (12 bases / 53 variants); `--full` adds 53 explicit selector IDs; `--legacy` writes legacy explicit-only config; `--dry-run` and `--no-cache-clear` are supported.
 - Runtime requests preserve Codex stateless requirements: `store: false` and `reasoning.encrypted_content`.
+- GPT-5.6 uses responses-lite shaping and default client identity `opencode`; other models default to `codex_cli_rs`.
+- Account selection uses `rotationStrategy` (`hybrid` default) with health scoring in `lib/rotation.ts`.
 - Per-project account storage is enabled by default.
 - Optional OS keychain backend is opt-in with `CODEX_KEYCHAIN=1`.
 
@@ -74,6 +78,7 @@ Package version: 6.1.8
 - Do not treat `oc-chatgpt-multi-auth` as current except in migration/cleanup logic.
 - Do not expose account emails, access tokens, refresh tokens, or raw prompt/response bodies in normal diagnostics.
 - Do not silently delete JSON credentials when keychain operations fail.
+- Do not document boolean env overrides as truthy for `"true"` / `"yes"` — only `"1"` is truthy.
 
 ## COMMANDS
 
@@ -85,6 +90,16 @@ npm run test:coverage    # vitest coverage
 npm run audit:ci         # prod audit + dev allowlist
 npm run test:watch       # vitest watch mode
 npm run lint             # eslint
+```
+
+Standalone CLI examples:
+
+```bash
+npx -y oc-codex-multi-auth@latest
+npx -y oc-codex-multi-auth@latest --full
+oc-codex-multi-auth warm
+oc-codex-multi-auth status --json
+oc-codex-multi-auth doctor
 ```
 
 ## NOTES
@@ -99,7 +114,9 @@ npm run lint             # eslint
 - Global accounts: `~/.opencode/oc-codex-multi-auth-accounts.json`.
 - Flagged accounts: `~/.opencode/oc-codex-multi-auth-flagged-accounts.json`.
 - Request logs: `~/.opencode/logs/codex-plugin/` when logging is enabled.
-- Prompt templates sync from Codex CLI GitHub releases with ETag caching.
+- Model catalog: 12 modern bases / 53 variants; legacy 53 explicit.
+- Bases: `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`, `gpt-5.5`, `gpt-5.5-fast`, `gpt-5.4-mini`, `gpt-5.4-nano`, `gpt-5.1-codex-max`, `gpt-5.1-codex`, `gpt-5.1-codex-mini`, `gpt-5.1`, `gpt-5-codex`.
+- Prompt templates sync from Codex CLI GitHub releases with ETag caching; 5.6 instructions come from the Codex model catalog.
 - 5xx server errors trigger account rotation and health penalty like network errors.
 - API deprecation/sunset headers (RFC 8594) are logged as warnings.
 - StorageError preserves original stack traces via `cause` parameter.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![CI](https://github.com/ndycode/oc-codex-multi-auth/actions/workflows/ci.yml/badge.svg)](https://github.com/ndycode/oc-codex-multi-auth/actions/workflows/ci.yml)
 [![MIT license](https://img.shields.io/npm/l/oc-codex-multi-auth.svg)](LICENSE)
 
-`oc-codex-multi-auth` is an OpenCode plugin for ChatGPT Plus/Pro OAuth, Codex and GPT-5 model routing, multi-account rotation, account switching, health checks, quota visibility, diagnostics, and recovery tools. It installs the OpenCode provider/TUI configuration, registers a `codex-*` command toolkit, and routes OpenCode OpenAI SDK requests through the ChatGPT-backed Codex flow with local account state.
+`oc-codex-multi-auth` is an OpenCode plugin for ChatGPT Plus/Pro OAuth, Codex and GPT-5 model routing (including GPT-5.6 Sol/Terra/Luna), multi-account rotation, account switching, health checks, quota visibility, diagnostics, and recovery tools. It installs the OpenCode provider/TUI configuration, registers a 24-tool `codex-*` command toolkit, and routes OpenCode OpenAI SDK requests through the ChatGPT-backed Codex flow with local account state.
 
 Use it when you want OpenCode to run Codex-style coding workflows from your own ChatGPT subscription while keeping accounts visible, switchable, health-checked, and recoverable from the terminal.
 
@@ -20,10 +20,10 @@ Use it when you want OpenCode to run Codex-style coding workflows from your own 
 ## What You Get
 
 - OpenCode plugin support for ChatGPT Plus/Pro OAuth and Codex/GPT-5 coding workflows
-- Ready-to-use GPT-5.5, GPT-5.5 Fast, GPT-5.4 Mini, GPT-5.4 Nano, GPT-5.1, and Codex model templates
-- Compact modern OpenCode config with variant-based selectors, plus explicit legacy selector IDs when needed
+- GPT-5.6 Sol, Terra, and Luna (responses-lite path) plus GPT-5.5, GPT-5.5 Fast, GPT-5.4 Mini, GPT-5.4 Nano, GPT-5.1, and Codex model templates
+- Compact modern OpenCode config with 12 base families and 53 variant presets; explicit legacy selector IDs when needed
 - Stateless Codex-compatible request handling with `store: false` and `reasoning.encrypted_content`
-- Multi-account rotation with health-aware selection, cooldowns, automatic token refresh, and failover
+- Multi-account rotation with hybrid health scoring, cooldowns, automatic token refresh, and failover
 - Explicit saved-account listing, account switching, labeling, tagging, notes, health checks, and diagnostics
 - Per-project account storage under `~/.opencode/projects/<project-key>/...`
 - Guided setup, doctor, next-action, dashboard, export/import, keychain, and troubleshooting tools
@@ -46,10 +46,10 @@ Use it when you want OpenCode to run Codex-style coding workflows from your own 
 
 | Surface | Purpose |
 | --- | --- |
-| `oc-codex-multi-auth` | npm installer bin; updates `~/.config/opencode/opencode.json`, manages `tui.json`, normalizes stale plugin entries, and clears OpenCode plugin cache |
+| `oc-codex-multi-auth` | npm installer bin; updates `~/.config/opencode/opencode.json`, manages `tui.json`, normalizes stale plugin entries, and clears OpenCode plugin cache. Also runs standalone commands: `doctor`, `status`, `list`, `limits`, `dashboard`, `health`, `diag`, `warm` |
 | OpenCode plugin entry (`index.ts`) | auth loader, OAuth login modes, provider fetch pipeline, account rotation, retry/failover, and `codex-*` tool registry |
 | OpenCode TUI plugin (`tui.ts`) | prompt quota status, quota details, shared quota cache, and active-account-aware display |
-| 21 `codex-*` tools | setup, help, status, list, switch, limits, health, metrics, doctor, dashboard, backup, keychain, diagnostics, and recovery actions |
+| 24 `codex-*` tools | setup, help, status, list, switch, warm, limits, health, metrics, doctor, dashboard, pool, backup, keychain, diagnostics, and recovery actions |
 
 The plugin does not replace OpenCode. OpenCode remains the host; this package installs provider/TUI config and supplies the OAuth-backed Codex request pipeline that OpenCode calls.
 
@@ -76,11 +76,23 @@ The plugin does not replace OpenCode. OpenCode remains the host; this package in
 <details open>
 <summary><b>For Humans</b></summary>
 
-### Option A: Standard install
+### Option A: Standard install (compact modern)
+
+Default mode writes 12 base OAuth model families and leaves reasoning depth to OpenCode's variant picker.
 
 ```bash
 npx -y oc-codex-multi-auth@latest
 ```
+
+Installer flags:
+
+| Flag | Effect |
+| --- | --- |
+| (default) / `--modern` | Compact modern catalog: 12 bases, 53 variants |
+| `--full` | Compact bases plus 53 explicit selector IDs |
+| `--legacy` | Explicit-only catalog for older OpenCode |
+| `--dry-run` | Show actions without writing |
+| `--no-cache-clear` | Skip clearing the OpenCode plugin cache |
 
 ### Option B: Full explicit model catalog
 
@@ -100,6 +112,20 @@ opencode auth login
 
 The installer updates `~/.config/opencode/opencode.json`, backs up the previous config, normalizes the plugin entry to `"oc-codex-multi-auth"`, enables the TUI status plugin in `~/.config/opencode/tui.json`, and clears the OpenCode cached plugin copy so OpenCode reinstalls the latest package.
 
+### Standalone CLI (no agent / no token cost)
+
+```bash
+oc-codex-multi-auth status
+oc-codex-multi-auth list
+oc-codex-multi-auth warm
+oc-codex-multi-auth doctor
+oc-codex-multi-auth health
+oc-codex-multi-auth limits
+oc-codex-multi-auth dashboard
+oc-codex-multi-auth diag
+# or: npx -y oc-codex-multi-auth@latest warm --json
+```
+
 </details>
 
 <details>
@@ -113,7 +139,7 @@ The installer updates `~/.config/opencode/opencode.json`, backs up the previous 
    - `opencode auth login`
 3. Validate config:
    - `opencode debug config`
-4. Run a smoke request:
+4. Run a smoke request (compact modern selectors):
    - `opencode run "Explain this repository" --model=openai/gpt-5.5 --variant=medium`
 5. Inspect plugin state with the OpenCode tool surface:
    - `codex-status`
@@ -146,6 +172,7 @@ Run a prompt with compact modern selectors:
 ```bash
 opencode run "Summarize the failing test and suggest a fix" --model=openai/gpt-5.5 --variant=medium
 opencode run "Summarize the failing test and suggest a fix" --model=openai/gpt-5.5-fast --variant=medium
+opencode run "Plan the refactor" --model=openai/gpt-5.6-sol --variant=high
 ```
 
 Use Codex-focused routing:
@@ -210,7 +237,8 @@ Most of these also run as a **direct CLI** with no agent/model involvement (no t
 
 - stateless request handling forces `store: false`
 - `reasoning.encrypted_content` is preserved for multi-turn continuity
-- account rotation is health-aware and avoids repeatedly selecting cooling accounts
+- GPT-5.6 tiers use the responses-lite request shape and default client identity `opencode`; other models default to `codex_cli_rs`
+- account rotation is health-aware (`rotationStrategy` default `hybrid`) and avoids repeatedly selecting cooling accounts
 - 5xx bursts, network failures, and quota responses penalize account health
 - token refresh is queued to avoid refresh races
 - unsupported-model handling is strict by default, with opt-in fallback controls
@@ -304,19 +332,22 @@ Selected runtime/environment overrides:
 | `CODEX_AUTH_REQUEST_TRANSFORM_MODE=legacy` | Re-enable legacy Codex request rewriting |
 | `CODEX_MODE=0/1` | Disable/enable bridge prompt behavior |
 | `CODEX_TUI_V2=0/1` | Disable/enable codex-style tool output |
-| `CODEX_TUI_COLOR_PROFILE=truecolor|ansi256|ansi16` | Force terminal color profile |
-| `CODEX_TUI_GLYPHS=ascii|unicode|auto` | Force terminal glyph style |
+| `CODEX_TUI_COLOR_PROFILE=truecolor\|ansi256\|ansi16` | Force terminal color profile |
+| `CODEX_TUI_GLYPHS=ascii\|unicode\|auto` | Force terminal glyph style |
 | `CODEX_TUI_MASK_EMAIL=0/1` | Hide account email in TUI quota status only |
 | `CODEX_TUI_MASK_EMAIL_DETAILS=0/1` | Also hide account email in quota details when prompt masking is enabled |
 | `CODEX_AUTH_PER_PROJECT_ACCOUNTS=0/1` | Disable/enable per-project account pools |
 | `CODEX_AUTH_AUTO_UPDATE=0/1` | Disable/enable daily npm update check and cache refresh |
-| `CODEX_AUTH_UNSUPPORTED_MODEL_POLICY=strict|fallback` | Control unsupported-model retry behavior |
+| `CODEX_AUTH_ROTATION_STRATEGY=hybrid\|sticky\|round-robin` | Account selection strategy |
+| `CODEX_AUTH_UNSUPPORTED_MODEL_POLICY=strict\|fallback` | Control unsupported-model retry behavior |
 | `CODEX_AUTH_ACCOUNT_ID=<id>` | Force a specific workspace/account id |
 | `CODEX_AUTH_FETCH_TIMEOUT_MS=<ms>` | Request timeout override |
 | `CODEX_AUTH_STREAM_STALL_TIMEOUT_MS=<ms>` | SSE stream stall timeout override |
 | `ENABLE_PLUGIN_REQUEST_LOGGING=1` | Enable request metadata logs |
 | `CODEX_PLUGIN_LOG_BODIES=1` | Include raw request/response bodies in logs; sensitive |
 | `CODEX_KEYCHAIN=1` | Opt in to OS-native keychain account storage |
+
+Boolean env overrides are truthy only for the literal string `"1"`.
 
 Validate config after changes:
 
@@ -434,7 +465,7 @@ codex-doctor deep=true format="json"
 
 ## Release Notes
 
-- Current package version: `6.1.8`
+- Current package version: `6.9.1`
 - Changelog: [CHANGELOG.md](CHANGELOG.md)
 - Releases are automated with [release-please](https://github.com/googleapis/release-please)
 

--- a/README.md
+++ b/README.md
@@ -334,7 +334,7 @@ Selected runtime/environment overrides:
 | `CODEX_TUI_V2=0/1` | Disable/enable codex-style tool output |
 | `CODEX_TUI_COLOR_PROFILE=truecolor\|ansi256\|ansi16` | Force terminal color profile |
 | `CODEX_TUI_GLYPHS=ascii\|unicode\|auto` | Force terminal glyph style |
-| `CODEX_TUI_MASK_EMAIL=0/1` | Hide account email in TUI quota status only |
+| `CODEX_TUI_MASK_EMAIL=0/1` | Mask account emails across account-display surfaces (list/status/limits/health/dashboard/menus + TUI quota status) |
 | `CODEX_TUI_MASK_EMAIL_DETAILS=0/1` | Also hide account email in quota details when prompt masking is enabled |
 | `CODEX_AUTH_PER_PROJECT_ACCOUNTS=0/1` | Disable/enable per-project account pools |
 | `CODEX_AUTH_AUTO_UPDATE=0/1` | Disable/enable daily npm update check and cache refresh |

--- a/config/README.md
+++ b/config/README.md
@@ -1,15 +1,29 @@
 # Configuration
 
-This directory contains the official OpenCode config templates for `oc-codex-multi-auth`.
+This directory contains the official OpenCode config templates for `oc-codex-multi-auth` v6.9.1.
 
 ## Required: choose the right config file
 
 | File | OpenCode version | Description |
 |------|------------------|-------------|
-| [`opencode-modern.json`](./opencode-modern.json) | **v1.0.210+** | Variant-based config: 9 base models with 36 total presets |
-| [`opencode-legacy.json`](./opencode-legacy.json) | **v1.0.209 and below** | Legacy explicit entries: 36 individual model definitions |
+| [`opencode-modern.json`](./opencode-modern.json) | **v1.0.210+** | Variant-based config: **12 base models**, **53 variants** total |
+| [`opencode-legacy.json`](./opencode-legacy.json) | **v1.0.209 and below** | Legacy explicit entries: **53** individual model definitions |
 
-The installer uses the compact modern template by default so the model picker shows only base OAuth model families. Rerun the default installer to remove explicit preset IDs and stale base models left by earlier plugin catalogs. Use `--full` when you want the explicit preset IDs installed too.
+## Install modes
+
+| Installer flag | What gets written |
+|----------------|-------------------|
+| default / `--modern` | Compact modern: 12 base OAuth families + variant picker |
+| `--full` | Modern bases **plus** explicit legacy selector IDs |
+| `--legacy` | Explicit-only catalog (53 preset model entries) |
+
+```bash
+npx -y oc-codex-multi-auth@latest          # compact modern (default)
+npx -y oc-codex-multi-auth@latest --full   # modern + explicit IDs
+npx -y oc-codex-multi-auth@latest --legacy # explicit only
+```
+
+Rerun the default installer to remove explicit preset IDs and stale base models left by earlier plugin catalogs.
 
 ## Quick pick
 
@@ -33,19 +47,47 @@ opencode --version
 
 ## Why there are two templates
 
-OpenCode v1.0.210+ added model `variants`, so one model entry can expose multiple reasoning levels. That keeps modern config much smaller while preserving the same effective presets.
+OpenCode v1.0.210+ added model `variants`, so one model entry can expose multiple reasoning levels. That keeps modern config smaller while preserving the same effective presets.
 
 Both templates include:
-- GPT-5.5, GPT-5.5 Fast, GPT-5.4 Mini, GPT-5.4 Nano, GPT-5 Codex, GPT-5.1, GPT-5.1 Codex, GPT-5.1 Codex Max, GPT-5.1 Codex Mini
-- Reasoning variants per model family
+
+### Base model families (12)
+
+| Base | Variants (modern) |
+|------|-------------------|
+| `gpt-5.6-sol` | low, medium, high, xhigh, max, ultra |
+| `gpt-5.6-terra` | low, medium, high, xhigh, max, ultra |
+| `gpt-5.6-luna` | low, medium, high, xhigh, max |
+| `gpt-5.5` | none, low, medium, high, xhigh |
+| `gpt-5.5-fast` | none, low, medium, high, xhigh |
+| `gpt-5.4-mini` | none, low, medium, high, xhigh |
+| `gpt-5.4-nano` | none, low, medium, high, xhigh |
+| `gpt-5.1-codex-max` | low, medium, high, xhigh |
+| `gpt-5.1-codex` | low, medium, high |
+| `gpt-5.1-codex-mini` | medium, high |
+| `gpt-5.1` | none, low, medium, high |
+| `gpt-5-codex` | low, medium, high |
+
+Shared template requirements:
+
 - `store: false` and `include: ["reasoning.encrypted_content"]`
-- Context metadata (`gpt-5.5`/`gpt-5.5-fast`: 1,050,000; `gpt-5.4-mini`/`gpt-5.4-nano`/Codex models: 400,000; `gpt-5.1`: 272,000; all output: 128,000)
+- Context metadata:
+  - `gpt-5.6-sol` / `gpt-5.6-terra` / `gpt-5.6-luna` / `gpt-5.5` / `gpt-5.5-fast`: context **1,050,000**, output **128,000**
+  - `gpt-5.4-mini` / `gpt-5.4-nano` / Codex models (`gpt-5-codex`, `gpt-5.1-codex*`, …): context **400,000**, output **128,000**
+  - `gpt-5.1`: context **272,000**, output **128,000**
 
-Use `opencode debug config` to verify that these template entries were merged into your effective config. The default compact install shows base OAuth entries such as `gpt-5.5` / `gpt-5.5-fast`; the separate OpenCode variant picker exposes the reasoning presets.
+Use `opencode debug config` to verify that these template entries were merged into your effective config. The default compact install shows base OAuth entries such as `gpt-5.5` / `gpt-5.6-sol`; the separate OpenCode variant picker exposes the reasoning presets.
 
-If your OpenCode runtime supports global compaction tuning, you can also set:
-- `model_context_window = 1050000`
-- `model_auto_compact_token_limit = 950000`
+If your OpenCode runtime supports global compaction tuning, you can also set values near the largest context windows (for example ~1M context / slightly lower auto-compact limit). Prefer values that match your selected model family.
+
+## GPT-5.6 notes
+
+- Served over the **responses-lite** path (`use_responses_lite`).
+- Preview entitlement: accounts without access auto-fallback  
+  `gpt-5.6-sol → gpt-5.6-terra → gpt-5.6-luna → gpt-5.5`  
+  (disable with `CODEX_AUTH_DISABLE_GPT56_AUTO_FALLBACK=1`).
+- Default client identity for 5.6 is host/opencode (`originator: opencode`); other families default to Codex CLI identity.
+- `ultra` is accepted as a client-side alias and sent as `max` on the wire (no subagent orchestration in this plugin).
 
 ## Spark model note
 
@@ -60,6 +102,7 @@ Recommended compact UI selectors:
 ```bash
 opencode run "task" --model=openai/gpt-5.5 --variant=medium
 opencode run "task" --model=openai/gpt-5.5-fast --variant=medium
+opencode run "task" --model=openai/gpt-5.6-sol --variant=medium
 opencode run "task" --model=openai/gpt-5-codex --variant=high
 ```
 
@@ -75,29 +118,35 @@ A barebones debug template is available at [`minimal-opencode.json`](./minimal-o
 
 ## Unsupported-model behavior
 
-Current defaults are strict entitlement handling except for default public selectors that are commonly entitlement-gated:
-- `gpt-5.5` and canonical `gpt-5-codex` can auto-fallback through `gpt-5.4`, `gpt-5.4-mini`, then `gpt-5.4-nano` when the backend reports the selected model is not supported for the active account/workspace
+Current defaults are strict entitlement handling except for common default-selector entitlement gates:
+
+- **GPT-5.6** auto-fallback: `gpt-5.6-sol → gpt-5.6-terra → gpt-5.6-luna → gpt-5.5`
+- **`gpt-5.5`** and canonical **`gpt-5-codex`** can auto-fallback through `gpt-5.4`, `gpt-5.4-mini`, then `gpt-5.4-nano` when the backend reports the selected model is not supported
 - `unsupportedCodexPolicy: "strict"` returns other entitlement errors directly
 - set `unsupportedCodexPolicy: "fallback"` (or `CODEX_AUTH_UNSUPPORTED_MODEL_POLICY=fallback`) to enable the full fallback chain for manual/legacy selectors
 - `fallbackToGpt52OnUnsupportedGpt53: true` keeps the legacy `gpt-5.3-codex -> gpt-5.2-codex` edge inside fallback mode
 - user-typed `gpt-5.5-pro*` is canonicalized to `gpt-5.5` before fallback because GPT-5.5 Pro is ChatGPT-only, not a Codex-routable model
 - legacy Codex selectors such as `gpt-5.2-codex`, `gpt-5.3-codex`, and `gpt-5.3-codex-spark` normalize to canonical `gpt-5-codex`; if that canonical Codex model is gated, the default auto-fallback can retry through the GPT-5.4 family
+- set `CODEX_AUTH_DISABLE_GPT56_AUTO_FALLBACK=1` to disable GPT-5.6 auto-fallback
 - set `CODEX_AUTH_DISABLE_GPT55_AUTO_FALLBACK=1` to disable GPT-5.5 auto-fallback
 - set `CODEX_AUTH_DISABLE_CODEX_AUTO_FALLBACK=1` to disable canonical Codex/GPT-5.4-family auto-fallback
 - `gpt-5.4-pro -> gpt-5.4` remains available for older manual configs
 - `unsupportedCodexFallbackChain` lets you override fallback order per model
 
-Default fallback chain (auto-fallback for `gpt-5.5`/`gpt-5-codex` through the GPT-5.4 family; full chain when policy is `fallback`):
-- `gpt-5.5 -> gpt-5.4 -> gpt-5.4-mini -> gpt-5.4-nano`
-- `gpt-5-codex -> gpt-5.4 -> gpt-5.4-mini -> gpt-5.4-nano`
-- `gpt-5.4-pro -> gpt-5.4` (if you manually select `gpt-5.4-pro`)
-- `gpt-5.3-codex -> gpt-5-codex -> gpt-5.2-codex`
-- `gpt-5.3-codex-spark -> gpt-5-codex -> gpt-5.3-codex -> gpt-5.2-codex` (only relevant if Spark IDs are added manually)
-- `gpt-5.2-codex -> gpt-5-codex`
-- `gpt-5.1-codex -> gpt-5-codex`
+Default chains when generic fallback policy is enabled (and empty override map):
+
+- `gpt-5.6-sol → gpt-5.6-terra → gpt-5.6-luna → gpt-5.5` (also auto under default strict for preview gates)
+- `gpt-5.5 → gpt-5.4 → gpt-5.4-mini → gpt-5.4-nano`
+- `gpt-5-codex → gpt-5.4 → gpt-5.4-mini → gpt-5.4-nano`
+- `gpt-5.4-pro → gpt-5.4` (if you manually select `gpt-5.4-pro`)
+- `gpt-5.3-codex → gpt-5-codex → gpt-5.2-codex`
+- `gpt-5.3-codex-spark → gpt-5-codex → gpt-5.3-codex → gpt-5.2-codex` (only if Spark IDs are added manually)
+- `gpt-5.2-codex → gpt-5-codex`
+- `gpt-5.1-codex → gpt-5-codex`
 
 ## Additional docs
 
 - Main config reference: [`docs/configuration.md`](../docs/configuration.md)
 - Getting started: [`docs/getting-started.md`](../docs/getting-started.md)
+- Tools and CLI: [`docs/tools-and-cli.md`](../docs/tools-and-cli.md)
 - Troubleshooting: [`docs/troubleshooting.md`](../docs/troubleshooting.md)

--- a/docs/DOCUMENTATION.md
+++ b/docs/DOCUMENTATION.md
@@ -20,6 +20,7 @@ docs/
 ├── index.md                            # documentation landing page
 ├── architecture.md                     # public architecture overview
 ├── getting-started.md                  # install + first-run guide
+├── tools-and-cli.md                    # 24 codex-* tools + standalone CLI
 ├── configuration.md                    # full config reference
 ├── troubleshooting.md                  # operational debugging guide
 ├── faq.md                              # short common answers
@@ -32,7 +33,7 @@ docs/
 │   ├── CONFIG_FLOW.md                  # config resolution internals
 │   ├── TESTING.md                      # testing strategy and commands
 │   └── TUI_PARITY_CHECKLIST.md         # auth dashboard UI parity checks
-└── audits/
+└── audits/                             # HISTORICAL review archive (not live product contract)
     ├── INDEX.md
     ├── 01-executive-summary.md ... 16-verdict.md
     ├── _findings/                      # T01 through T16 detailed findings
@@ -41,13 +42,14 @@ docs/
 
 ## config/ (copy-paste templates)
 
-- `config/opencode-modern.json` - OpenCode v1.0.210+ variant-based template
-- `config/opencode-legacy.json` - OpenCode v1.0.209 and below template
+- `config/opencode-modern.json` - OpenCode v1.0.210+ variant-based template (12 bases / 53 variants)
+- `config/opencode-legacy.json` - OpenCode v1.0.209 and below template (53 explicit entries)
 - `config/minimal-opencode.json` - minimal debug template
-- `config/README.md` - template-selection guide
+- `config/README.md` - template-selection guide and install modes
 
 ## Notes
 
 - `dist/` is build output and not a documentation source of truth.
 - `tmp*` files are release scratch artifacts and not part of user docs.
-- For user-facing guidance, start with `README.md`, `docs/getting-started.md`, or `docs/architecture.md`.
+- `docs/audits/` is retained as a **historical** audit snapshot; verify current behavior against user guides, development docs, and tests.
+- For user-facing guidance, start with `README.md`, `docs/getting-started.md`, `docs/tools-and-cli.md`, or `docs/architecture.md`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,7 +5,8 @@ This documentation set is split by purpose so the main README can stay focused o
 ## Start Here
 
 - [Getting Started](getting-started.md): full install, auth, configuration templates, model selectors, and first-run verification
-- [Architecture Overview](architecture.md): public map of the installer, OpenCode plugin entry, TUI plugin, tool registry, request pipeline, and storage model
+- [Tools and CLI](tools-and-cli.md): complete catalog of 24 `codex-*` tools and standalone bin commands
+- [Architecture Overview](architecture.md): public map of the installer, OpenCode plugin entry, TUI plugin, tool registry, request pipeline, rotation, and storage model
 - [Configuration Reference](configuration.md): config keys, environment variables, fallback behavior, and file locations
 - [Troubleshooting](troubleshooting.md): common failure modes and recovery steps
 - [FAQ](faq.md): short answers for common questions
@@ -19,6 +20,10 @@ This documentation set is split by purpose so the main README can stay focused o
 - [Configuration Fields](development/CONFIG_FIELDS.md)
 - [Testing Guide](development/TESTING.md)
 - [TUI Parity Checklist](development/TUI_PARITY_CHECKLIST.md)
+
+## Historical audits
+
+Files under [audits/](audits/INDEX.md) are a **historical** review archive. They are useful for context but are not the source of truth for current package behavior (v6.9.1). Prefer the guides above and `CHANGELOG.md` for live contracts.
 
 ## Notes
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 # oc-codex-multi-auth Architecture
 
-Public overview of how the `oc-codex-multi-auth` OpenCode plugin installs config, handles ChatGPT Plus/Pro OAuth, routes Codex/GPT-5 requests, rotates local account pools, exposes diagnostics, and publishes TUI quota status.
+Public overview of how `oc-codex-multi-auth` v6.9.1 installs config, handles ChatGPT Plus/Pro OAuth, routes Codex/GPT-5 requests, rotates local account pools, exposes diagnostics, and publishes TUI quota status.
 
 ---
 
@@ -8,11 +8,12 @@ Public overview of how the `oc-codex-multi-auth` OpenCode plugin installs config
 
 `oc-codex-multi-auth` is an OpenCode plugin for ChatGPT OAuth-backed Codex and GPT-5 workflows.
 
-- The `oc-codex-multi-auth` npm bin is an installer, not a replacement for OpenCode.
+- The `oc-codex-multi-auth` npm bin is an installer and a small standalone CLI, not a replacement for OpenCode.
 - OpenCode loads `dist/index.js` as the provider plugin entry.
-- The plugin registers 21 `codex-*` tools for setup, account switching, health checks, diagnostics, backup, keychain, and recovery.
+- The plugin registers **24** `codex-*` tools via **24 per-file factories** under `lib/tools/` (`codex-list`, `codex-switch`, `codex-warm`, and 21 others).
 - OpenCode loads `dist/tui.js` as the TUI plugin for active-session quota status.
 - Request handling stays stateless for the ChatGPT-backed Codex API by enforcing `store: false` and preserving `reasoning.encrypted_content`.
+- GPT-5.6 tiers use the responses-lite request path; pre-5.6 models keep the classic shape.
 - Account, config, backup, log, and TUI quota state lives under `~/.opencode` and `~/.config/opencode`.
 - Per-project account pools are enabled by default under `~/.opencode/projects/<project-key>/...`.
 
@@ -20,22 +21,32 @@ Public overview of how the `oc-codex-multi-auth` OpenCode plugin installs config
 
 ## Main Components
 
-### 1. Installer surface
+### 1. Installer and standalone CLI
 
-`package.json` publishes one command:
+`package.json` publishes one bin:
 
-- `oc-codex-multi-auth` -> `scripts/install-oc-codex-multi-auth.js`
+- `oc-codex-multi-auth` → `scripts/install-oc-codex-multi-auth.js`
 
-The installer updates OpenCode config, backs up previous files, normalizes stale plugin entries from older package names, enables the TUI status plugin, writes compact or full model templates, and clears OpenCode's cached package copy so the next OpenCode start uses the latest plugin.
+With no subcommand (or with `install`), the installer updates OpenCode config, backs up previous files, normalizes stale plugin entries (including the legacy package name `oc-chatgpt-multi-auth`), enables the TUI status plugin, writes model templates, and clears OpenCode's cached package copy so the next OpenCode start uses the latest plugin.
+
+Install modes:
+
+| Flag | Config written |
+| --- | --- |
+| (default) / `--modern` | Compact modern: 12 base model families + variant picker (53 variants total) |
+| `--full` | Compact modern bases **plus** explicit legacy selector IDs |
+| `--legacy` | Explicit-only catalog (53 model entries) |
+
+Standalone read/ops commands (no OpenCode agent loop required): `doctor`, `status`, `list`, `limits`, `dashboard`, `health`, `diag`, `warm`. See [tools-and-cli.md](tools-and-cli.md).
 
 ### 2. OpenCode plugin entry
 
 `index.ts` is the runtime entry OpenCode loads. It owns:
 
 - OAuth login modes: browser callback, device code, and manual URL paste
-- account manager lifecycle and local account storage
-- request URL/body/header transformation
-- health-aware account selection and workspace-aware routing
+- account manager lifecycle and local account storage (V3)
+- request URL/body/header transformation (native or legacy, plus responses-lite for GPT-5.6)
+- health-aware account selection, `rotationStrategy`, and `modelAccountPools`
 - retry budgets, circuit breaking, rate-limit backoff, and failover
 - session recovery hooks and beginner-safe next-action guidance
 - `ToolContext` construction for the `codex-*` registry
@@ -53,21 +64,43 @@ OpenCode provider system
   | custom fetch()
   v
 oc-codex-multi-auth index.ts
-  |- rewrite OpenAI SDK URL to Codex/ChatGPT backend
+  |- rewrite OpenAI SDK URL to chatgpt.com/backend-api/codex/responses
   |- shape body for native or legacy transform mode
+  |- for GPT-5.6: apply responses-lite reshape (per attempt)
   |- force stream:true, store:false, reasoning.encrypted_content
-  |- select/refresh a healthy account
-  |- attach OAuth headers
+  |- select/refresh a healthy account (pools + rotationStrategy)
+  |- attach OAuth headers + client identity (originator / User-Agent)
   |- handle SSE, errors, retries, fallback, and metrics
   v
 ChatGPT-backed Codex endpoint
 ```
 
-Native mode keeps the host payload shape whenever possible. Legacy mode applies compatibility rewrites for older OpenCode/AI SDK behavior, including filtering unsupported `item_reference` payloads and stripping IDs that cannot be used with `store: false`.
+**Native mode** keeps the host payload shape whenever possible. **Legacy mode** applies compatibility rewrites for older OpenCode/AI SDK behavior, including filtering unsupported `item_reference` payloads and stripping IDs that cannot be used with `store: false`.
 
-### 4. Tool registry
+**Responses-lite (GPT-5.6 only):** for `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna`, the plugin reshapes the request the way Codex does: tool definitions move into `input` as a leading `additional_tools` developer item, Codex instructions follow as a developer message, top-level `instructions` is emptied, `tools` is omitted, `parallel_tool_calls` is forced off, image `detail` fields are stripped, and `x-openai-internal-codex-responses-lite: true` is sent. Lite reshape is applied per request attempt against the model actually being sent, so a sol → gpt-5.5 fallback re-serializes into the classic shape and keeps its tools.
 
-`lib/tools/index.ts` builds the OpenCode tool map from 24 per-file factories under `lib/tools/`.
+**Client identity:** by default GPT-5.6 uses the host/opencode identity (`originator: opencode` with an `opencode/...` User-Agent). Other families default to the Codex CLI identity. Override with `CODEX_AUTH_CLIENT_IDENTITY`.
+
+**Auto-fallback (preview entitlement gates):**
+
+- GPT-5.6: `gpt-5.6-sol` → `gpt-5.6-terra` → `gpt-5.6-luna` → `gpt-5.5` (disable with `CODEX_AUTH_DISABLE_GPT56_AUTO_FALLBACK=1`)
+- GPT-5.5 / canonical Codex also have default auto-fallback through the GPT-5.4 family; broader fallback chains require `unsupportedCodexPolicy: "fallback"`.
+
+### 4. Account rotation and model pools
+
+`rotationStrategy` (`hybrid` | `sticky` | `round-robin`, default `hybrid`) selects how the plugin load-balances across healthy accounts:
+
+| Strategy | Behavior |
+| --- | --- |
+| `hybrid` (default) | Stay on the current account while healthy; otherwise score-select the next |
+| `sticky` | Drain one account until rate-limited/cooling, then move to the lowest-indexed available account |
+| `round-robin` | Advance through accounts in order |
+
+`modelAccountPools` maps effective model IDs to preferred stable account IDs. While a preferred pool has a healthy selectable account, selection stays inside that pool (still applying quota, cooldown, and token-health rules). If the preferred pool is empty or exhausted, routing falls back to the general pool. Manage pools with `codex-pool` or edit `~/.opencode/openai-codex-auth-config.json`.
+
+### 5. Tool registry
+
+`lib/tools/index.ts` builds the OpenCode tool map from **24 per-file factories** under `lib/tools/`.
 
 Common groups:
 
@@ -78,11 +111,13 @@ Common groups:
 - backup and secrets: `codex-export`, `codex-import`, `codex-keychain`
 - interactive surface: `codex-dashboard`
 
-### 5. TUI quota status plugin
+Full catalog: [tools-and-cli.md](tools-and-cli.md).
 
-`tui.ts` exposes an OpenCode TUI plugin that reads the active account, shared quota cache, and direct usage endpoints when available. It shows compact prompt status during sessions and provides a quota details command without polluting the home prompt.
+### 6. TUI quota status plugin
 
-### 6. Storage and sync
+`tui.ts` exposes an OpenCode TUI plugin that reads the active account, shared quota cache (`lib/tui-quota-cache.ts`), and direct usage endpoints when available. It shows compact prompt status during sessions and provides a quota details command without polluting the home prompt.
+
+### 7. Storage and sync
 
 The storage layer uses V3 account files with migrations from older formats, atomic writes, keychain opt-in, import/export previews, flagged-account recovery, and per-project path resolution.
 
@@ -95,6 +130,7 @@ The storage layer uses V3 account files with migrations from older formats, atom
 | Global account pool | `~/.opencode/oc-codex-multi-auth-accounts.json` |
 | Project account pool | `~/.opencode/projects/<project-key>/oc-codex-multi-auth-accounts.json` |
 | Flagged accounts | `~/.opencode/oc-codex-multi-auth-flagged-accounts.json` |
+| TUI quota cache | OpenCode state path plus `~/.opencode/oc-codex-multi-auth-tui-quota.json` fallback |
 | Logs | `~/.opencode/logs/codex-plugin/` |
 
 ---
@@ -102,12 +138,13 @@ The storage layer uses V3 account files with migrations from older formats, atom
 ## Design Constraints
 
 - OpenCode remains the host runtime and provider loader.
-- The canonical package/plugin name is `oc-codex-multi-auth`.
-- OAuth callback port remains `1455`.
+- The canonical package/plugin name is `oc-codex-multi-auth` (legacy npm name `oc-chatgpt-multi-auth` is migration-only).
+- Node engines: `>=18`.
+- OAuth callback port remains `1455`; callback path is `/auth/callback`.
 - ChatGPT-backed Codex requests require `store: false`.
 - Multi-turn continuity depends on `reasoning.encrypted_content` and the host-supplied conversation history.
 - Credentials and account metadata stay local unless the user exports or migrates them.
-- Diagnostic commands redact sensitive account/token details.
+- Diagnostic commands redact sensitive account/token details by default.
 - The optional keychain backend must fall back without deleting JSON credentials silently.
 
 ---
@@ -115,6 +152,7 @@ The storage layer uses V3 account files with migrations from older formats, atom
 ## Related
 
 - [getting-started.md](getting-started.md)
+- [tools-and-cli.md](tools-and-cli.md)
 - [configuration.md](configuration.md)
 - [troubleshooting.md](troubleshooting.md)
 - [privacy.md](privacy.md)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -146,9 +146,11 @@ The storage layer uses V3 account files with migrations from older formats, atom
 - Multi-turn continuity depends on `reasoning.encrypted_content` and the host-supplied conversation history.
 - Account pool limits: max **20** accounts; auth-failure cooldown **30s**; auto-removal after **3** consecutive auth failures.
 - Account bootstrap can hydrate from Codex CLI storage under `~/.codex` unless `CODEX_AUTH_SYNC_CODEX_CLI=0`.
+- Auth methods exposed to OpenCode are the three OAuth labels only (browser, device code, manual URL). There is no registered API-key login method.
 - Credentials and account metadata stay local unless the user exports or migrates them.
 - Diagnostic commands redact sensitive account/token details by default.
 - The optional keychain backend must fall back without deleting JSON credentials silently.
+- Session recovery rewrites OpenCode message/part files under the host storage root (`$XDG_DATA_HOME/opencode/storage` or platform equivalent) when `sessionRecovery` is enabled.
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -138,11 +138,14 @@ The storage layer uses V3 account files with migrations from older formats, atom
 ## Design Constraints
 
 - OpenCode remains the host runtime and provider loader.
+- Package exports: `"."` (provider plugin) and `"./tui"` (TUI quota plugin).
 - The canonical package/plugin name is `oc-codex-multi-auth` (legacy npm name `oc-chatgpt-multi-auth` is migration-only).
 - Node engines: `>=18`.
 - OAuth callback port remains `1455`; callback path is `/auth/callback`.
 - ChatGPT-backed Codex requests require `store: false`.
 - Multi-turn continuity depends on `reasoning.encrypted_content` and the host-supplied conversation history.
+- Account pool limits: max **20** accounts; auth-failure cooldown **30s**; auto-removal after **3** consecutive auth failures.
+- Account bootstrap can hydrate from Codex CLI storage under `~/.codex` unless `CODEX_AUTH_SYNC_CODEX_CLI=0`.
 - Credentials and account metadata stay local unless the user exports or migrates them.
 - Diagnostic commands redact sensitive account/token details by default.
 - The optional keychain backend must fall back without deleting JSON credentials silently.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,6 +1,8 @@
 # Configuration Reference
 
-Complete reference for configuring `oc-codex-multi-auth`. Most of this is optional; the defaults work for most people.
+Complete reference for configuring `oc-codex-multi-auth` v6.9.1. Most of this is optional; the defaults work for most people.
+
+Boolean environment overrides are truthy only for the literal string `"1"`.
 
 ---
 
@@ -53,12 +55,30 @@ controls how much thinking the model does.
 
 The shipped config templates include 12 base model families and 53 shipped presets overall (53 modern variants or 53 legacy explicit entries). The default installer uses the compact modern template so the TUI model picker shows base OAuth model families and the separate variant picker selects the reasoning preset. Use `--full` to install explicit selector IDs too. `gpt-5.5-pro` is ChatGPT-only (not routed by this plugin), while `gpt-5.3-codex-spark` remains a manual add-on for entitled workspaces only.
 
+Base families:
+
+```text
+gpt-5.6-sol
+gpt-5.6-terra
+gpt-5.6-luna
+gpt-5.5
+gpt-5.5-fast
+gpt-5.4-mini
+gpt-5.4-nano
+gpt-5.1-codex-max
+gpt-5.1-codex
+gpt-5.1-codex-mini
+gpt-5.1
+gpt-5-codex
+```
+
 GPT-5.6 notes:
 - 5.6 models are served over the **responses-lite** path. Their catalog entry sets `use_responses_lite: true` and `tool_mode: "code_mode_only"`, so the plugin reshapes the request the way Codex does: tool definitions move into `input` as a leading `additional_tools` developer item, the Codex instructions follow as a developer message, top-level `instructions` is emptied, `tools` is omitted, `parallel_tool_calls` is forced off, image `detail` fields are stripped, and an `x-openai-internal-codex-responses-lite: true` header is sent. Pre-5.6 models keep the classic shape.
 - No 5.6 tier accepts `none` or `minimal`; both are raised to `low`.
 - `max` and `ultra` are new in 5.6. Requesting them on an older family steps down to `xhigh` (then `high` where xhigh is unsupported).
 - `ultra` is a client-side tier. Codex rewrites it to `max` before the request leaves the client, and the subagent orchestration that distinguishes ultra lives in the Codex client rather than the request body. This plugin is a proxy, so `-ultra` is accepted as an alias and sent on the wire as `max` — it does **not** spawn subagents.
 - 5.6 is opt-in: the legacy `gpt-5` alias and the plugin default still resolve to `gpt-5.5` / `gpt-5.4`. Because 5.6 shipped as a limited preview, an account without access falls back down the 5.6 tiers and then to `gpt-5.5` automatically — this works under the default `strict` policy, like the `gpt-5.5`/`gpt-5-codex` auto-fallbacks, and can be disabled with `CODEX_AUTH_DISABLE_GPT56_AUTO_FALLBACK=1`. The lite shape is applied per request attempt, so a request that falls back from `gpt-5.6-sol` to `gpt-5.5` is re-serialized into the classic shape and keeps its tools.
+- Client identity defaults to `originator: opencode` for GPT-5.6 tiers and `codex_cli_rs` for other models. Override with `CODEX_AUTH_CLIENT_IDENTITY=codex|opencode`.
 - Instructions for the 5.6 tiers come from the Codex model catalog — see "System instructions" below.
 
 ### System instructions
@@ -155,6 +175,7 @@ advanced settings go in `~/.opencode/openai-codex-auth-config.json`:
   "fastSession": false,
   "fastSessionStrategy": "hybrid",
   "fastSessionMaxInputItems": 30,
+  "rotationStrategy": "hybrid",
   "modelAccountPools": {
     "gpt-5.6-sol": ["org-example-account-id"]
   },
@@ -175,7 +196,18 @@ advanced settings go in `~/.opencode/openai-codex-auth-config.json`:
   "unsupportedCodexFallbackChain": {
     "gpt-5.4-pro": ["gpt-5.4"],
     "gpt-5-codex": ["gpt-5.2-codex"]
-  }
+  },
+  "parallelProbing": false,
+  "parallelProbingMaxConcurrency": 2,
+  "emptyResponseMaxRetries": 2,
+  "emptyResponseRetryDelayMs": 1000,
+  "pidOffsetEnabled": false,
+  "sessionRecovery": true,
+  "autoResume": true,
+  "tokenRefreshSkewMs": 60000,
+  "rateLimitToastDebounceMs": 60000,
+  "fetchTimeoutMs": 60000,
+  "streamStallTimeoutMs": 45000
 }
 ```
 
@@ -196,6 +228,7 @@ The sample above intentionally sets `"retryAllAccountsMaxRetries": 3` as a bound
 | `fastSession` | `false` | forces low-latency settings per request (`reasoningEffort=none/low`, `reasoningSummary=auto`, `textVerbosity=low`) |
 | `fastSessionStrategy` | `hybrid` | `hybrid` speeds simple turns and keeps full-depth for complex prompts; `always` forces fast mode every turn |
 | `fastSessionMaxInputItems` | `30` | max input items kept when fast mode is applied |
+| `rotationStrategy` | `hybrid` | account selection strategy: `hybrid` (stick while healthy, else score-select), `sticky` (drain one account first), or `round-robin` |
 | `modelAccountPools` | `{}` | optional map of effective model IDs to preferred stable account IDs; selection uses the configured pool while it has a healthy account, then falls back to the general account pool |
 | `retryProfile` | `balanced` | retry budget profile for request classes (`conservative`, `balanced`, `aggressive`) |
 | `retryBudgetOverrides` | `{}` | optional per-class budget overrides (`authRefresh`, `network`, `server`, `rateLimitShort`, `rateLimitGlobal`, `emptyResponse`) |
@@ -213,6 +246,11 @@ The sample above intentionally sets `"retryAllAccountsMaxRetries": 3` as a bound
 | `autoResume` | `true` | auto-resume after thinking block recovery |
 | `tokenRefreshSkewMs` | `60000` | refresh tokens this many ms before expiry |
 | `rateLimitToastDebounceMs` | `60000` | debounce rate limit toasts |
+| `parallelProbing` | `false` | enable concurrent account health probes |
+| `parallelProbingMaxConcurrency` | `2` | max concurrent probes when parallel probing is enabled (1–5) |
+| `emptyResponseMaxRetries` | `2` | retries after an empty SSE/response body |
+| `emptyResponseRetryDelayMs` | `1000` | delay in ms between empty-response retries |
+| `pidOffsetEnabled` | `false` | add a small PID-based offset to hybrid selection scores (helps multi-process load spread) |
 | `fetchTimeoutMs` | `60000` | upstream fetch timeout in ms |
 | `streamStallTimeoutMs` | `45000` | max time to wait for next SSE chunk before aborting |
 
@@ -276,7 +314,7 @@ legacy toggle compatibility:
 
 ### Environment Variables
 
-override any config with env vars:
+override any config with env vars (boolean values are truthy only for `"1"`):
 
 | variable | what it does |
 |----------|--------------|
@@ -295,9 +333,15 @@ override any config with env vars:
 | `CODEX_AUTH_FAST_SESSION=1` | enable fast-session defaults |
 | `CODEX_AUTH_FAST_SESSION_STRATEGY=always` | force fast mode on every prompt |
 | `CODEX_AUTH_FAST_SESSION_MAX_INPUT_ITEMS=24` | tune max retained input items in fast mode |
+| `CODEX_AUTH_ROTATION_STRATEGY=sticky` | override account selection (`hybrid`, `sticky`, `round-robin`) |
 | `CODEX_AUTH_BEGINNER_SAFE_MODE=1` | enable beginner-safe retry behavior |
 | `CODEX_AUTH_RETRY_PROFILE=aggressive` | override retry profile (`conservative`, `balanced`, `aggressive`) |
 | `CODEX_AUTH_PER_PROJECT_ACCOUNTS=0` | disable per-project accounts |
+| `CODEX_AUTH_PARALLEL_PROBING=1` | enable concurrent account health probes |
+| `CODEX_AUTH_PARALLEL_PROBING_MAX_CONCURRENCY=3` | max concurrent probes (1–5) |
+| `CODEX_AUTH_EMPTY_RESPONSE_MAX_RETRIES=3` | override empty-response retry count |
+| `CODEX_AUTH_EMPTY_RESPONSE_RETRY_DELAY_MS=1500` | override empty-response retry delay |
+| `CODEX_AUTH_PID_OFFSET_ENABLED=1` | enable PID-based hybrid score offset |
 | `CODEX_AUTH_AUTO_UPDATE=0` | disable automatic OpenCode plugin cache refresh when npm has a newer plugin version |
 | `CODEX_AUTH_TOAST_DURATION_MS=8000` | set toast duration |
 | `CODEX_AUTH_RETRY_ALL_RATE_LIMITED=0` | disable wait-and-retry |
@@ -317,6 +361,7 @@ override any config with env vars:
 | `CODEX_AUTH_SEND_ORGANIZATION_HEADER=1` | restore legacy `openai-organization` request pinning (off by default; upstream Codex never sends it) |
 | `CODEX_AUTH_FETCH_TIMEOUT_MS=120000` | override fetch timeout |
 | `CODEX_AUTH_STREAM_STALL_TIMEOUT_MS=60000` | override SSE stall timeout |
+| `CODEX_KEYCHAIN=1` | opt in to OS-native keychain account storage |
 
 ---
 
@@ -358,8 +403,8 @@ different settings for different models:
           "name": "fast gpt-5.5",
           "options": { "reasoningEffort": "low" }
         },
-        "gpt-5.5-smart": {
-          "name": "smart gpt-5.5",
+        "gpt-5.6-sol": {
+          "name": "GPT 5.6 Sol (OAuth)",
           "options": { "reasoningEffort": "high" }
         }
       }
@@ -378,115 +423,55 @@ global (`~/.config/opencode/opencode.json`):
   "plugin": ["oc-codex-multi-auth"],
   "provider": {
     "openai": {
-      "options": { "reasoningEffort": "medium" }
+      "options": {
+        "store": false,
+        "include": ["reasoning.encrypted_content"]
+      }
     }
   }
 }
 ```
 
-project (`my-project/.opencode.json`):
-```json
-{
-  "provider": {
-    "openai": {
-      "options": { "reasoningEffort": "high" }
-    }
-  }
-}
+project override (`<project>/.opencode.json`) can set a default model or per-project provider options without changing the global install.
+
+### Compact modern selectors (default install)
+
+```bash
+opencode run "task" --model=openai/gpt-5.5 --variant=medium
+opencode run "task" --model=openai/gpt-5.5-fast --variant=medium
+opencode run "task" --model=openai/gpt-5.6-sol --variant=high
+opencode run "task" --model=openai/gpt-5-codex --variant=high
 ```
 
-result: project uses `high`, other projects use `medium`.
+### Explicit selectors (`--full` or `--legacy`)
+
+```bash
+npx -y oc-codex-multi-auth@latest --full
+opencode run "task" --model=openai/gpt-5.5-medium
+opencode run "task" --model=openai/gpt-5.6-sol-high
+```
 
 ---
 
 ## File Locations
 
-| file | what it's for |
-|------|---------------|
-| `~/.config/opencode/opencode.json` | global opencode config |
-| `<project>/.opencode.json` | project-specific config |
-| `~/.opencode/openai-codex-auth-config.json` | plugin config |
-| `~/.opencode/auth/openai.json` | oauth tokens |
-| `~/.opencode/oc-codex-multi-auth-accounts.json` | global account storage |
-| `~/.opencode/projects/<project-key>/oc-codex-multi-auth-accounts.json` | per-project account storage |
-| `~/.opencode/backups/codex-backup-YYYYMMDD-HHMMSSmmm-<hex>.json` | timestamped export backup (global storage mode) |
-| `~/.opencode/projects/<project-key>/backups/codex-backup-YYYYMMDD-HHMMSSmmm-<hex>.json` | timestamped export backup (per-project storage mode) |
-| `.../backups/codex-pre-import-backup-YYYYMMDD-HHMMSSmmm-<hex>.json` | automatic snapshot created before non-dry-run imports when existing accounts are present |
-| `~/.opencode/logs/codex-plugin/` | debug logs |
+| Path | Purpose |
+|------|---------|
+| `~/.config/opencode/opencode.json` | OpenCode provider/plugin config |
+| `~/.config/opencode/tui.json` | OpenCode TUI plugin config |
+| `~/.opencode/openai-codex-auth-config.json` | plugin runtime config (this page) |
+| `~/.opencode/auth/openai.json` | OpenCode OAuth tokens |
+| `~/.opencode/oc-codex-multi-auth-accounts.json` | global V3 account pool |
+| `~/.opencode/projects/<project-key>/oc-codex-multi-auth-accounts.json` | per-project account pool |
+| `~/.opencode/logs/codex-plugin/` | request/debug logs when enabled |
 
 ---
 
-## Debugging
+## See Also
 
-### Check Config Is Valid
-
-```bash
-opencode
-# shows errors if config is invalid
-```
-
-### Verify Model Resolution
-
-```bash
-DEBUG_CODEX_PLUGIN=1 opencode run "test" --model=openai/gpt-5.5 --variant=medium
-```
-
-look for:
-```text
-[openai-codex-plugin] Model config lookup: "gpt-5.5" -> normalized to "gpt-5.5" for API {
-  hasModelSpecificConfig: true,
-  resolvedConfig: { ... }
-}
-```
-
-### Test Per-Model Options
-
-```bash
-# default compact selectors
-ENABLE_PLUGIN_REQUEST_LOGGING=1 opencode run "test" --model=openai/gpt-5.5 --variant=medium
-ENABLE_PLUGIN_REQUEST_LOGGING=1 opencode run "test" --model=openai/gpt-5.5 --variant=high
-
-# direct selector IDs, only after installing with --full
-ENABLE_PLUGIN_REQUEST_LOGGING=1 opencode run "test" --model=openai/gpt-5.5-medium
-
-# compare reasoning.effort in logs
-cat ~/.opencode/logs/codex-plugin/request-*-after-transform.json | jq '.reasoning.effort'
-```
-
----
-
-## Troubleshooting
-
-### Model Not Found
-
-**error**: `Model 'openai/my-model' not found`
-
-**fix**: make sure config key matches exactly:
-```json
-{ "models": { "my-model": { ... } } }
-```
-```bash
-opencode run "test" --model=openai/my-model
-```
-
-### Per-Model Options Not Applied
-
-```bash
-DEBUG_CODEX_PLUGIN=1 opencode run "test" --model=openai/your-model
-```
-
-look for `hasModelSpecificConfig: true`. if it's false, config lookup failed - check for typos.
-
-### Per-Project Accounts Not Working
-
-make sure you're in a project directory (has `.git`, `package.json`, etc). the plugin auto-detects the project root and uses a namespaced file under `~/.opencode/projects/`. if no project root is found, it falls back to global storage.
-
-check which storage is being used:
-```bash
-DEBUG_CODEX_PLUGIN=1 opencode
-# look for storage path in logs
-```
-
----
-
-**next**: [troubleshooting](troubleshooting.md) | [back to docs](index.md)
+- [getting-started.md](getting-started.md)
+- [tools-and-cli.md](tools-and-cli.md)
+- [architecture.md](architecture.md)
+- [development/CONFIG_FIELDS.md](development/CONFIG_FIELDS.md)
+- [development/CONFIG_FLOW.md](development/CONFIG_FLOW.md)
+- [../config/README.md](../config/README.md)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -376,6 +376,20 @@ override any config with env vars (boolean values are truthy only for `"1"`):
 | `CODEX_COLLABORATION_MODE=plan` | collaboration mode hint for request shaping (`OPENCODE_COLLABORATION_MODE` is accepted as an alias) |
 | `OPENCODE_STATE_DIR=/path` | override OpenCode state dir used for the TUI quota cache file |
 
+### Advanced / power-user environment variables
+
+These are real runtime knobs used by the plugin. Most people never need them.
+
+| variable | what it does |
+|----------|--------------|
+| `CODEX_THREAD_ID=<id>` | optional correlation / prompt-cache seed attached to outbound Codex requests |
+| `OPENCODE_CODEX_PROMPT_URL=<url>` | override the OpenCode→Codex bridge prompt catalog URL used in legacy transform |
+| `OPENCODE_SKIP_EMAIL_HYDRATE=1` | skip account email hydrate during account-manager bootstrap |
+| `FORCE_INTERACTIVE_MODE=1` | force interactive menu paths even when the host looks non-interactive (tests / special shells) |
+| `OPENCODE_TUI=1` / `OPENCODE_DESKTOP=1` | host-injected markers used for non-interactive detection (normally set by OpenCode, not by you) |
+
+Boolean overrides remain truthy only for the literal string `"1"`.
+
 ---
 
 ## Config Patterns
@@ -476,7 +490,12 @@ opencode run "task" --model=openai/gpt-5.6-sol-high
 | `~/.opencode/auth/openai.json` | OpenCode OAuth tokens |
 | `~/.opencode/oc-codex-multi-auth-accounts.json` | global V3 account pool |
 | `~/.opencode/projects/<project-key>/oc-codex-multi-auth-accounts.json` | per-project account pool |
+| `~/.opencode/oc-codex-multi-auth-flagged-accounts.json` | flagged/deactivated account metadata |
 | `~/.opencode/logs/codex-plugin/` | request/debug logs when enabled |
+| `~/.opencode/cache/` | instruction/catalog and auto-update caches |
+| `$OPENCODE_STATE_DIR` or OpenCode state dir + `oc-codex-multi-auth-tui-quota.json` | TUI quota cache |
+| `$XDG_DATA_HOME/opencode/storage/…` (Windows: `%APPDATA%/opencode/storage`) | OpenCode session message/part store (session recovery) |
+| `openai-codex-accounts.json` / `openai-codex-flagged-accounts.json` / `openai-codex-blocked-accounts.json` | legacy migration sources only |
 
 ---
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -281,14 +281,19 @@ by default the plugin is strict (`unsupportedCodexPolicy: "strict"`) except for 
 
 set `unsupportedCodexPolicy: "fallback"` to enable model fallback after account/workspace attempts are exhausted.
 
-defaults when fallback policy is enabled and `unsupportedCodexFallbackChain` is empty:
+defaults when fallback policy is enabled and `unsupportedCodexFallbackChain` is empty (plus the always-on public-selector auto-fallbacks for common entitlement gates):
+- `gpt-5.6-sol -> gpt-5.6-terra -> gpt-5.6-luna -> gpt-5.5` (then the `gpt-5.5` chain)
+- `gpt-5.6-terra -> gpt-5.6-luna -> gpt-5.5`
+- `gpt-5.6-luna -> gpt-5.5`
 - `gpt-5.5 -> gpt-5.4 -> gpt-5.4-mini -> gpt-5.4-nano`
 - `gpt-5-codex -> gpt-5.4 -> gpt-5.4-mini -> gpt-5.4-nano`
-- `gpt-5.4-pro -> gpt-5.4` (if `gpt-5.4-pro` is selected manually)
+- `gpt-5.4-pro -> gpt-5.4` (if `gpt-5.4-pro` is selected manually; not a shipped base)
 - `gpt-5.3-codex -> gpt-5-codex -> gpt-5.2-codex`
 - `gpt-5.3-codex-spark -> gpt-5-codex -> gpt-5.3-codex -> gpt-5.2-codex` (applies if you manually select Spark model IDs)
 - `gpt-5.2-codex -> gpt-5-codex`
 - `gpt-5.1-codex -> gpt-5-codex`
+
+Note: `gpt-5.4` and `gpt-5.4-pro` appear in fallback/runtime normalization but are not shipped as compact modern base picker entries (bases use `gpt-5.4-mini` / `gpt-5.4-nano`).
 
 note: the TUI can continue showing your originally selected model while fallback is applied internally. use request logs to verify the effective upstream model (`request-*-after-transform.json`). set `CODEX_PLUGIN_LOG_BODIES=1` when you need to inspect raw `.body.*` fields.
 
@@ -329,7 +334,11 @@ override any config with env vars (boolean values are truthy only for `"1"`):
 | `CODEX_TUI_GLYPHS=unicode` | override glyph mode (`ascii`, `unicode`, `auto`) |
 | `CODEX_TUI_MASK_EMAIL=1` | mask account emails across account-display surfaces (TUI prompt quota status, command output, interactive account menu, and standalone login menu) |
 | `CODEX_TUI_MASK_EMAIL_DETAILS=1` | also mask the active account email in quota details when prompt masking is enabled |
-| `CODEX_AUTH_PREWARM=0` | disable startup prewarm (prompt/instruction cache warmup) |
+| `CODEX_AUTH_PREWARM=0` | disable startup prewarm when legacy transform is enabled (native mode does not prewarm) |
+| `CODEX_AUTH_TOKEN_REFRESH_SKEW_MS=60000` | refresh OAuth tokens this many ms before expiry |
+| `CODEX_AUTH_RATE_LIMIT_TOAST_DEBOUNCE_MS=60000` | debounce rate-limit toast notifications |
+| `CODEX_AUTH_SESSION_RECOVERY=0` | disable automatic session recovery hooks |
+| `CODEX_AUTH_AUTO_RESUME=0` | disable auto-resume after thinking-block recovery |
 | `CODEX_AUTH_FAST_SESSION=1` | enable fast-session defaults |
 | `CODEX_AUTH_FAST_SESSION_STRATEGY=always` | force fast mode on every prompt |
 | `CODEX_AUTH_FAST_SESSION_MAX_INPUT_ITEMS=24` | tune max retained input items in fast mode |
@@ -362,6 +371,10 @@ override any config with env vars (boolean values are truthy only for `"1"`):
 | `CODEX_AUTH_FETCH_TIMEOUT_MS=120000` | override fetch timeout |
 | `CODEX_AUTH_STREAM_STALL_TIMEOUT_MS=60000` | override SSE stall timeout |
 | `CODEX_KEYCHAIN=1` | opt in to OS-native keychain account storage |
+| `CODEX_AUTH_SYNC_CODEX_CLI=0` | disable hydrating accounts from Codex CLI `~/.codex` storage (on by default) |
+| `CODEX_CONSOLE_LOG=1` | also mirror plugin logs to the console |
+| `CODEX_COLLABORATION_MODE=plan` | collaboration mode hint for request shaping (`OPENCODE_COLLABORATION_MODE` is accepted as an alias) |
+| `OPENCODE_STATE_DIR=/path` | override OpenCode state dir used for the TUI quota cache file |
 
 ---
 

--- a/docs/development/ARCHITECTURE.md
+++ b/docs/development/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Architecture
 
-Runtime architecture for the `oc-codex-multi-auth` OpenCode plugin, installer, ChatGPT Plus/Pro OAuth flow, Codex/GPT-5 request bridge, multi-account rotation, `codex-*` tool registry, TUI quota status plugin, and local storage model.
+Runtime architecture for the `oc-codex-multi-auth` OpenCode plugin, installer, ChatGPT Plus/Pro OAuth flow, Codex/GPT-5 request bridge (including GPT-5.6 responses-lite), multi-account rotation, `codex-*` tool registry, TUI quota status plugin, and local storage model.
 
 > Reflects the codebase as of the current `main` branch. Historical audit section markers are retained in the docs tree for traceability, but this file is the current maintainer architecture source.
 
@@ -21,17 +21,20 @@ Runtime architecture for the `oc-codex-multi-auth` OpenCode plugin, installer, C
 ## System Diagram
 
 ```text
-Install / refresh
+Install / refresh / standalone CLI
   |
-  | npx -y oc-codex-multi-auth@latest [--modern|--full|--legacy]
+  | npx -y oc-codex-multi-auth@latest
+  |   default compact modern | --full | --legacy
+  |   [--dry-run] [--no-cache-clear]
+  | standalone: doctor | status | list | limits | dashboard | health | diag | warm
   v
 scripts/install-oc-codex-multi-auth.js
   |- delegates to scripts/install-oc-codex-multi-auth-core.js
   |- writes ~/.config/opencode/opencode.json
   |- writes ~/.config/opencode/tui.json
-  |- merges config/opencode-modern.json or config/opencode-legacy.json
+  |- merges config/opencode-modern.json and/or config/opencode-legacy.json
   |- normalizes old package/plugin entries
-  |- clears OpenCode plugin cache
+  |- clears OpenCode plugin cache (unless --no-cache-clear)
 
 OpenCode runtime
   |
@@ -57,7 +60,11 @@ lib/request/fetch-helpers.ts + lib/request/request-transformer.ts
   |- native mode: preserve host payload shape
   |- legacy mode: apply compatibility rewrites
   |- force store:false and include reasoning.encrypted_content
-  |- select/refresh account, attach OAuth headers
+  |- GPT-5.6: responses-lite reshape + opencode client identity
+  |- other models: codex_cli_rs client identity (default)
+  |- resolve modelAccountPools preferred accounts
+  |- select/refresh account (hybrid health scoring)
+  |- attach OAuth headers
   v
 ChatGPT-backed Codex endpoint
   |
@@ -66,6 +73,7 @@ lib/request/response-handler.ts
   |- SSE parsing
   |- error mapping
   |- quota/rate-limit/header extraction
+  |- empty-response retries
 
 OpenCode TUI runtime
   |
@@ -82,16 +90,16 @@ tui.ts
 
 | Subsystem | Key files | Responsibility |
 | --- | --- | --- |
-| Installer CLI | `scripts/install-oc-codex-multi-auth.js`, `scripts/install-oc-codex-multi-auth-core.js` | npm bin, config merge, cache cleanup, modern/full/legacy catalog selection, TUI plugin enablement |
+| Installer CLI | `scripts/install-oc-codex-multi-auth.js`, `scripts/install-oc-codex-multi-auth-core.js` | npm bin; config merge; cache cleanup; modern/full/legacy catalog selection; standalone doctor/status/list/limits/dashboard/health/diag/warm; TUI plugin enablement |
 | OpenCode plugin entry | `index.ts` | auth loader, runtime wiring, custom fetch pipeline, account manager lifecycle, `ToolContext`, OpenCode plugin export |
 | TUI plugin entry | `tui.ts`, `lib/tui-status.ts`, `lib/tui-quota-cache.ts`, `lib/codex-usage.ts` | prompt quota status, account-aware quota snapshots, usage refresh, details rendering |
 | Auth flow | `lib/auth/auth.ts`, `lib/auth/server.ts`, `lib/auth/browser.ts`, `lib/auth/device-code.ts`, `lib/auth/login-runner.ts`, `lib/auth/scopes.ts` | PKCE OAuth, callback server, device/manual login, workspace/account selection, scope validation |
-| Account manager | `lib/accounts.ts`, `lib/accounts/` | account state facade, persistence, rotation, recovery, rate-limit tracking, workspace identity preservation |
+| Account manager | `lib/accounts.ts`, `lib/accounts/` | account state facade, persistence, rotation, recovery, rate-limit tracking, workspace identity preservation, warm |
 | Storage | `lib/storage.ts`, `lib/storage/` | V3 JSON storage, atomic writes, migrations, per-project paths, backups, import/export, keychain opt-in, flagged accounts |
-| Request bridge | `lib/request/fetch-helpers.ts`, `lib/request/request-transformer.ts`, `lib/request/response-handler.ts`, `lib/request/retry-budget.ts`, `lib/request/rate-limit-backoff.ts` | URL/body/header shaping, Codex invariants, SSE conversion, retry budgets, backoff, error mapping |
+| Request bridge | `lib/request/fetch-helpers.ts`, `lib/request/request-transformer.ts`, `lib/request/response-handler.ts`, `lib/request/retry-budget.ts`, `lib/request/rate-limit-backoff.ts`, `lib/request/helpers/` | URL/body/header shaping, Codex invariants, responses-lite, client identity, SSE conversion, retry budgets, backoff, error mapping |
 | Model/prompt mapping | `lib/prompts/codex.ts`, `lib/prompts/opencode-codex.ts`, `lib/prompts/codex-opencode-bridge.ts`, `lib/request/helpers/model-map.ts` | model-family detection, Codex instructions cache, OpenCode prompt adaptation, fallback aliases |
 | Tool registry | `lib/tools/index.ts`, `lib/tools/codex-*.ts` | 24 OpenCode tools for setup, account switching, status, health, quota resets, diagnostics, backup, keychain, and recovery |
-| Runtime support | `lib/runtime.ts`, `lib/circuit-breaker.ts`, `lib/proactive-refresh.ts`, `lib/parallel-probe.ts`, `lib/recovery/`, `lib/shutdown.ts` | pure runtime helpers, failure isolation, refresh scheduling, health probing, session recovery, cleanup |
+| Runtime support | `lib/runtime.ts`, `lib/circuit-breaker.ts`, `lib/proactive-refresh.ts`, `lib/parallel-probe.ts`, `lib/recovery/`, `lib/rotation.ts`, `lib/shutdown.ts` | pure runtime helpers, failure isolation, refresh scheduling, health probing, hybrid selection scoring, session recovery, cleanup |
 | UI helpers | `lib/ui/` | terminal formatting, auth menu, select/confirm prompts, theme/color handling, beginner checklist |
 | Config templates | `config/opencode-modern.json`, `config/opencode-legacy.json`, `config/minimal-opencode.json`, `config/README.md` | copy-paste OpenCode provider templates and model catalog guidance |
 | Tests | `test/` | Vitest suites for auth, request transforms, storage, rotation, tools, TUI quota, installer, docs parity, and release regressions |
@@ -136,7 +144,7 @@ docs/
 High-level provider fetch flow:
 
 1. Parse OpenCode request URL and body.
-2. Resolve plugin config from defaults, `~/.opencode/openai-codex-auth-config.json`, and environment overrides.
+2. Resolve plugin config from defaults, `~/.opencode/openai-codex-auth-config.json`, and environment overrides (boolean env truthy only for `"1"`).
 3. Choose request transform mode:
    - `native` keeps OpenCode payloads unchanged except required Codex invariants.
    - `legacy` fetches Codex/OpenCode prompts and applies compatibility rewrites.
@@ -144,12 +152,16 @@ High-level provider fetch flow:
    - `stream: true`
    - `store: false`
    - `include: ["reasoning.encrypted_content"]` or equivalent inclusion
-5. Normalize model aliases and fallback candidates.
-6. Resolve account/workspace selection with health, cooldown, token bucket, and explicit `CODEX_AUTH_ACCOUNT_ID` constraints.
-7. Refresh tokens through the queued refresh path when needed.
-8. Attach OAuth/Codex headers and forward the request.
-9. Parse SSE responses, quota headers, retryable errors, and unsupported-model details.
-10. Update runtime metrics, account health, TUI quota cache, and persisted storage.
+5. Normalize model aliases and fallback candidates (including GPT-5.6 Sol/Terra/Luna tiers).
+6. For GPT-5.6 models, apply the responses-lite reshape (`lib/request/helpers/responses-lite.ts`): tools move into `input` as `additional_tools`, instructions become a developer message, top-level `tools`/`instructions` are cleared for lite shape, image `detail` is stripped, and `x-openai-internal-codex-responses-lite: true` is set.
+7. Resolve client identity (`lib/request/helpers/client-identity.ts`): GPT-5.6 defaults to `originator: opencode`; other models default to `codex_cli_rs`. Override with `CODEX_AUTH_CLIENT_IDENTITY`.
+8. Resolve preferred accounts from `modelAccountPools` for the effective model; fall back to the general pool when the preferred pool is empty or unavailable.
+9. Resolve account/workspace selection with the configured `rotationStrategy` (default `hybrid` health scoring), cooldown, token bucket, and explicit `CODEX_AUTH_ACCOUNT_ID` constraints.
+10. Refresh tokens through the queued refresh path when needed.
+11. Attach OAuth/Codex headers and forward the request.
+12. Parse SSE responses, quota headers, retryable errors, empty responses, and unsupported-model details.
+13. Update runtime metrics, account health, circuit breaker state, TUI quota cache, and persisted storage.
+14. On recoverable failures, apply session recovery / auto-resume hooks when enabled.
 
 ---
 
@@ -164,6 +176,8 @@ Context is preserved through:
 - `reasoning.encrypted_content` returned by the backend and sent back on later turns
 
 Legacy mode exists for compatibility with older OpenCode/AI SDK payload behavior. It removes unsupported `item_reference` items and message IDs that cannot be looked up when `store: false` is active. Native mode is the default and preserves the host payload shape as much as possible.
+
+GPT-5.6 responses-lite is a separate body shape layered on top of the same stateless contract: tool definitions live in the input prefix rather than the top-level `tools` field.
 
 ---
 
@@ -188,6 +202,8 @@ Tool groups:
 | Diagnostics | `codex-health`, `codex-metrics`, `codex-doctor`, `codex-diag`, `codex-diff` |
 | Backup/secrets | `codex-export`, `codex-import`, `codex-keychain` |
 
+Standalone CLI mirrors a subset without loading the agent: `doctor`, `status`, `list`, `limits`, `dashboard`, `health`, `diag`, `warm`.
+
 ---
 
 ## Storage Model
@@ -208,7 +224,7 @@ Canonical OpenCode plugin state lives under `~/.opencode`, while OpenCode config
 
 Storage invariants:
 
-1. V1/V2 account files migrate into V3 on load/save paths.
+1. V1/V2 account files migrate into V3 on load/save paths (V2 surfaces a typed recovery error rather than silent discard).
 2. Per-project storage is enabled by default and keyed by detected project identity.
 3. JSON files are written atomically where supported.
 4. Optional keychain storage is opt-in via `CODEX_KEYCHAIN=1`.
@@ -232,17 +248,31 @@ The request path also writes quota snapshots from response headers, so the TUI c
 
 ## Model Catalog and Fallback Notes
 
-The default installer writes the modern OpenCode template:
+The default installer writes the modern OpenCode template (`config/opencode-modern.json`):
 
-- 9 base model families in the picker
-- 36 effective variants through OpenCode's variant selector
+- 12 base model families in the picker:
+  - `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`
+  - `gpt-5.5`, `gpt-5.5-fast`
+  - `gpt-5.4-mini`, `gpt-5.4-nano`
+  - `gpt-5.1-codex-max`, `gpt-5.1-codex`, `gpt-5.1-codex-mini`, `gpt-5.1`, `gpt-5-codex`
+- 53 effective variants through OpenCode's variant selector
 - `store: false`
 - `reasoning.encrypted_content`
 - large context/output metadata for supported model families
 
-`--full` adds explicit selector IDs for scripts, and `--legacy` writes the explicit-only template for older OpenCode versions.
+`--full` adds 53 explicit selector IDs for scripts. `--legacy` writes the explicit-only template (53 entries) for older OpenCode versions.
 
-Unsupported-model behavior is strict by default. Fallback can be enabled through config or environment variables, with GPT-5.5 rollout fallback handled separately where documented.
+Unsupported-model behavior is strict by default. Default auto-fallbacks still cover common entitlement gates for GPT-5.6 tiers → `gpt-5.5`, and for `gpt-5.5` / `gpt-5-codex` through the GPT-5.4 family. Full generic fallback can be enabled through config or environment variables.
+
+---
+
+## Rotation and Reliability
+
+- `rotationStrategy` default `hybrid`: stick while healthy, otherwise score-select (health + tokens + freshness). Alternatives: `sticky`, `round-robin`.
+- `lib/rotation.ts` owns hybrid health scoring; `lib/accounts/rotation.ts` wires it into account manager state.
+- Circuit breaker isolates repeated failures per account/path.
+- Empty-response retries use `emptyResponseMaxRetries` / `emptyResponseRetryDelayMs`.
+- Optional `parallelProbing` can probe account health concurrently (default off).
 
 ---
 
@@ -257,7 +287,8 @@ Unsupported-model behavior is strict by default. Fallback can be enabled through
 7. Account emails and tokens must not be exposed in diagnostic payloads or response headers.
 8. Keychain failures must not silently delete JSON credentials.
 9. Tool additions require a per-file factory, registry wiring, and focused test/docs updates.
-10. Docs, package metadata, GitHub About text, and plugin metadata should lead with OpenCode, ChatGPT OAuth, Codex/GPT-5 routing, multi-account rotation, account switching, health checks, diagnostics, and recovery tools.
+10. Boolean environment overrides are truthy only for the literal string `"1"`.
+11. Docs, package metadata, GitHub About text, and plugin metadata should lead with OpenCode, ChatGPT OAuth, Codex/GPT-5 routing, multi-account rotation, account switching, health checks, diagnostics, and recovery tools.
 
 ---
 

--- a/docs/development/ARCHITECTURE.md
+++ b/docs/development/ARCHITECTURE.md
@@ -280,15 +280,19 @@ Unsupported-model behavior is strict by default. Default auto-fallbacks still co
 
 1. OAuth callback port remains `1455`.
 2. Dist output is generated; source of truth is `index.ts`, `tui.ts`, `lib/`, `scripts/`, `config/`, and `docs/`.
-3. The canonical package and plugin entry is `oc-codex-multi-auth`.
+3. The canonical package and plugin entry is `oc-codex-multi-auth` (exports `"."` and `"./tui"`).
 4. The installer should normalize stale `oc-chatgpt-multi-auth` entries rather than preserve duplicates.
 5. ChatGPT-backed Codex requests use `store: false`.
 6. `reasoning.encrypted_content` must stay available for multi-turn continuity.
 7. Account emails and tokens must not be exposed in diagnostic payloads or response headers.
 8. Keychain failures must not silently delete JSON credentials.
-9. Tool additions require a per-file factory, registry wiring, and focused test/docs updates.
-10. Boolean environment overrides are truthy only for the literal string `"1"`.
-11. Docs, package metadata, GitHub About text, and plugin metadata should lead with OpenCode, ChatGPT OAuth, Codex/GPT-5 routing, multi-account rotation, account switching, health checks, diagnostics, and recovery tools.
+9. Account pool limits stay at `ACCOUNT_LIMITS` (max 20, 30s auth cooldown, remove after 3 consecutive auth failures).
+10. Codex CLI hydrate from `~/.codex` stays on unless `CODEX_AUTH_SYNC_CODEX_CLI=0`.
+11. Startup prewarm runs only for legacy request transform when not disabled via `CODEX_AUTH_PREWARM=0`.
+12. Installer help/post-install strings must match the live catalog (12 modern bases / 53 variants; 53 legacy explicit).
+13. Tool additions require a per-file factory, registry wiring, and focused test/docs updates.
+14. Boolean environment overrides are truthy only for the literal string `"1"`.
+15. Docs, package metadata, GitHub About text, and plugin metadata should lead with OpenCode, ChatGPT OAuth, Codex/GPT-5 routing, multi-account rotation, account switching, health checks, diagnostics, and recovery tools.
 
 ---
 

--- a/docs/development/ARCHITECTURE.md
+++ b/docs/development/ARCHITECTURE.md
@@ -232,6 +232,18 @@ Storage invariants:
 
 ---
 
+## Session Recovery Storage
+
+When `sessionRecovery` is true (default), `lib/recovery/` may rewrite OpenCode host storage:
+
+| Path | Purpose |
+|------|---------|
+| `$XDG_DATA_HOME/opencode/storage` (or `%APPDATA%/opencode/storage` on Windows; else `~/.local/share/opencode/storage`) | Root |
+| `…/message/{sessionID}/…` | Session messages |
+| `…/part/{messageID}/*.json` | Message parts (thinking inject/strip, synthetic tool results) |
+
+Recovered classes: `tool_result_missing`, `thinking_block_order`, `thinking_disabled_violation`. Optional `autoResume` re-prompts after thinking recovery.
+
 ## TUI Quota Status Flow
 
 `tui.ts` is loaded by OpenCode's TUI plugin system after the installer writes `~/.config/opencode/tui.json`.

--- a/docs/development/CONFIG_FIELDS.md
+++ b/docs/development/CONFIG_FIELDS.md
@@ -18,15 +18,21 @@ The installer normalizes to this unpinned value on purpose.
 
 ### `model`
 
-Sets the default selected model:
+Sets the default selected model. Compact modern installs use base IDs plus OpenCode variants:
+
+```json
+{
+  "model": "openai/gpt-5.5"
+}
+```
+
+With `--full` or `--legacy`, explicit preset IDs also work:
 
 ```json
 {
   "model": "openai/gpt-5.5-medium"
 }
 ```
-
-Tested live on OpenCode `1.14.22`, explicit GPT-5.5 preset IDs such as `openai/gpt-5.5-medium` work directly at runtime.
 
 ## `provider.openai.options`
 
@@ -66,7 +72,7 @@ This field differs slightly between the modern and legacy shipped templates.
 
 ### Modern template fields
 
-Modern templates define base model families and expose presets through `variants`.
+Modern templates define 12 base model families and expose 53 presets through `variants`.
 
 Example:
 
@@ -90,6 +96,21 @@ Example:
             "medium": { "reasoningEffort": "medium" },
             "xhigh": { "reasoningEffort": "xhigh" }
           }
+        },
+        "gpt-5.6-sol": {
+          "name": "GPT 5.6 Sol (OAuth)",
+          "limit": {
+            "context": 1050000,
+            "output": 128000
+          },
+          "variants": {
+            "low": { "reasoningEffort": "low" },
+            "medium": { "reasoningEffort": "medium" },
+            "high": { "reasoningEffort": "high" },
+            "xhigh": { "reasoningEffort": "xhigh" },
+            "max": { "reasoningEffort": "max" },
+            "ultra": { "reasoningEffort": "ultra" }
+          }
         }
       }
     }
@@ -101,7 +122,7 @@ Important fields:
 
 | Field | Purpose |
 |------|---------|
-| model key (`gpt-5.5`) | base model family exposed to OpenCode |
+| model key (`gpt-5.5`, `gpt-5.6-sol`, …) | base model family exposed to OpenCode |
 | `name` | human-readable picker label |
 | `limit` | context/output metadata shown to OpenCode |
 | `modalities` | allowed input/output types |
@@ -112,11 +133,12 @@ If your OpenCode release exposes bare base entries, modern selection looks like:
 
 ```bash
 opencode run "task" --model=openai/gpt-5.5 --variant=high
+opencode run "task" --model=openai/gpt-5.6-sol --variant=medium
 ```
 
 ### Legacy template fields
 
-Legacy templates expose each preset as its own model key.
+Legacy templates expose each preset as its own model key (53 explicit entries).
 
 Example:
 
@@ -163,23 +185,74 @@ Examples:
 
 | Selected model | Effective upstream family |
 |------|---------|
+| `openai/gpt-5.5` + variant `medium` | `gpt-5.5` |
 | `openai/gpt-5.5-medium` | `gpt-5.5` |
+| `openai/gpt-5.6-sol` + variant `high` | `gpt-5.6-sol` |
+| `openai/gpt-5.6-sol-xhigh` | `gpt-5.6-sol` |
+| `openai/gpt-5.6` | `gpt-5.6-sol` |
+| `openai/gpt-5.6-terra-medium` | `gpt-5.6-terra` |
+| `openai/gpt-5.6-luna-max` | `gpt-5.6-luna` |
 | `openai/gpt-5.4-mini-xhigh` | `gpt-5.4-mini` |
 | `openai/gpt-5.1-codex-high` | `gpt-5.1-codex` |
 | `openai/gpt-5-mini` | `gpt-5.4-mini` |
 | `openai/gpt-5-nano` | `gpt-5.4-nano` |
 
-This normalization is why legacy aliases and snapshot-like IDs can still route to a stable family while preserving the user-facing config surface.
+This normalization is why legacy aliases and snapshot-like IDs can still route to a stable family while preserving the user-facing config surface. GPT-5.6 tiers also trigger the responses-lite request shape after normalization.
 
-## `modelAccountPools`
+## Plugin Runtime Config
 
-The plugin runtime config at `~/.opencode/openai-codex-auth-config.json` can
-map effective model IDs to preferred stable account IDs:
+Path: `~/.opencode/openai-codex-auth-config.json`
+
+Defaults come from `lib/config.ts` / `lib/schemas.ts`. Environment overrides win over file values. Boolean env values are truthy only for `"1"`.
+
+| Field | Default | Env override | Purpose |
+|------|---------|--------------|---------|
+| `codexMode` | `true` | `CODEX_MODE` | Legacy bridge prompt behavior when `requestTransformMode=legacy` |
+| `requestTransformMode` | `native` | `CODEX_AUTH_REQUEST_TRANSFORM_MODE` | `native` preserves host payload; `legacy` rewrites for older SDKs |
+| `codexTuiV2` | `true` | `CODEX_TUI_V2` | Codex-style terminal UI output |
+| `codexTuiColorProfile` | `truecolor` | `CODEX_TUI_COLOR_PROFILE` | `truecolor` / `ansi256` / `ansi16` |
+| `codexTuiGlyphMode` | `ascii` | `CODEX_TUI_GLYPHS` | `ascii` / `unicode` / `auto` |
+| `maskEmail` | `false` | `CODEX_TUI_MASK_EMAIL` | Mask account emails on display surfaces |
+| `maskEmailInQuotaDetails` | `false` | `CODEX_TUI_MASK_EMAIL_DETAILS` | Also mask email in quota details |
+| `beginnerSafeMode` | `false` | `CODEX_AUTH_BEGINNER_SAFE_MODE` | Conservative retries and recovery |
+| `fastSession` | `false` | `CODEX_AUTH_FAST_SESSION` | Force low-latency reasoning/verbosity |
+| `fastSessionStrategy` | `hybrid` | `CODEX_AUTH_FAST_SESSION_STRATEGY` | `hybrid` or `always` |
+| `fastSessionMaxInputItems` | `30` | `CODEX_AUTH_FAST_SESSION_MAX_INPUT_ITEMS` | Max input items kept in fast mode |
+| `rotationStrategy` | `hybrid` | `CODEX_AUTH_ROTATION_STRATEGY` | `hybrid`, `sticky`, or `round-robin` account selection |
+| `modelAccountPools` | `{}` | (file only) | Preferred stable account IDs per effective model |
+| `retryProfile` | `balanced` | `CODEX_AUTH_RETRY_PROFILE` | `conservative` / `balanced` / `aggressive` |
+| `retryBudgetOverrides` | `{}` | (file only) | Per-class budget overrides |
+| `retryAllAccountsRateLimited` | `true` | `CODEX_AUTH_RETRY_ALL_RATE_LIMITED` | Wait/retry when every account is limited |
+| `retryAllAccountsMaxWaitMs` | `0` | `CODEX_AUTH_RETRY_ALL_MAX_WAIT_MS` | Max wait ms (`0` = unlimited) |
+| `retryAllAccountsMaxRetries` | `Infinity` | `CODEX_AUTH_RETRY_ALL_MAX_RETRIES` | Max all-account retries |
+| `unsupportedCodexPolicy` | `strict` | `CODEX_AUTH_UNSUPPORTED_MODEL_POLICY` | `strict` or `fallback` |
+| `fallbackOnUnsupportedCodexModel` | `false` | `CODEX_AUTH_FALLBACK_UNSUPPORTED_MODEL` | Legacy fallback toggle |
+| `fallbackToGpt52OnUnsupportedGpt53` | `true` | `CODEX_AUTH_FALLBACK_GPT53_TO_GPT52` | Legacy 5.3→5.2 edge |
+| `unsupportedCodexFallbackChain` | `{}` | (file only) | Per-model fallback chain overrides |
+| `tokenRefreshSkewMs` | `60000` | (via config helpers) | Refresh tokens this many ms before expiry |
+| `rateLimitToastDebounceMs` | `60000` | `CODEX_AUTH_RATE_LIMIT_TOAST_DEBOUNCE_MS` | Debounce rate-limit toasts |
+| `toastDurationMs` | `5000` | `CODEX_AUTH_TOAST_DURATION_MS` | Toast visibility duration |
+| `perProjectAccounts` | `true` | `CODEX_AUTH_PER_PROJECT_ACCOUNTS` | Project-scoped account pools |
+| `sessionRecovery` | `true` | `CODEX_AUTH_SESSION_RECOVERY` | Auto-recover common API errors |
+| `autoResume` | `true` | `CODEX_AUTH_AUTO_RESUME` | Auto-resume after thinking-block recovery |
+| `autoUpdate` | `true` | `CODEX_AUTH_AUTO_UPDATE` | Daily npm update check + cache refresh |
+| `parallelProbing` | `false` | `CODEX_AUTH_PARALLEL_PROBING` | Concurrent account health probes |
+| `parallelProbingMaxConcurrency` | `2` | `CODEX_AUTH_PARALLEL_PROBING_MAX_CONCURRENCY` | Max concurrent probes (1–5) |
+| `emptyResponseMaxRetries` | `2` | `CODEX_AUTH_EMPTY_RESPONSE_MAX_RETRIES` | Retries after empty SSE bodies |
+| `emptyResponseRetryDelayMs` | `1000` | `CODEX_AUTH_EMPTY_RESPONSE_RETRY_DELAY_MS` | Delay between empty-response retries |
+| `pidOffsetEnabled` | `false` | `CODEX_AUTH_PID_OFFSET_ENABLED` | Small PID-based hybrid score offset for multi-process spread |
+| `fetchTimeoutMs` | `60000` | `CODEX_AUTH_FETCH_TIMEOUT_MS` | Upstream fetch timeout |
+| `streamStallTimeoutMs` | `45000` | `CODEX_AUTH_STREAM_STALL_TIMEOUT_MS` | SSE stall abort timeout |
+
+### `modelAccountPools`
+
+The plugin runtime config can map effective model IDs to preferred stable account IDs:
 
 ```json
 {
   "modelAccountPools": {
-    "gpt-5.6-sol": ["org-example-account-id"]
+    "gpt-5.6-sol": ["org-example-account-id"],
+    "gpt-5.5": ["org-another-account-id"]
   }
 }
 ```
@@ -203,9 +276,20 @@ the tool does not automatically prune them because they may be valid elsewhere.
 
 ## Verification Notes
 
-Use these commands when validating config fields:
+Use these commands when validating config fields.
+
+### Compact modern (default install)
 
 ```bash
+opencode debug config
+ENABLE_PLUGIN_REQUEST_LOGGING=1 opencode run "ping" --model=openai/gpt-5.5 --variant=medium
+ENABLE_PLUGIN_REQUEST_LOGGING=1 opencode run "ping" --model=openai/gpt-5.6-sol --variant=medium
+```
+
+### Full / legacy explicit selectors
+
+```bash
+npx -y oc-codex-multi-auth@latest --full
 opencode debug config
 ENABLE_PLUGIN_REQUEST_LOGGING=1 opencode run "ping" --model=openai/gpt-5.5-medium
 ```
@@ -213,8 +297,10 @@ ENABLE_PLUGIN_REQUEST_LOGGING=1 opencode run "ping" --model=openai/gpt-5.5-mediu
 Important behavior:
 
 - `opencode debug config` shows merged config-defined models and variants.
-- On tested OpenCode `1.14.22`, `opencode models openai` exposes explicit GPT-5.5 entries such as `gpt-5.5-medium` / `gpt-5.5-high`.
-- Bare `openai/gpt-5.5` can still be rejected by provider lookup, so use explicit GPT-5.5 preset IDs for reliable CLI verification.
+- Default compact installs expose base OAuth entries such as `gpt-5.5`, `gpt-5.5-fast`, and `gpt-5.6-sol`.
+- Bare `openai/gpt-5.5` works with `--variant=medium` on compact modern installs.
+- Explicit IDs such as `openai/gpt-5.5-medium` require `--full` or `--legacy` unless you added them manually.
+- Do not use `gpt-5.5-medium` for verification unless the full/legacy catalog is installed.
 
 ## Account Metadata Fields
 

--- a/docs/development/CONFIG_FIELDS.md
+++ b/docs/development/CONFIG_FIELDS.md
@@ -302,6 +302,21 @@ Important behavior:
 - Explicit IDs such as `openai/gpt-5.5-medium` require `--full` or `--legacy` unless you added them manually.
 - Do not use `gpt-5.5-medium` for verification unless the full/legacy catalog is installed.
 
+## Advanced / non-schema environment variables
+
+Not part of `PluginConfigSchema`, but used by runtime modules:
+
+| Env | Effect |
+|-----|--------|
+| `CODEX_THREAD_ID` | Optional correlation / prompt-cache seed on outbound requests |
+| `OPENCODE_CODEX_PROMPT_URL` | Override OpenCode→Codex bridge prompt catalog URL (legacy transform) |
+| `OPENCODE_SKIP_EMAIL_HYDRATE=1` | Skip email hydrate during account bootstrap |
+| `FORCE_INTERACTIVE_MODE=1` | Force interactive menu paths for tests/special shells |
+| `CODEX_AUTH_SYNC_CODEX_CLI=0` | Disable `~/.codex` account hydrate (on unless `"0"`) |
+| `CODEX_CONSOLE_LOG=1` | Mirror plugin logs to console |
+| `CODEX_COLLABORATION_MODE` / `OPENCODE_COLLABORATION_MODE` | Collaboration mode hint for request shaping |
+| `OPENCODE_STATE_DIR` | Override state directory for TUI quota cache |
+
 ## Account Metadata Fields
 
 Account storage also includes user-facing metadata fields used by the `codex-*` tools:

--- a/docs/development/CONFIG_FIELDS.md
+++ b/docs/development/CONFIG_FIELDS.md
@@ -229,7 +229,7 @@ Defaults come from `lib/config.ts` / `lib/schemas.ts`. Environment overrides win
 | `fallbackOnUnsupportedCodexModel` | `false` | `CODEX_AUTH_FALLBACK_UNSUPPORTED_MODEL` | Legacy fallback toggle |
 | `fallbackToGpt52OnUnsupportedGpt53` | `true` | `CODEX_AUTH_FALLBACK_GPT53_TO_GPT52` | Legacy 5.3→5.2 edge |
 | `unsupportedCodexFallbackChain` | `{}` | (file only) | Per-model fallback chain overrides |
-| `tokenRefreshSkewMs` | `60000` | (via config helpers) | Refresh tokens this many ms before expiry |
+| `tokenRefreshSkewMs` | `60000` | `CODEX_AUTH_TOKEN_REFRESH_SKEW_MS` | Refresh tokens this many ms before expiry |
 | `rateLimitToastDebounceMs` | `60000` | `CODEX_AUTH_RATE_LIMIT_TOAST_DEBOUNCE_MS` | Debounce rate-limit toasts |
 | `toastDurationMs` | `5000` | `CODEX_AUTH_TOAST_DURATION_MS` | Toast visibility duration |
 | `perProjectAccounts` | `true` | `CODEX_AUTH_PER_PROJECT_ACCOUNTS` | Project-scoped account pools |

--- a/docs/development/CONFIG_FLOW.md
+++ b/docs/development/CONFIG_FLOW.md
@@ -41,17 +41,29 @@ Plugin-specific runtime settings live outside the OpenCode config file:
 ~/.opencode/openai-codex-auth-config.json
 ```
 
-That file controls plugin behavior such as retry policy, beginner safe mode, fallback policy, TUI output, and per-project account storage.
+That file controls plugin behavior such as retry policy, rotation strategy, beginner safe mode, fallback policy, TUI output, model account pools, and per-project account storage. Schema and defaults live in `lib/schemas.ts` and `lib/config.ts`. Boolean environment overrides are truthy only for the literal string `"1"`.
 
 ## Installer Flow
 
 `scripts/install-oc-codex-multi-auth.js` performs these steps:
 
-1. Load the selected template set (`config/opencode-modern.json` by default, merged modern+legacy templates with `--full`, or `config/opencode-legacy.json` with `--legacy`).
+1. Load the selected template set:
+   - default / `--modern`: `config/opencode-modern.json` (compact 12 bases / 53 variants)
+   - `--full`: modern bases merged with `config/opencode-legacy.json` explicit entries
+   - `--legacy`: `config/opencode-legacy.json` only (53 explicit IDs)
 2. Back up an existing `~/.config/opencode/opencode.json`.
 3. Normalize the plugin list so it ends with plain `oc-codex-multi-auth`.
 4. Replace `provider.openai` with the selected shipped template block.
-5. Clear the cached OpenCode plugin copy under `~/.cache/opencode/`.
+5. Enable the TUI plugin in `~/.config/opencode/tui.json`.
+6. Clear the cached OpenCode plugin copy under `~/.cache/opencode/` unless `--no-cache-clear`.
+
+Additional flags:
+
+| Flag | Effect |
+|------|--------|
+| `--dry-run` | Print planned actions without writing |
+| `--no-cache-clear` | Skip OpenCode plugin cache cleanup |
+| standalone first arg | Run CLI without install: `doctor`, `status`, `list`, `limits`, `dashboard`, `health`, `diag`, `warm` |
 
 Important detail:
 
@@ -67,18 +79,37 @@ Important detail:
 
 It currently ships:
 
-- 9 base model families
-- 36 total variants
+- 12 base model families
+- 53 total variants
+- GPT-5.6 Sol / Terra / Luna (responses-lite path)
 - `gpt-5.5` and `gpt-5.5-fast` at 1,050,000 context / 128,000 output
+- GPT-5.6 tiers at 1,050,000 context / 128,000 output
 - `gpt-5.4-mini`, `gpt-5.4-nano`, and Codex families at 400,000 context / 128,000 output
 - `gpt-5.1` at 272,000 context / 128,000 output
 - `store: false` plus `include: ["reasoning.encrypted_content"]`
+
+Base families:
+
+```text
+gpt-5.6-sol
+gpt-5.6-terra
+gpt-5.6-luna
+gpt-5.5
+gpt-5.5-fast
+gpt-5.4-mini
+gpt-5.4-nano
+gpt-5.1-codex-max
+gpt-5.1-codex
+gpt-5.1-codex-mini
+gpt-5.1
+gpt-5-codex
+```
 
 ### Default installer mode
 
 The default installer mode writes:
 
-- the 9 modern base model entries from `config/opencode-modern.json`
+- the 12 modern base model entries from `config/opencode-modern.json`
 
 That compact install mode keeps the OpenCode TUI model picker focused on actual OAuth model families. Reasoning presets are selected through the separate variant picker.
 
@@ -97,8 +128,15 @@ Example shape:
         "store": false
       },
       "models": {
-        "gpt-5.4": {
+        "gpt-5.5": {
           "name": "GPT 5.5 (OAuth)",
+          "variants": {
+            "medium": { "reasoningEffort": "medium" },
+            "high": { "reasoningEffort": "high" }
+          }
+        },
+        "gpt-5.6-sol": {
+          "name": "GPT 5.6 Sol (OAuth)",
           "variants": {
             "medium": { "reasoningEffort": "medium" },
             "high": { "reasoningEffort": "high" }
@@ -115,14 +153,15 @@ Default install uses base model IDs plus variants:
 ```bash
 opencode run "task" --model=openai/gpt-5.5 --variant=medium
 opencode run "task" --model=openai/gpt-5.5-fast --variant=medium
+opencode run "task" --model=openai/gpt-5.6-sol --variant=high
 ```
 
 ### Full installer mode
 
 `--full` combines:
 
-- the 9 modern base model entries from `config/opencode-modern.json`
-- the 36 explicit preset entries from `config/opencode-legacy.json`
+- the 12 modern base model entries from `config/opencode-modern.json`
+- the 53 explicit preset entries from `config/opencode-legacy.json`
 
 Use it when scripts require direct selector IDs:
 
@@ -130,6 +169,7 @@ Use it when scripts require direct selector IDs:
 npx -y oc-codex-multi-auth@latest --full
 opencode run "task" --model=openai/gpt-5.5-medium
 opencode run "task" --model=openai/gpt-5.5-fast-medium
+opencode run "task" --model=openai/gpt-5.6-sol-high
 ```
 
 ### Legacy template
@@ -138,8 +178,8 @@ opencode run "task" --model=openai/gpt-5.5-fast-medium
 
 It currently ships:
 
-- 36 explicit model entries
-- separate model IDs such as `gpt-5.5-medium`, `gpt-5.5-fast-medium`, `gpt-5.5-high`, and `gpt-5.4-mini-xhigh`
+- 53 explicit model entries
+- separate model IDs such as `gpt-5.5-medium`, `gpt-5.5-fast-medium`, `gpt-5.5-high`, `gpt-5.6-sol-xhigh`, and `gpt-5.4-mini-xhigh`
 - the same OpenAI provider defaults (`store: false`, `reasoning.encrypted_content`)
 
 Legacy OpenCode selection uses:
@@ -156,12 +196,17 @@ At runtime, OpenCode passes `provider.openai.options` and `provider.openai.model
 2. Reads per-model definitions.
 3. Applies request-shaping behavior (`native` by default, `legacy` when explicitly enabled).
 4. Normalizes selected model IDs to canonical upstream Codex/ChatGPT model families before the final API call.
+5. For GPT-5.6 Sol/Terra/Luna, applies the responses-lite request shape and default `opencode` client identity.
+6. Resolves preferred accounts via `modelAccountPools`, then selects an account with `rotationStrategy`.
 
 Examples:
 
 - `openai/gpt-5.5` with variant `medium` normalizes to `gpt-5.5`
+- `openai/gpt-5.6-sol` with variant `high` normalizes to `gpt-5.6-sol`
+- `openai/gpt-5.6-sol-xhigh` normalizes to `gpt-5.6-sol`
 - `openai/gpt-5.4-mini-xhigh` normalizes to `gpt-5.4-mini`
 - legacy aliases such as `gpt-5-mini` normalize to `gpt-5.4-mini`
+- bare `gpt-5.6` normalizes to flagship tier `gpt-5.6-sol`
 
 ## Verification
 
@@ -170,19 +215,22 @@ Use these commands when checking the effective config:
 ```bash
 opencode debug config
 ENABLE_PLUGIN_REQUEST_LOGGING=1 opencode run "ping" --model=openai/gpt-5.5 --variant=medium
+ENABLE_PLUGIN_REQUEST_LOGGING=1 opencode run "ping" --model=openai/gpt-5.6-sol --variant=medium
 ```
 
 Important runtime behavior:
 
 - `opencode debug config` shows merged provider models from your config.
-- The default install shows compact GPT-5.5 OAuth base entries such as `gpt-5.5` / `gpt-5.5-fast`.
-- `--full` additionally shows explicit GPT-5.5 entries such as `gpt-5.5-medium` / `gpt-5.5-fast-medium` / `gpt-5.5-high`.
+- The default install shows compact OAuth base entries such as `gpt-5.5`, `gpt-5.5-fast`, and `gpt-5.6-sol`.
+- `--full` additionally shows explicit entries such as `gpt-5.5-medium` / `gpt-5.5-fast-medium` / `gpt-5.6-sol-high`.
+- Compact verification should use `--model=openai/gpt-5.5 --variant=medium`, not `gpt-5.5-medium`, unless `--full` or `--legacy` was installed.
 
 ## File Locations
 
 | Path | Purpose |
 |------|---------|
 | `~/.config/opencode/opencode.json` | global OpenCode config used by the installer |
+| `~/.config/opencode/tui.json` | OpenCode TUI plugin config |
 | `<project>/.opencode.json` | project-local OpenCode override |
 | `~/.opencode/openai-codex-auth-config.json` | plugin runtime config |
 | `~/.opencode/auth/openai.json` | OAuth token storage |

--- a/docs/development/TESTING.md
+++ b/docs/development/TESTING.md
@@ -95,7 +95,7 @@ Important note:
 ### Request-path smoke
 
 ```bash
-ENABLE_PLUGIN_REQUEST_LOGGING=1 opencode run "ping" --model=openai/gpt-5.5-medium
+ENABLE_PLUGIN_REQUEST_LOGGING=1 opencode run "ping" --model=openai/gpt-5.5 --variant=medium
 ```
 
 Verify:
@@ -138,7 +138,7 @@ If validation fails, sort the failure first:
 For request-path debugging:
 
 ```bash
-DEBUG_CODEX_PLUGIN=1 ENABLE_PLUGIN_REQUEST_LOGGING=1 CODEX_PLUGIN_LOG_BODIES=1 opencode run "ping" --model=openai/gpt-5.5-medium
+DEBUG_CODEX_PLUGIN=1 ENABLE_PLUGIN_REQUEST_LOGGING=1 CODEX_PLUGIN_LOG_BODIES=1 opencode run "ping" --model=openai/gpt-5.5 --variant=medium
 ```
 
 Use that only when you need payload-level detail because it can log sensitive request and response bodies.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -2,11 +2,11 @@
 
 ## What is this project?
 
-`oc-codex-multi-auth` is an OpenCode plugin that lets you sign in with ChatGPT Plus/Pro through OAuth and use GPT-5/Codex model presets from OpenCode.
+`oc-codex-multi-auth` is an OpenCode plugin that lets you sign in with ChatGPT Plus/Pro through OAuth and use GPT-5/Codex model presets from OpenCode, including multi-account rotation, health checks, and recovery tools.
 
 ## Who is it for?
 
-It is aimed at individual developers who use OpenCode and want ChatGPT-backed GPT-5 or Codex workflows for personal development.
+It is aimed at individual developers who use OpenCode and want ChatGPT-backed GPT-5 or Codex workflows for personal development. It is not intended for commercial resale, shared multi-user access, or production services.
 
 ## When should I use this instead of the OpenAI Platform API?
 
@@ -25,15 +25,46 @@ See [config/README.md](../config/README.md) for the template split.
 
 ## What models are included by default?
 
-The shipped templates focus on current GPT-5 and Codex families such as `gpt-5.5`, `gpt-5.5-fast`, `gpt-5.4-mini`, `gpt-5-codex`, and `gpt-5.1-*`. Optional or entitlement-gated model IDs can be added manually when your workspace supports them. `gpt-5.5-pro` is ChatGPT-only and is not routed through this Codex plugin.
+The shipped templates include **12 base families** and **53 presets** total:
+
+| Base | Family |
+|------|--------|
+| `gpt-5.6-sol` | GPT-5.6 (responses-lite) |
+| `gpt-5.6-terra` | GPT-5.6 (responses-lite) |
+| `gpt-5.6-luna` | GPT-5.6 (responses-lite) |
+| `gpt-5.5` | GPT-5.5 |
+| `gpt-5.5-fast` | GPT-5.5 Fast |
+| `gpt-5.4-mini` | GPT-5.4 Mini |
+| `gpt-5.4-nano` | GPT-5.4 Nano |
+| `gpt-5.1-codex-max` | GPT-5.1 Codex Max |
+| `gpt-5.1-codex` | GPT-5.1 Codex |
+| `gpt-5.1-codex-mini` | GPT-5.1 Codex Mini |
+| `gpt-5.1` | GPT-5.1 |
+| `gpt-5-codex` | GPT-5 Codex |
+
+GPT-5.6 is entitlement-gated for some accounts. Without access, the plugin auto-falls back `sol → terra → luna → gpt-5.5` (disable with `CODEX_AUTH_DISABLE_GPT56_AUTO_FALLBACK=1`). Optional or entitlement-gated model IDs can be added manually when your workspace supports them. `gpt-5.5-pro` is ChatGPT-only and is not routed through this Codex plugin.
+
+Default install is compact modern (bases + variants). Use `--full` for modern + explicit IDs, or `--legacy` for explicit-only.
 
 ## Can I use multiple accounts?
 
-Yes. The plugin supports multiple ChatGPT accounts, health-aware rotation, per-project storage, and guided account management commands.
+Yes. The plugin supports multiple ChatGPT accounts, health-aware rotation (`rotationStrategy`: `hybrid` default, `sticky`, or `round-robin`), per-project storage (default on), preferred model→account pools (`modelAccountPools` / `codex-pool`), and guided account management commands such as `codex-list`, `codex-switch`, and `codex-warm`.
+
+## How do I warm accounts without spending an agent turn?
+
+Run the standalone CLI:
+
+```bash
+oc-codex-multi-auth warm
+# or
+npx -y oc-codex-multi-auth@latest warm
+```
+
+That opens every enabled account's usage window with no OpenCode agent loop. Inside a session you can still call `codex-warm`.
 
 ## Where does it store data?
 
-Tokens, account state, and cache files are stored locally on your machine. See [Privacy & Data Handling](privacy.md) for the exact paths.
+Tokens, account state, plugin config, quota cache, and logs are stored locally on your machine. See [Privacy & Data Handling](privacy.md) for the exact paths. Account pools use V3 JSON by default; opt into the OS keychain with `CODEX_KEYCHAIN=1`.
 
 ## What should I do if authentication fails?
 
@@ -41,4 +72,12 @@ Start with [Troubleshooting](troubleshooting.md), rerun `opencode auth login`, a
 
 ## I used the old package name. What changed?
 
-This package has gone through earlier naming changes. If you still reference any older package name in your OpenCode config, replace it with `oc-codex-multi-auth`.
+The supported package/plugin name is `oc-codex-multi-auth`. The legacy name `oc-chatgpt-multi-auth` is migration-only: the installer rewrites stale plugin entries and storage migrations may still recognize old files. Replace any remaining config references with `oc-codex-multi-auth`.
+
+## Which Node version do I need?
+
+Node.js `>=18`.
+
+## Where is the full tool and CLI list?
+
+See [Tools and CLI](tools-and-cli.md) for all 24 `codex-*` tools and the standalone bin commands.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -48,7 +48,7 @@ Default install is compact modern (bases + variants). Use `--full` for modern + 
 
 ## Can I use multiple accounts?
 
-Yes. The plugin supports multiple ChatGPT accounts, health-aware rotation (`rotationStrategy`: `hybrid` default, `sticky`, or `round-robin`), per-project storage (default on), preferred model→account pools (`modelAccountPools` / `codex-pool`), and guided account management commands such as `codex-list`, `codex-switch`, and `codex-warm`.
+Yes. The plugin supports multiple ChatGPT accounts, health-aware rotation (`rotationStrategy`: `hybrid` default, `sticky`, or `round-robin`), per-project storage (default on), preferred model→account pools (`modelAccountPools` / `codex-pool`), and guided account management commands such as `codex-list`, `codex-switch`, and `codex-warm`. Hard limits: at most **20** saved OAuth accounts, a **30s** cooldown after auth failures, and automatic removal after **3** consecutive auth failures on the same account.
 
 ## How do I warm accounts without spending an agent turn?
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -64,7 +64,11 @@ That opens every enabled account's usage window with no OpenCode agent loop. Ins
 
 ## Where does it store data?
 
-Tokens, account state, plugin config, quota cache, and logs are stored locally on your machine. See [Privacy & Data Handling](privacy.md) for the exact paths. Account pools use V3 JSON by default; opt into the OS keychain with `CODEX_KEYCHAIN=1`.
+Tokens, account state, plugin config, quota cache, and logs are stored locally on your machine. See [Privacy & Data Handling](privacy.md) for the exact paths. Account pools use V3 JSON by default; opt into the OS keychain with `CODEX_KEYCHAIN=1`. Session recovery may also touch OpenCode's message/part store under the host data directory. Older `openai-codex-*.json` filenames are migration sources only.
+
+## Is there an API-key login?
+
+No. The plugin registers three OAuth methods only (browser, device code, manual URL paste). A dummy SDK key string is used internally for the OpenAI client; ChatGPT OAuth tokens do the real auth.
 
 ## What should I do if authentication fails?
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,6 +1,6 @@
 # Getting Started
 
-This guide covers the full installation and first-run flow for `oc-codex-multi-auth`.
+This guide covers the full installation and first-run flow for `oc-codex-multi-auth` v6.9.1.
 
 ## Before You Begin
 
@@ -17,7 +17,7 @@ This guide covers the full installation and first-run flow for `oc-codex-multi-a
 |-------------|-------|
 | OpenCode | Install from [opencode.ai](https://opencode.ai) |
 | ChatGPT Plus or Pro | Required for OAuth access and model entitlements |
-| Node.js 20+ | Needed for local OpenCode runtime and plugin installation |
+| Node.js `>=18` | Needed for local OpenCode runtime and plugin installation |
 
 ## Fastest Install Path
 
@@ -27,17 +27,17 @@ opencode auth login
 opencode run "Explain this repository" --model=openai/gpt-5.5 --variant=medium
 ```
 
-The installer updates `~/.config/opencode/opencode.json`, backs up the previous config, normalizes the plugin entry to `oc-codex-multi-auth`, and clears the cached plugin copy so OpenCode reinstalls the latest package.
+The installer updates `~/.config/opencode/opencode.json`, backs up the previous config, normalizes the plugin entry to `oc-codex-multi-auth`, enables the TUI status plugin, and clears the cached plugin copy so OpenCode reinstalls the latest package.
 
-By default, the installer writes the compact UI config so the model picker shows base OAuth model families such as `gpt-5.5` and `gpt-5.5-fast`, then the separate model variant picker handles `none`, `low`, `medium`, `high`, and `xhigh`. Rerunning the default installer also removes explicit preset entries and stale base models left by earlier plugin catalogs.
+By default, the installer writes the **compact modern** config so the model picker shows **12 base OAuth model families** (including `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`, `gpt-5.5`, `gpt-5.5-fast`, and the Codex families). The separate model variant picker selects reasoning presets. Altogether the modern catalog covers **53 variants**. Rerunning the default installer also removes explicit preset entries and stale base models left by earlier plugin catalogs.
 
-If you want direct explicit selector IDs such as `openai/gpt-5.5-medium`, use the full catalog:
+If you want direct explicit selector IDs such as `openai/gpt-5.5-medium` (modern bases **plus** explicit entries):
 
 ```bash
 npx -y oc-codex-multi-auth@latest --full
 ```
 
-If you explicitly want the older explicit-only layout, use:
+If you explicitly want the older explicit-only layout (53 individual model keys):
 
 ```bash
 npx -y oc-codex-multi-auth@latest --legacy
@@ -77,7 +77,7 @@ Then choose:
 1. `OpenAI`
 2. `Codex OAuth (ChatGPT Plus/Pro)`
 
-The browser-based OAuth flow uses the same local callback port as Codex CLI. The authorize redirect is `http://localhost:1455/auth/callback`, while the local callback server binds `http://127.0.0.1:1455/auth/callback` and `[::1]:1455` for dual-stack localhost redirects.
+The browser-based OAuth flow uses the same local callback port as Codex CLI. The authorize redirect is `http://localhost:1455/auth/callback`, while the local callback server binds `http://127.0.0.1:1455/auth/callback` and `[::1]:1455` for dual-stack localhost redirects. Authorization and token exchange go to `auth.openai.com`.
 
 If you authenticated before the connector scopes were added, re-run `opencode auth login`. Current account records persist the granted OAuth scope and accounts missing `api.connectors.read` / `api.connectors.invoke` are marked for re-auth instead of being silently reused.
 
@@ -111,9 +111,25 @@ The repository ships two supported templates:
 | `v1.0.209` and earlier | [`config/opencode-legacy.json`](../config/opencode-legacy.json) |
 
 The templates include the supported GPT-5/Codex families, required `store: false` handling, and `reasoning.encrypted_content` for multi-turn sessions.
-Current templates expose 9 shipped base model families and 36 shipped presets overall (36 modern variants or 36 legacy explicit entries).
 
-On OpenCode `v1.0.210+`, the modern template intentionally shows 9 base model entries because the additional presets are selected through `--variant` instead of separate model keys.
+Current templates expose **12 base model families** and **53 presets** overall (53 modern variants or 53 legacy explicit entries):
+
+| Base family | Notes |
+|-------------|-------|
+| `gpt-5.6-sol` | responses-lite; flagship 5.6 tier |
+| `gpt-5.6-terra` | responses-lite |
+| `gpt-5.6-luna` | responses-lite |
+| `gpt-5.5` | default public GPT-5.5 selector |
+| `gpt-5.5-fast` | faster GPT-5.5 variant |
+| `gpt-5.4-mini` | |
+| `gpt-5.4-nano` | |
+| `gpt-5.1-codex-max` | |
+| `gpt-5.1-codex` | |
+| `gpt-5.1-codex-mini` | |
+| `gpt-5.1` | |
+| `gpt-5-codex` | canonical Codex |
+
+On OpenCode `v1.0.210+`, the modern template shows the 12 base entries because additional presets are selected through `--variant` instead of separate model keys.
 
 `gpt-5.5-pro` is not shipped in the Codex templates because it is ChatGPT-only, not Codex-routable. Add entitlement-gated Spark variants manually only when your workspace supports them.
 
@@ -127,6 +143,9 @@ opencode run "Create a short TODO list for this repo" --model=openai/gpt-5.5 --v
 opencode run "Create a short TODO list for this repo" --model=openai/gpt-5.5-fast --variant=medium
 opencode run "Inspect the retry logic and summarize it" --model=openai/gpt-5-codex --variant=high
 
+# Optional GPT-5.6 (requires account entitlement; auto-falls back sol→terra→luna→gpt-5.5)
+opencode run "Create a short TODO list for this repo" --model=openai/gpt-5.6-sol --variant=medium
+
 # Direct selector IDs, only after installing with --full
 opencode run "Create a short TODO list for this repo" --model=openai/gpt-5.5-medium
 ```
@@ -139,28 +158,44 @@ ENABLE_PLUGIN_REQUEST_LOGGING=1 opencode run "test" --model=openai/gpt-5.5 --var
 
 The first request should create logs under `~/.opencode/logs/codex-plugin/`.
 
-Use `opencode debug config` when you want to verify that template-defined or custom models were merged into your effective config. The default install exposes compact OAuth model entries such as `gpt-5.5` and `gpt-5.5-fast`; `--full` additionally exposes explicit entries such as `gpt-5.5-medium` / `gpt-5.5-fast-medium` / `gpt-5.5-high`.
+Use `opencode debug config` when you want to verify that template-defined or custom models were merged into your effective config. The default install exposes compact OAuth model entries such as `gpt-5.5` and `gpt-5.6-sol`; `--full` additionally exposes explicit entries such as `gpt-5.5-medium` / `gpt-5.5-fast-medium` / `gpt-5.5-high`.
 
 ## Multi-Account Setup
 
-The plugin can manage multiple ChatGPT accounts and choose the healthiest account or workspace for each request.
+The plugin can manage multiple ChatGPT accounts and choose the healthiest account or workspace for each request. Per-project account pools default to **on** under `~/.opencode/projects/<project-key>/`.
 
 After your first successful login, you can add more accounts by running `opencode auth login` again or by using the guided commands below.
 
+Optional: pin models to preferred accounts with `modelAccountPools` / `codex-pool` (see [configuration.md](configuration.md) and [tools-and-cli.md](tools-and-cli.md)).
+
 ## Guided Onboarding Commands
 
-These commands are useful after installation:
+These commands are useful after installation (from inside OpenCode as tools, or for several of them via the standalone bin):
 
 ```text
 codex-setup
 codex-help topic="setup"
 codex-doctor
 codex-next
+codex-list
+codex-warm
+codex-pool
+codex-reset
+```
+
+Standalone equivalents (no agent/model loop):
+
+```bash
+oc-codex-multi-auth doctor
+oc-codex-multi-auth status
+oc-codex-multi-auth list
+oc-codex-multi-auth warm
 ```
 
 Notes:
 
 - `codex-switch`, `codex-label`, and `codex-remove` can show interactive account pickers when `index` is omitted in a supported terminal.
+- `codex-warm` opens every enabled account's usage window so rolling quota windows start at session start.
 - The plugin can show a startup preflight summary with the current account health state and suggested next step.
 
 ## Beginner Safe Mode
@@ -197,9 +232,13 @@ npm ci
 npm run build
 ```
 
+When `autoUpdate` is enabled (default), the plugin also checks npm daily and can clear the OpenCode plugin cache so a restart picks up a newer release.
+
 ## Next Reading
 
+- [Tools and CLI](tools-and-cli.md)
 - [Configuration Reference](configuration.md)
 - [Troubleshooting](troubleshooting.md)
 - [FAQ](faq.md)
 - [Privacy & Data Handling](privacy.md)
+- [Architecture Overview](architecture.md)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -75,7 +75,12 @@ opencode auth login
 Then choose:
 
 1. `OpenAI`
-2. `Codex OAuth (ChatGPT Plus/Pro)`
+2. One of the **three** plugin OAuth methods:
+   - `Codex OAuth (ChatGPT Plus/Pro)` — browser callback (default)
+   - `Codex OAuth (Device Code)` — headless / SSH
+   - `Codex OAuth (Manual URL Paste)` — paste the redirect URL
+
+There is **no** registered “Manual API Key” login path for this plugin. The provider still presents a dummy SDK key (`chatgpt-oauth`) internally; real auth is always OAuth.
 
 The browser-based OAuth flow uses the same local callback port as Codex CLI. The authorize redirect is `http://localhost:1455/auth/callback`, while the local callback server binds `http://127.0.0.1:1455/auth/callback` and `[::1]:1455` for dual-stack localhost redirects. Authorization and token exchange go to `auth.openai.com`.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,10 +1,11 @@
 # oc-codex-multi-auth Docs
 
-Use your ChatGPT Plus/Pro subscription inside OpenCode with OAuth login, Codex/GPT-5 model routing, multi-account rotation, account switching, health checks, quota status, diagnostics, and recovery tools.
+Use your ChatGPT Plus/Pro subscription inside OpenCode with OAuth login, Codex/GPT-5 model routing (including GPT-5.6), multi-account rotation, account switching, health checks, quota status, diagnostics, and recovery tools.
 
 ## User Guides
 
 - [Getting Started](getting-started.md)
+- [Tools and CLI](tools-and-cli.md)
 - [Configuration Reference](configuration.md)
 - [Troubleshooting](troubleshooting.md)
 - [FAQ](faq.md)
@@ -19,6 +20,12 @@ Use your ChatGPT Plus/Pro subscription inside OpenCode with OAuth login, Codex/G
 - [Configuration Fields](development/CONFIG_FIELDS.md)
 - [Testing Guide](development/TESTING.md)
 - [TUI Parity Checklist](development/TUI_PARITY_CHECKLIST.md)
+
+## Historical audits
+
+The `audits/` tree is a **historical** review snapshot. Prefer current user and development docs above for live behavior; treat audit findings as dated context, not the product contract.
+
+- [Audits index](audits/INDEX.md)
 
 ## Repository Links
 

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -2,208 +2,252 @@
 
 This page explains how `oc-codex-multi-auth` handles local data, upstream requests, and debugging artifacts.
 
+**Last updated:** 2026-07-18
+
 ## Overview
 
-This plugin prioritizes user privacy and data security. We believe in transparency about data handling and giving you full control over your information.
+This plugin prioritizes local control and transparency. It does not ship product telemetry or analytics to third parties. Network traffic is limited to the OpenAI/ChatGPT auth and API endpoints you are actively using, optional Codex instruction/catalog fetches from GitHub, and an optional daily npm version check when auto-update is enabled.
+
+> [!CAUTION]
+> This plugin is for personal development use with your own ChatGPT Plus/Pro subscription. You are responsible for your prompts, exports, and OpenAI policy compliance.
 
 ---
 
 ## What We Collect
 
-**Nothing.** This plugin does not collect, store, or transmit usage data to third parties.
+**No first-party telemetry.** This plugin does not send usage analytics, crash reports, or account inventories to the package maintainers.
 
-- ❌ No telemetry
-- ❌ No analytics
-- ❌ No usage tracking
-- ❌ No personal information collection
+- No analytics product
+- No usage tracking service
+- No remote logging of prompts to maintainers
+
+Local logs, caches, and config files on **your** machine are separate; see [Data Storage](#data-storage).
 
 ---
 
 ## Data Storage
 
-All data is stored **locally on your machine**:
+All plugin state is stored **locally on your machine** unless you export it or opt into OS keychain storage.
 
-### OAuth Tokens
-- **Location:** `~/.opencode/auth/openai.json`
-- **Contents:** Access tokens, refresh tokens, expiration timestamps
-- **Managed by:** OpenCode's credential management system
-- **Security:** File permissions restrict access to your user account
+### Account storage (V3)
 
-### Cache Files
-- **Location:** `~/.opencode/cache/`
-- **Contents:**
-  - `codex-instructions.txt` - Codex system instructions (fetched from GitHub)
-  - `codex-instructions-meta.json` - ETag and timestamp metadata
-- **Purpose:** Reduce GitHub API calls and improve performance
-- **TTL:** 15 minutes (automatically refreshes when stale)
+| Item | Default path |
+|------|----------------|
+| Global account pool | `~/.opencode/oc-codex-multi-auth-accounts.json` |
+| Per-project account pool | `~/.opencode/projects/<project-key>/oc-codex-multi-auth-accounts.json` |
+| Flagged accounts | `~/.opencode/oc-codex-multi-auth-flagged-accounts.json` |
 
-### Debug Logs
-- **Location:** `~/.opencode/logs/codex-plugin/`
-- **Contents:** Request/response metadata logs (only when `ENABLE_PLUGIN_REQUEST_LOGGING=1` is set)
-- **Includes:**
-  - Request metadata (model, flags, response status, timing)
-  - Raw request/response payloads only when `CODEX_PLUGIN_LOG_BODIES=1` is also set
-  - Timestamps
-  - Configuration used
-- **⚠️ Warning:** Logs may contain your prompts and model responses - handle with care
+Contents typically include OAuth access/refresh material, account IDs, labels/tags/notes, rate-limit reset metadata, and rotation state. Per-project pools are enabled by default (`perProjectAccounts: true`).
+
+### Plugin configuration
+
+| Item | Default path |
+|------|----------------|
+| Plugin config | `~/.opencode/openai-codex-auth-config.json` |
+
+Includes runtime options such as retry profile, rotation strategy, model account pools, TUI preferences, and beginner-safe mode.
+
+### OpenCode host files
+
+| Item | Default path |
+|------|----------------|
+| OpenCode config | `~/.config/opencode/opencode.json` |
+| OpenCode TUI config | `~/.config/opencode/tui.json` |
+| OpenCode auth tokens | `~/.opencode/auth/openai.json` |
+
+### Optional OS keychain
+
+When `CODEX_KEYCHAIN=1` is set, account pools can be stored in the OS credential store (macOS Keychain, Windows Credential Manager, Linux libsecret) under service name `oc-codex-multi-auth`. JSON files may be renamed with a `.migrated-to-keychain.<timestamp>` suffix for rollback. Keychain failures fall back to JSON without silently deleting credentials.
+
+### TUI quota cache
+
+| Item | Default path |
+|------|----------------|
+| TUI quota cache | OpenCode state path, with fallback `~/.opencode/oc-codex-multi-auth-tui-quota.json` |
+
+Caches recent quota/usage snapshots for prompt status display.
+
+### Catalog and instruction caches
+
+| Item | Default path |
+|------|----------------|
+| Cache directory | `~/.opencode/cache/` |
+
+May include Codex system instructions, catalog-derived instruction files, ETag/meta files, and the auto-update check cache (`update-check-cache.json`).
+
+### Debug logs
+
+| Item | Default path |
+|------|----------------|
+| Request logs | `~/.opencode/logs/codex-plugin/` |
+
+Written only when request logging is enabled (`ENABLE_PLUGIN_REQUEST_LOGGING=1`). Metadata logs omit raw bodies by default; set `CODEX_PLUGIN_LOG_BODIES=1` only when you need raw request/response payloads (sensitive: may include prompts and model output).
+
+### Backups and exports
+
+Export/import and installer backups may create files under `~/.opencode/backups/` or project-scoped backup directories. Treat exports as credential-bearing data.
 
 ---
 
 ## Data Transmission
 
-### Direct to OpenAI
-All API requests go **directly from your machine to OpenAI's servers**:
-- ✅ No intermediary proxies
-- ✅ No third-party data collection
-- ✅ HTTPS encrypted communication
-- ✅ OAuth-secured authentication
+### Direct to OpenAI / ChatGPT
 
-### What Gets Sent to OpenAI
-When you use the plugin, the following is transmitted to OpenAI:
-- Your prompts and conversation history
+API and auth traffic go **directly from your machine** to OpenAI/ChatGPT endpoints over HTTPS. There is no maintainer proxy.
+
+| Service | Endpoint family |
+|---------|-----------------|
+| OAuth authorize / token | `https://auth.openai.com/...` (e.g. `/oauth/authorize`, `/oauth/token`) |
+| Codex API | `https://chatgpt.com/backend-api/codex/responses` |
+| Usage / quota helpers | related `chatgpt.com/backend-api` paths used for usage windows |
+
+### What gets sent on a normal model request
+
+When you use the plugin, a request can include:
+
+- Your prompts and conversation history (as supplied by OpenCode)
 - OAuth access token (for authentication)
-- ChatGPT account ID (from token JWT)
-- Configuration options (reasoning effort, verbosity, etc.)
-- Model selection
+- ChatGPT account/workspace identifiers used for routing
+- Model selection, reasoning effort, verbosity, and related options
+- **Client identity headers**: `originator` and a product `User-Agent` (Codex CLI style or host/opencode style, depending on model and config). These **are** sent; they are not suppressed by default.
+- For GPT-5.6: responses-lite markers such as `x-openai-internal-codex-responses-lite`
 
-**Note:** This is identical to what the official OpenAI Codex CLI sends.
+This is analogous to what official Codex-style clients send when talking to the same backend. Exact fields vary by model family and transform mode.
 
-### What Does NOT Get Sent
-- ❌ Your filesystem contents (unless explicitly requested via tools)
-- ❌ Personal information beyond what's in your prompts
-- ❌ Usage statistics or analytics
-- ❌ Plugin version or system information
+### What does not get sent to maintainers
+
+- No automatic upload of account lists, tokens, or logs to the plugin authors
+- No remote analytics endpoint for this package
+
+### Optional npm auto-update check
+
+When `autoUpdate` is enabled (default `true`; disable with `autoUpdate: false` or `CODEX_AUTH_AUTO_UPDATE=0`), the plugin may query the public npm registry (`registry.npmjs.org/oc-codex-multi-auth/latest`) about once per day to detect a newer version, cache the result under `~/.opencode/cache/`, and clear the OpenCode-managed plugin cache so a restart can pick up the update. That request does not send your ChatGPT tokens or prompts.
 
 ---
 
 ## Third-Party Services
 
 ### GitHub API
-The plugin fetches Codex instructions from GitHub:
-- **URL:** `https://api.github.com/repos/openai/codex/releases/latest`
-- **Purpose:** Get latest Codex system instructions
-- **Frequency:** Once per 15 minutes (cached with ETag)
-- **Data sent:** HTTP GET request (no personal data)
-- **Rate limiting:** 60 requests/hour (unauthenticated)
+
+The plugin may fetch Codex instructions / model catalog material from GitHub (for example release metadata under `openai/codex`) with local caching and ETag reuse. Requests are ordinary HTTPS GETs without your ChatGPT credentials.
 
 ### OpenAI Services
-All interactions with OpenAI go through:
-- **OAuth:** `https://chatgpt.com/oauth`
-- **API:** `https://chatgpt.com/backend-api/conversation`
 
-See [OpenAI Privacy Policy](https://openai.com/policies/privacy-policy/) for how OpenAI handles data.
+All auth and inference go through OpenAI/ChatGPT as listed above. See [OpenAI Privacy Policy](https://openai.com/policies/privacy-policy/) for how OpenAI handles data.
 
 ---
 
 ## Your Data Rights
 
-You have complete control over your data:
+You have complete control over local data:
 
 ### Delete OAuth Tokens
+
 ```bash
 opencode auth logout
 # Or manually:
 rm ~/.opencode/auth/openai.json
 ```
 
-### Delete Cache Files
+### Delete Account Pools and Flagged State
+
 ```bash
-rm -rf ~/.opencode/cache/
+rm ~/.opencode/oc-codex-multi-auth-accounts.json
+rm ~/.opencode/oc-codex-multi-auth-flagged-accounts.json
+rm -rf ~/.opencode/projects/
 ```
 
-### Delete Logs
+Also remove any project-scoped account files and keychain entries if you migrated with `CODEX_KEYCHAIN=1` (see `codex-keychain`).
+
+### Delete Plugin Config, Caches, Logs, Quota Cache
+
 ```bash
+rm ~/.opencode/openai-codex-auth-config.json
+rm -rf ~/.opencode/cache/
 rm -rf ~/.opencode/logs/codex-plugin/
+rm -f ~/.opencode/oc-codex-multi-auth-tui-quota.json
 ```
 
 ### Revoke OAuth Access
-1. Visit [ChatGPT Settings → Authorized Apps](https://chatgpt.com/settings/apps)
-2. Find "OpenCode" or "Codex CLI"
-3. Click "Revoke"
 
-This immediately invalidates all access tokens.
+1. Visit [ChatGPT Settings → Authorized Apps](https://chatgpt.com/settings/apps)
+2. Find the app entry used for login (OpenCode / Codex-related)
+3. Click Revoke
+
+This invalidates access tokens for that authorization.
 
 ---
 
 ## Security Measures
 
 ### Token Protection
-- **Local storage only:** Tokens never leave your machine except when sent to OpenAI for authentication
-- **File permissions:** Auth files are readable only by your user account
-- **No logging:** OAuth tokens are never written to debug logs
-- **Automatic refresh:** Expired tokens are refreshed automatically
+
+- Tokens stay local except when sent to OpenAI/ChatGPT for authentication and API calls
+- Auth and account files should remain user-readable only where the OS allows
+- Diagnostic tools redact tokens and sensitive identifiers by default
+- Expired tokens are refreshed automatically; refresh is queued to avoid races
 
 ### PKCE Flow
-The plugin uses **PKCE (Proof Key for Code Exchange)** for OAuth:
-- Prevents authorization code interception attacks
-- Industry-standard security for OAuth 2.0
-- Same method used by OpenAI's official Codex CLI
+
+The plugin uses **PKCE** for the browser OAuth flow (same class of flow used by official Codex CLI login).
 
 ### HTTPS Encryption
-All network communication uses HTTPS:
-- OAuth authorization: Encrypted
-- API requests: Encrypted
-- Token refresh: Encrypted
+
+OAuth, token refresh, and API requests use HTTPS.
 
 ### Email Masking in Account Displays
-Account emails are personally identifying and can be exposed in screenshots, screen sharing, and terminal recordings during pair programming or shared OpenCode TUI sessions. To avoid this:
-- Set a stable, non-identifying label for each account with `codex-label` (for example `plus-1`, `plus-2`, `pro-1`). Labels are always preferred over emails in account displays.
-- Enable `maskEmail` in `~/.opencode/openai-codex-auth-config.json` to reduce any remaining emails to a masked form such as `us***@example.com` across the account menu, command output, and TUI quota status.
-- Raw emails are only emitted in `--includeSensitive` JSON output, which is opt-in and never shown by default.
+
+Account emails can appear in screenshots or shared TUI sessions. To reduce exposure:
+
+- Set a non-identifying label with `codex-label` (labels are preferred over emails)
+- Enable `maskEmail` in `~/.opencode/openai-codex-auth-config.json` (or `CODEX_TUI_MASK_EMAIL=1`) so remaining emails render as forms like `us***@example.com`
+- Raw emails appear in `--includeSensitive` / `includeSensitive` JSON output only when you opt in
 
 ---
 
 ## Compliance
 
-### OpenAI's Privacy Policy
+### OpenAI Policies
+
 When using this plugin, you are subject to:
+
 - [OpenAI Privacy Policy](https://openai.com/policies/privacy-policy/)
 - [OpenAI Terms of Use](https://openai.com/policies/terms-of-use/)
 
-**Your responsibility:** Ensure your usage complies with OpenAI's policies.
+Your responsibility: ensure usage complies with OpenAI's policies and your subscription terms.
 
-### GDPR Considerations
+### Local Data Control
+
 This plugin:
-- ✅ Does not collect personal data
-- ✅ Does not process data on behalf of third parties
-- ✅ Stores data locally under your control
-- ✅ Provides clear data deletion mechanisms
 
-However, data sent to OpenAI is subject to OpenAI's privacy practices.
+- Does not operate a maintainer-side personal data processing service
+- Stores operational state locally under your control
+- Provides deletion steps for local files and OAuth revocation
+
+Data sent to OpenAI remains subject to OpenAI's practices.
 
 ---
 
 ## Transparency
 
 ### Open Source
-The entire plugin source code is available at:
-- **GitHub:** [https://github.com/ndycode/oc-codex-multi-auth](https://github.com/ndycode/oc-codex-multi-auth)
 
+Source: [https://github.com/ndycode/oc-codex-multi-auth](https://github.com/ndycode/oc-codex-multi-auth)
 
-You can:
-- Review all code
-- Audit data handling
-- Verify no hidden telemetry
-- Inspect network requests
+You can review request shaping, storage, and logging behavior in the repository.
 
-### No Hidden Behavior
-- No obfuscated code
-- No minified dependencies
-- All network requests are documented
-- Debug logging shows exactly what's sent to APIs
+### No Hidden Telemetry Product
+
+There is no separate analytics backend for this package. Documented network calls are OAuth/API, optional GitHub catalog fetches, and optional npm version checks.
 
 ---
 
 ## Questions?
 
-For privacy-related questions:
 - **Plugin-specific:** [GitHub Issues](https://github.com/ndycode/oc-codex-multi-auth/issues)
-
 - **OpenAI data handling:** [OpenAI Support](https://help.openai.com/)
-- **Security concerns:** See [SECURITY.md](../SECURITY.md)
+- **Security concerns:** [SECURITY.md](../SECURITY.md)
 
 ---
 
-**Last Updated:** 2026-03-11
-
-**Back to:** [Documentation Home](index.md) | [Getting Started](getting-started.md)
+**Back to:** [Documentation Home](index.md) | [Getting Started](getting-started.md) | [Tools and CLI](tools-and-cli.md)

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -43,6 +43,19 @@ Contents typically include OAuth access/refresh material, account IDs, labels/ta
 
 On startup the plugin may also read Codex CLI account material under `~/.codex` (for example `accounts.json`) to help bootstrap the local pool. Disable with `CODEX_AUTH_SYNC_CODEX_CLI=0`. This is local filesystem access only; nothing is uploaded to the package maintainers.
 
+### Legacy account filenames (migration only)
+
+Older installs may still have migration sources under `~/.opencode/` or a project tree:
+
+| Legacy file | Role |
+|-------------|------|
+| `openai-codex-accounts.json` | Pre-rename account pool seed |
+| `openai-codex-flagged-accounts.json` | Pre-rename flagged metadata |
+| `openai-codex-blocked-accounts.json` | Older blocked-account list (migrated into flagged handling) |
+| `<project>/.opencode/openai-codex-accounts.json` | In-repo legacy pool (read for migration; current pools live under `~/.opencode/projects/…`) |
+
+Current canonical names use the `oc-codex-multi-auth-*.json` prefix. Do not hand-edit legacy files unless you are recovering an old backup.
+
 ### Plugin configuration
 
 | Item | Default path |
@@ -67,9 +80,21 @@ When `CODEX_KEYCHAIN=1` is set, account pools can be stored in the OS credential
 
 | Item | Default path |
 |------|----------------|
-| TUI quota cache | OpenCode state path, with fallback `~/.opencode/oc-codex-multi-auth-tui-quota.json` |
+| TUI quota cache | `$OPENCODE_STATE_DIR` when set, otherwise OpenCode's state directory (typically `~/.local/state/opencode/`), file `oc-codex-multi-auth-tui-quota.json`, with a `~/.opencode/` fallback in some builds |
 
 Caches recent quota/usage snapshots for prompt status display.
+
+### Session recovery storage (host OpenCode)
+
+When `sessionRecovery` is enabled (default), recoverable session repairs read/write OpenCode's on-disk message/part store:
+
+| Item | Default path |
+|------|----------------|
+| OpenCode storage root | `$XDG_DATA_HOME/opencode/storage` (macOS/Linux default `~/.local/share/opencode/storage`; Windows `%APPDATA%/opencode/storage`) |
+| Messages | `…/message/{sessionID}/…` |
+| Parts | `…/part/{messageID}/*.json` |
+
+Only known structural recovery cases are patched (missing tool results, thinking-block order, thinking-disabled violations). Tokens are not written here.
 
 ### Catalog and instruction caches
 

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -39,6 +39,10 @@ All plugin state is stored **locally on your machine** unless you export it or o
 
 Contents typically include OAuth access/refresh material, account IDs, labels/tags/notes, rate-limit reset metadata, and rotation state. Per-project pools are enabled by default (`perProjectAccounts: true`).
 
+### Codex CLI hydrate (optional source)
+
+On startup the plugin may also read Codex CLI account material under `~/.codex` (for example `accounts.json`) to help bootstrap the local pool. Disable with `CODEX_AUTH_SYNC_CODEX_CLI=0`. This is local filesystem access only; nothing is uploaded to the package maintainers.
+
 ### Plugin configuration
 
 | Item | Default path |

--- a/docs/tools-and-cli.md
+++ b/docs/tools-and-cli.md
@@ -1,0 +1,172 @@
+# Tools and CLI
+
+Reference for the **24** OpenCode `codex-*` tools and the standalone `oc-codex-multi-auth` bin commands (package v6.9.1).
+
+Tools run inside OpenCode (agent/tool surface). Several diagnostics also run as a **direct CLI** with no agent loop and no model token cost.
+
+---
+
+## OpenCode tools (24)
+
+Registered from **24 per-file factories** under `lib/tools/` via `createToolRegistry` in `lib/tools/index.ts`.
+
+### Setup and guidance
+
+| Tool | Purpose |
+|------|---------|
+| `codex-setup` | Beginner checklist / optional wizard for first-run readiness |
+| `codex-help` | Topic-oriented help for plugin commands and workflows |
+| `codex-next` | Suggested next action when stuck |
+
+### Daily account use
+
+| Tool | Purpose |
+|------|---------|
+| `codex-list` | List saved accounts, active index, tags/labels |
+| `codex-switch` | Switch the active account (interactive picker when index omitted) |
+| `codex-warm` | Open every enabled account's usage window (one minimal request each) |
+| `codex-status` | Active account, model family, routing / pool mode |
+| `codex-limits` | Visible rate-limit / quota state |
+| `codex-reset` | Inspect or redeem banked rate-limit reset credit |
+| `codex-dashboard` | Interactive multi-account management surface |
+
+### Account metadata and routing
+
+| Tool | Purpose |
+|------|---------|
+| `codex-label` | Set a stable display label for an account |
+| `codex-tag` | Set or clear account tags for grouping/filtering |
+| `codex-note` | Attach a private note to an account |
+| `codex-pool` | Manage `modelAccountPools` (preferred accounts per model) |
+| `codex-remove` | Remove a saved account (confirm required) |
+| `codex-refresh` | Refresh tokens / re-auth guidance for an account |
+
+### Diagnostics and resilience
+
+| Tool | Purpose |
+|------|---------|
+| `codex-health` | Health summary across accounts |
+| `codex-metrics` | Runtime counters and request metrics |
+| `codex-doctor` | Beginner-friendly diagnostics with fix hints |
+| `codex-diag` | Redacted diagnostic snapshot export |
+| `codex-diff` | Diff account/config snapshots |
+
+### Backup and secrets
+
+| Tool | Purpose |
+|------|---------|
+| `codex-export` | Back up account storage |
+| `codex-import` | Restore accounts (supports dry-run) |
+| `codex-keychain` | Report credential backend; migrate/rollback OS keychain |
+
+### Common tool examples
+
+```text
+codex-list
+codex-switch index=2
+codex-warm
+codex-status
+codex-limits
+codex-reset
+codex-pool
+codex-pool action="set" model="gpt-5.6-sol" accounts=[7,8]
+codex-pool action="add" model="gpt-5.6-sol" accounts=[9]
+codex-pool action="remove" model="gpt-5.6-sol" accounts=[7]
+codex-pool action="clear" model="gpt-5.6-sol"
+codex-label index=2 label="plus-1"
+codex-tag index=2 tags="work,team-a"
+codex-note index=2 note="weekend only"
+codex-doctor
+codex-health
+codex-export
+codex-import dryRun=true
+codex-keychain
+```
+
+Many tools accept structured output (`format="json"`) and opt-in sensitive fields (`includeSensitive=true`). Prefer labels over emails; enable `maskEmail` in plugin config for shared screens.
+
+---
+
+## Standalone CLI
+
+Bin: `oc-codex-multi-auth` (also via `npx -y oc-codex-multi-auth@latest …`).
+
+### Commands
+
+| Command | Role |
+|---------|------|
+| `install` (default) | Install/update OpenCode config and TUI plugin entry |
+| `doctor` | Local account/config diagnostics |
+| `status` | Account/config status |
+| `list` | List configured accounts |
+| `limits` | Stored rate-limit state |
+| `dashboard` | Prints guidance (does not start a full dashboard server) |
+| `health` | Local token/account health summary |
+| `diag` | Alias for `doctor --deep` |
+| `warm` | Open every enabled account's usage window (same idea as `codex-warm`) |
+
+```bash
+oc-codex-multi-auth                 # install (default)
+oc-codex-multi-auth install
+oc-codex-multi-auth doctor
+oc-codex-multi-auth status
+oc-codex-multi-auth list
+oc-codex-multi-auth limits
+oc-codex-multi-auth dashboard
+oc-codex-multi-auth health
+oc-codex-multi-auth diag
+oc-codex-multi-auth warm
+```
+
+`warm` exits non-zero if any account failed. Disabled accounts are skipped.
+
+### Installer flags
+
+| Flag | Effect |
+|------|--------|
+| `--modern` | Force compact modern config (12 bases + variants) |
+| `--full` | Compact bases plus explicit selector entries |
+| `--legacy` | Explicit-only catalog (53 entries) |
+| `--dry-run` | Show actions without writing |
+| `--no-cache-clear` | Skip clearing OpenCode plugin cache |
+
+Choose only one of `--modern`, `--full`, or `--legacy`.
+
+### Standalone options
+
+| Flag | Effect |
+|------|--------|
+| `--json` | Machine-readable JSON output |
+| `--include-sensitive` | Include sensitive identity fields in JSON where applicable |
+| `--deep` | Deeper diagnostics (used with `doctor`; implied by `diag`) |
+| `--fix` | Request fix application where supported (may be a no-op for some safe CLI paths) |
+| `--tag <tag>` | Filter accounts by tag when listing |
+| `--config-path <path>` | Point at a specific accounts storage path |
+| `--help` / `-h` | Print usage |
+
+Examples:
+
+```bash
+oc-codex-multi-auth status --json
+oc-codex-multi-auth list --tag work
+oc-codex-multi-auth warm --json
+oc-codex-multi-auth doctor --deep
+npx -y oc-codex-multi-auth@latest warm
+```
+
+---
+
+## Related runtime concepts
+
+- **Rotation:** `rotationStrategy` = `hybrid` (default) | `sticky` | `round-robin` in `~/.opencode/openai-codex-auth-config.json` or `CODEX_AUTH_ROTATION_STRATEGY`.
+- **Model pools:** `modelAccountPools` + `codex-pool` prefer specific accounts per effective model ID, then fall back to the general pool.
+- **Per-project accounts:** default `true` under `~/.opencode/projects/<project-key>/`.
+- **Stateless Codex contract:** `store: false` and `reasoning.encrypted_content`.
+- **GPT-5.6:** responses-lite path; client identity defaults to host/opencode for 5.6.
+
+See also:
+
+- [architecture.md](architecture.md)
+- [getting-started.md](getting-started.md)
+- [configuration.md](configuration.md)
+- [faq.md](faq.md)

--- a/docs/tools-and-cli.md
+++ b/docs/tools-and-cli.md
@@ -85,6 +85,44 @@ codex-keychain
 
 Many tools accept structured output (`format="json"`) and opt-in sensitive fields (`includeSensitive=true`). Prefer labels over emails; enable `maskEmail` in plugin config for shared screens.
 
+### Tool arguments matrix
+
+Account indices are **1-based**. Destructive tools require an explicit confirm flag.
+
+| Tool | Args |
+|------|------|
+| `codex-setup` | `wizard?` (bool) — menu-driven setup when terminal supports it |
+| `codex-help` | `topic?` — `setup`, `switch`, `pools`, `health`, `backup`, `dashboard` |
+| `codex-next` | `format?` — `text` \| `json` |
+| `codex-list` | `tag?`, `format?`, `includeSensitive?` |
+| `codex-switch` | `index?` — omit for interactive picker when supported |
+| `codex-warm` | _(none)_ |
+| `codex-status` | `format?`, `includeSensitive?` |
+| `codex-limits` | `format?`, `includeSensitive?` |
+| `codex-reset` | `action?` (`status` \| `consume`), `creditId?`, `confirm?` (required true to redeem), `dryRun?`, `account?` (1-based), `format?`, `includeSensitive?` |
+| `codex-dashboard` | `format?`, `includeSensitive?` |
+| `codex-label` | `index?`, `label` (empty string clears) |
+| `codex-tag` | `index?`, `tags` (CSV; empty clears) |
+| `codex-note` | `index?`, `note` (empty clears) |
+| `codex-pool` | `action?` (`status` \| `set` \| `add` \| `remove` \| `clear`), `model?`, `accounts?` (1-based number array), `dryRun?`, `format?`, `includeSensitive?` |
+| `codex-remove` | `index?`, `confirm` (must be `true` to delete) |
+| `codex-refresh` | _(none)_ |
+| `codex-health` | `format?`, `includeSensitive?` |
+| `codex-metrics` | `format?` |
+| `codex-doctor` | `deep?`, `fix?` (safe automated fixes), `format?` |
+| `codex-diag` | _(none)_ — redacted snapshot only |
+| `codex-diff` | `left`, `right` (paths), `section?` (`accounts` \| `config` \| `both`) |
+| `codex-export` | `path?`, `force?`, `timestamped?` (default true when path omitted) |
+| `codex-import` | `path`, `dryRun?` |
+| `codex-keychain` | `command?` (`status` \| `migrate` \| `rollback`), `confirm?` (required for rollback when a live JSON file exists) |
+
+### Operational notes
+
+- **`codex-warm` / CLI `warm`:** one lightweight request per enabled account to open usage windows. CLI exits non-zero if any account fails; disabled accounts are skipped.
+- **`codex-reset`:** banked WHAM/rate-limit reset credits. `action="consume"` is irreversible and requires `confirm=true` (use `dryRun=true` to preview).
+- **`codex-pool`:** accepts 1-based numbers but persists **stable account IDs** in `~/.opencode/openai-codex-auth-config.json`. Restart OpenCode after mutations.
+- **Standalone default storage:** CLI commands read the **global** accounts file unless `--config-path` points at a project pool. In-session tools use the active per-project path when `perProjectAccounts` is true.
+
 ---
 
 ## Standalone CLI

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,6 +1,8 @@
 # Troubleshooting
 
-Common setup, authentication, model, and request-debugging issues for `oc-codex-multi-auth`.
+Common setup, authentication, model, and request-debugging issues for `oc-codex-multi-auth` (current package line, including the 24-tool surface and GPT-5.6 catalog).
+
+For install modes, the full tool list, and standalone CLI commands (`doctor`, `status`, `list`, `limits`, `health`, `diag`, `warm`), see [Tools and CLI](tools-and-cli.md) and [Getting Started](getting-started.md).
 
 ---
 
@@ -13,6 +15,14 @@ codex-setup
 codex-doctor
 codex-doctor --fix
 codex-next
+```
+
+Or without an agent loop (no model tokens):
+
+```bash
+oc-codex-multi-auth doctor
+oc-codex-multi-auth status --json
+oc-codex-multi-auth warm
 ```
 
 For machine-readable automation or CI checks, these read-only tools also accept `format="json"`:

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -2,7 +2,7 @@
 
 Common setup, authentication, model, and request-debugging issues for `oc-codex-multi-auth` (current package line, including the 24-tool surface and GPT-5.6 catalog).
 
-For install modes, the full tool list, and standalone CLI commands (`doctor`, `status`, `list`, `limits`, `health`, `diag`, `warm`), see [Tools and CLI](tools-and-cli.md) and [Getting Started](getting-started.md).
+For install modes, the full tool list (with args), and standalone CLI commands (`doctor`, `status`, `list`, `limits`, `health`, `diag`, `warm`), see [Tools and CLI](tools-and-cli.md) and [Getting Started](getting-started.md). For advanced env vars (`CODEX_THREAD_ID`, `OPENCODE_CODEX_PROMPT_URL`, etc.) see [Configuration](configuration.md#advanced--power-user-environment-variables).
 
 ---
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -94,7 +94,7 @@ Update your `~/.config/opencode/opencode.json`:
    ```
 3. **Remember: request logs only appear after the first OpenAI request**:
    ```bash
-   ENABLE_PLUGIN_REQUEST_LOGGING=1 opencode run "test" --model=openai/gpt-5.5-medium
+   ENABLE_PLUGIN_REQUEST_LOGGING=1 opencode run "test" --model=openai/gpt-5.5 --variant=medium
    ```
 4. **Check registry access**:
    ```bash
@@ -112,11 +112,11 @@ Update your `~/.config/opencode/opencode.json`:
 <summary><b>Slow first response / startup latency</b></summary>
 
 **What’s normal:**
-- The first request may fetch **Codex instructions** and/or the **OpenCode codex prompt** from GitHub.
-- Current releases use **stale-while-revalidate caching** and a **startup prewarm** to reduce first-turn latency.
+- The first request may fetch **Codex instructions** and/or the **OpenCode codex prompt** from GitHub (catalog + prompt caches under `~/.opencode/cache/`).
+- Default `requestTransformMode` is **`native`**. Startup prewarm of prompt caches only runs when legacy transform is enabled (`CODEX_AUTH_REQUEST_TRANSFORM_MODE=legacy` or config `requestTransformMode: "legacy"`) and is not disabled with `CODEX_AUTH_PREWARM=0`.
 
 **Tuning knobs:**
-1. Disable prewarm (if you prefer zero background fetches at startup):
+1. Disable prewarm when using legacy transform (if you prefer zero background fetches at startup):
    ```bash
    CODEX_AUTH_PREWARM=0 opencode
    ```
@@ -330,7 +330,13 @@ opencode run "test" --model=openai/gpt-5-codex-low  # Must match config key
 
 **Note:** `opencode models openai` currently shows only OpenCode's built-in provider catalog. If you add template-defined or custom models, use `opencode debug config` to confirm they were merged into the effective config.
 
-**GPT-5.5 note:** on tested OpenCode `1.14.22`, bare `openai/gpt-5.5` can still fail with `ProviderModelNotFoundError` even when the base template entry exists. Use explicit shipped IDs like `openai/gpt-5.5-medium` or `openai/gpt-5.5-high` for current live CLI tests.
+**Selector note:** the default compact install exposes base OAuth families. Prefer:
+
+```bash
+opencode run "test" --model=openai/gpt-5.5 --variant=medium
+```
+
+Use explicit IDs such as `openai/gpt-5.5-medium` only after installing with `--full` or `--legacy`. If a host build rejects the bare base entry even when `opencode debug config` shows it, reinstall with `--full` rather than assuming medium IDs exist on a compact install.
 
 </details>
 
@@ -687,7 +693,7 @@ DEBUG_CODEX_PLUGIN=1 ENABLE_PLUGIN_REQUEST_LOGGING=1 CODEX_PLUGIN_LOG_BODIES=1 o
 <summary><b>Inspect Actual API Requests</b></summary>
 
 ```bash
-ENABLE_PLUGIN_REQUEST_LOGGING=1 CODEX_PLUGIN_LOG_BODIES=1 opencode run "test" --model=openai/gpt-5.5-medium
+ENABLE_PLUGIN_REQUEST_LOGGING=1 CODEX_PLUGIN_LOG_BODIES=1 opencode run "test" --model=openai/gpt-5.5 --variant=medium
 
 cat ~/.opencode/logs/codex-plugin/request-*-after-transform.json | jq '{
   model: .body.model,

--- a/lib/tools/AGENTS.md
+++ b/lib/tools/AGENTS.md
@@ -16,6 +16,7 @@ lib/tools/
   index.ts                # ToolContext type + createToolRegistry(ctx) barrel
   codex-list.ts           # one file per tool
   codex-switch.ts
+  codex-warm.ts
   codex-status.ts
   codex-limits.ts
   codex-reset.ts

--- a/scripts/install-oc-codex-multi-auth-core.js
+++ b/scripts/install-oc-codex-multi-auth-core.js
@@ -89,13 +89,13 @@ function printHelp() {
 		"Default behavior:\n" +
 		"  - Installs/updates global config at ~/.config/opencode/opencode.json\n" +
 		"  - Enables the prompt status bar TUI plugin at ~/.config/opencode/tui.json\n" +
-		"  - Uses compact UI config by default (9 base OAuth models + variant picker presets)\n" +
+		"  - Uses compact UI config by default (12 base OAuth models + variant picker presets)\n" +
 		"  - Ensures plugin is unpinned (latest)\n" +
 		"  - Clears OpenCode plugin cache\n\n" +
 		"Options:\n" +
-		"  --modern           Force compact modern config (9 base OAuth models + --variant presets)\n" +
-		"  --full             Install compact base models plus 36 explicit selector entries\n" +
-		"  --legacy           Force explicit legacy config (36 preset model entries)\n" +
+		"  --modern           Force compact modern config (12 base OAuth models + --variant presets)\n" +
+		"  --full             Install compact base models plus 53 explicit selector entries\n" +
+		"  --legacy           Force explicit legacy config (53 preset model entries)\n" +
 		"  --dry-run          Show actions without writing\n" +
 		"  --no-cache-clear   Skip clearing OpenCode cache\n"
 	);
@@ -907,10 +907,10 @@ export async function runInstaller(argv = process.argv.slice(2), options = {}) {
 	log("\nDone. Restart OpenCode to (re)install the plugin.");
 	log("Example: opencode");
 	if (configMode === "modern") {
-		log("Note: Modern config intentionally shows 9 base OAuth model entries; use the variant picker for reasoning presets.");
+		log("Note: Modern config intentionally shows 12 base OAuth model entries; use the variant picker for reasoning presets.");
 	}
 	if (configMode === "legacy") {
-		log("Note: Legacy config writes 36 explicit preset entries and is also safe for older OpenCode versions.");
+		log("Note: Legacy config writes 53 explicit preset entries and is also safe for older OpenCode versions.");
 	}
 	if (configMode === "full") {
 		log("Note: Full config installs both compact base models and explicit preset entries for direct selector IDs.");

--- a/skills/oc-codex-setup/SKILL.md
+++ b/skills/oc-codex-setup/SKILL.md
@@ -7,35 +7,74 @@ description: Install or refresh oc-codex-multi-auth in OpenCode, choose the righ
 
 Use this skill when the user wants to install, reinstall, upgrade, or troubleshoot `oc-codex-multi-auth` in OpenCode.
 
-## Default install
+## Default install (compact modern)
 
 ```bash
 npx -y oc-codex-multi-auth@latest
 ```
 
-Use this when the user wants the full catalog config, including base entries like `gpt-5.5` and explicit preset entries like `gpt-5.5-medium`.
+This is the default. It installs the compact modern catalog: 12 base OAuth model families with OpenCode variant presets (53 total variants). The TUI model picker shows bases such as `gpt-5.5` and `gpt-5.6-sol`; reasoning depth is selected with `--variant`.
 
-## Modern compact install
+## Full install (explicit selector IDs)
 
 ```bash
-npx -y oc-codex-multi-auth@latest --modern
+npx -y oc-codex-multi-auth@latest --full
 ```
 
-Use this on OpenCode `v1.0.210+` when the user wants the compact variant-based config.
+Use this when the user needs direct selector IDs such as `openai/gpt-5.5-medium` or `openai/gpt-5.6-sol-high` in addition to the compact bases.
+
+## Legacy install (older OpenCode)
+
+```bash
+npx -y oc-codex-multi-auth@latest --legacy
+```
+
+Use this on older OpenCode versions that do not support variant-based model entries. Installs 53 explicit model IDs only.
+
+## Other installer flags
+
+- `--dry-run` — show planned actions without writing files
+- `--no-cache-clear` — skip clearing the OpenCode plugin cache
+- `--modern` — same compact modern catalog as the default
+
+## Standalone CLI (no agent cost)
+
+```bash
+oc-codex-multi-auth status
+oc-codex-multi-auth list
+oc-codex-multi-auth warm
+oc-codex-multi-auth doctor
+```
+
+Also available: `limits`, `dashboard`, `health`, `diag`.
 
 ## Login and verification
 
 1. Run `opencode auth login`.
-2. Run a quick verification request:
+2. Run a quick verification request with **compact modern** selectors (default install):
 
 ```bash
-opencode run "Explain this repository" --model=openai/gpt-5.5-medium
+opencode run "Explain this repository" --model=openai/gpt-5.5 --variant=medium
 ```
 
-3. For a Codex-focused workflow, try:
+Do **not** use `openai/gpt-5.5-medium` unless the user installed with `--full` or `--legacy`.
+
+3. Optional GPT-5.6 smoke:
+
+```bash
+opencode run "Explain this repository" --model=openai/gpt-5.6-sol --variant=medium
+```
+
+4. For a Codex-focused workflow, try:
 
 ```bash
 opencode run "Refactor the retry logic and update the tests" --model=openai/gpt-5-codex --variant=high
+```
+
+5. After `--full`, explicit IDs are valid:
+
+```bash
+opencode run "Explain this repository" --model=openai/gpt-5.5-medium
 ```
 
 ## Troubleshooting

--- a/test/doc-parity.test.ts
+++ b/test/doc-parity.test.ts
@@ -241,6 +241,18 @@ describe("runtime documentation parity", () => {
 		}
 	});
 
+	it("keeps installer help catalog counts aligned with shipped templates", () => {
+		const installerHelp = readRepoFile("scripts/install-oc-codex-multi-auth-core.js");
+		expect(installerHelp).toContain("12 base OAuth models");
+		expect(installerHelp).toContain("53 explicit selector entries");
+		expect(installerHelp).toContain("53 preset model entries");
+		expect(installerHelp).toContain("12 base OAuth model entries");
+		expect(installerHelp).toContain("53 explicit preset entries");
+		expect(installerHelp).not.toContain("9 base OAuth models");
+		expect(installerHelp).not.toContain("36 explicit selector entries");
+		expect(installerHelp).not.toContain("36 preset model entries");
+	});
+
 	it("keeps the documented tool layout aligned with the live registry", () => {
 		const toolFiles = readdirSync(path.resolve(testDir, "..", "lib/tools"))
 			.filter((name) => /^codex-[a-z-]+\.ts$/.test(name))


### PR DESCRIPTION
## Summary

Rewrites user-facing and maintainer documentation so it matches the current `oc-codex-multi-auth` **v6.9.1** code architecture.

### What changed
- **24 tools** (was inconsistently documented as 21) across README, architecture, and tool registry docs
- **Model catalog**: 12 modern base families / 53 variants (including GPT-5.6 sol/terra/luna); legacy 53 explicit entries
- Installer modes: default compact modern, `--full`, `--legacy`, plus standalone CLI (`doctor`, `status`, `list`, `limits`, `dashboard`, `health`, `diag`, `warm`)
- Config/runtime: `rotationStrategy`, `modelAccountPools`, parallel probing, empty-response retries, responses-lite + client identity notes
- **New** `docs/tools-and-cli.md` for the full tool + CLI surface
- Privacy: correct Codex API path, local data inventory, and request identity headers
- Skill + AGENTS.md aligned with compact-default install and current paths
- Audit corpus left **historical** (not rewritten as live product contract)

### Verification
- `npx vitest run test/doc-parity.test.ts` — 12/12 passed

## Test plan
- [x] Doc parity suite passes
- [ ] Spot-check install/auth links from README → getting-started → tools-and-cli
- [ ] Confirm config template counts still match `config/opencode-modern.json` / legacy

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---


<h3>Greptile Summary</h3>

doc rewrite aligning all user-facing and maintainer docs with the v6.9.1 codebase: 24 tools (up from inconsistently documented 21), 12 base model families / 53 variants (up from 9/36), and a new compact-default install convention with `--full` and `--legacy` as opt-ins.

- **new `docs/tools-and-cli.md`** adds the authoritative full-surface reference covering all 24 `codex-*` tools with arg matrices and all standalone bin commands; now linked from readme, architecture, getting-started, faq, skill, and agents.
- **model catalog and install modes** updated consistently across readme, architecture, getting-started, faq, configuration, skill, and the installer script, including gpt-5.6 sol/terra/luna, responses-lite path notes, and `rotationStrategy` documentation.
- **`docs/troubleshooting.md`** fixes two stale `--model=openai/gpt-5.5-medium` usages to the correct `--model=openai/gpt-5.5 --variant=medium` compact-modern form, resolving the previously flagged parity issue.

<h3>Confidence Score: 4/5</h3>

safe to merge; the one gap is that the new tools-and-cli.md file is not pinned in the doc-parity layout test, so a future accidental deletion would go undetected despite six cross-links pointing at it

the doc rewrite is thorough and internally consistent — model counts, installer flags, model selector forms, and the tool count all agree across every changed file and the updated tests. the missing requiredDocs entry for the new file is the only real gap: it leaves a heavily-linked doc unguarded by the parity suite

test/doc-parity.test.ts — add docs/tools-and-cli.md to the requiredDocs array before merging

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| docs/tools-and-cli.md | new file: complete reference for all 24 codex-* tools and the standalone bin; matches lib/tools/ file count and installer flags accurately |
| test/doc-parity.test.ts | adds installer count assertions (12 bases / 53 entries); does not add docs/tools-and-cli.md to requiredDocs, leaving the new cross-linked file unguarded against accidental deletion |
| docs/troubleshooting.md | fixes two stale --model=openai/gpt-5.5-medium usages to --model=openai/gpt-5.5 --variant=medium; adds standalone CLI block; prewarm docs corrected for native-vs-legacy mode |
| skills/oc-codex-setup/SKILL.md | restructured around compact-default install; do-not-use gpt-5.5-medium warning added; full/legacy install sections are clear and accurate |
| scripts/install-oc-codex-multi-auth-core.js | model counts updated from 9 to 12 bases and 36 to 53 entries in help text and log messages; consistent with test assertions and shipped templates |
| docs/architecture.md | well-updated for v6.9.1; adds rotation strategy table, responses-lite section, and install mode table; codex-diff still absent from common groups and codex-dashboard listed twice (pre-existing) |
| docs/privacy.md | expanded with correct codex API endpoint, OS keychain section, and local data inventory; unix paths throughout with no windows path guidance added |
| AGENTS.md | version bump to 6.9.1, 24-tool count, GPT-5.6 and responses-lite entries, standalone CLI commands, and bool-env-truthy note all accurate |


<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[npx oc-codex-multi-auth@latest] --> B{install mode}
    B -->|default or --modern| C[compact modern\n12 bases + 53 variants]
    B -->|--full| D[bases + 53 explicit IDs]
    B -->|--legacy| E[explicit-only 53 entries]
    C --> F[opencode auth login]
    D --> F
    E --> F
    F --> G{OAuth method}
    G -->|browser| H[ChatGPT OAuth]
    G -->|device code| H
    G -->|manual paste| H
    H --> I[OpenCode + plugin loaded]
    I --> J{model family}
    J -->|gpt-5.6-sol/terra/luna| K[responses-lite reshape\nidentity: opencode]
    J -->|pre-5.6| L[native or legacy transform\nidentity: codex_cli_rs]
    K --> M[chatgpt.com/backend-api/codex/responses]
    L --> M
    I --> N[24 codex tools + standalone CLI]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[npx oc-codex-multi-auth@latest] --> B{install mode}
    B -->|default or --modern| C[compact modern\n12 bases + 53 variants]
    B -->|--full| D[bases + 53 explicit IDs]
    B -->|--legacy| E[explicit-only 53 entries]
    C --> F[opencode auth login]
    D --> F
    E --> F
    F --> G{OAuth method}
    G -->|browser| H[ChatGPT OAuth]
    G -->|device code| H
    G -->|manual paste| H
    H --> I[OpenCode + plugin loaded]
    I --> J{model family}
    J -->|gpt-5.6-sol/terra/luna| K[responses-lite reshape\nidentity: opencode]
    J -->|pre-5.6| L[native or legacy transform\nidentity: codex_cli_rs]
    K --> M[chatgpt.com/backend-api/codex/responses]
    L --> M
    I --> N[24 codex tools + standalone CLI]
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `docs/troubleshooting.md`, line 97 ([link](https://github.com/ndycode/oc-codex-multi-auth/blob/ef93e68584476169ce1158a451022f803d1b7c5a/docs/troubleshooting.md#L97)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **stale explicit model selector contradicts the new compact-default convention**

   this line (and again at line 690 in the "inspect actual api requests" block) still tells users to pass `--model=openai/gpt-5.5-medium`, which only works after `--full` or `--legacy`. every other doc updated in this PR — including `skills/oc-codex-setup/SKILL.md` which explicitly says _"do not use `openai/gpt-5.5-medium` unless the user installed with `--full` or `--legacy`"_ — uses the compact selector form. a user following the troubleshooting guide on a default install will hit `Model 'openai/gpt-5.5-medium' not found`, which is exactly the failure the next section tries to diagnose. swap both occurrences to `--model=openai/gpt-5.5 --variant=medium`.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: docs/troubleshooting.md
   Line: 97

   Comment:
   **stale explicit model selector contradicts the new compact-default convention**

   this line (and again at line 690 in the "inspect actual api requests" block) still tells users to pass `--model=openai/gpt-5.5-medium`, which only works after `--full` or `--legacy`. every other doc updated in this PR — including `skills/oc-codex-setup/SKILL.md` which explicitly says _"do not use `openai/gpt-5.5-medium` unless the user installed with `--full` or `--legacy`"_ — uses the compact selector form. a user following the troubleshooting guide on a default install will hit `Model 'openai/gpt-5.5-medium' not found`, which is exactly the failure the next section tries to diagnose. swap both occurrences to `--model=openai/gpt-5.5 --variant=medium`.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Foc-codex-multi-auth%22%20on%20the%20existing%20branch%20%22docs%2Frewrite-v6.9.1-architecture%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22docs%2Frewrite-v6.9.1-architecture%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20docs%2Ftroubleshooting.md%0ALine%3A%2097%0A%0AComment%3A%0A**stale%20explicit%20model%20selector%20contradicts%20the%20new%20compact-default%20convention**%0A%0Athis%20line%20%28and%20again%20at%20line%20690%20in%20the%20%22inspect%20actual%20api%20requests%22%20block%29%20still%20tells%20users%20to%20pass%20%60--model%3Dopenai%2Fgpt-5.5-medium%60%2C%20which%20only%20works%20after%20%60--full%60%20or%20%60--legacy%60.%20every%20other%20doc%20updated%20in%20this%20PR%20%E2%80%94%20including%20%60skills%2Foc-codex-setup%2FSKILL.md%60%20which%20explicitly%20says%20_%22do%20not%20use%20%60openai%2Fgpt-5.5-medium%60%20unless%20the%20user%20installed%20with%20%60--full%60%20or%20%60--legacy%60%22_%20%E2%80%94%20uses%20the%20compact%20selector%20form.%20a%20user%20following%20the%20troubleshooting%20guide%20on%20a%20default%20install%20will%20hit%20%60Model%20'openai%2Fgpt-5.5-medium'%20not%20found%60%2C%20which%20is%20exactly%20the%20failure%20the%20next%20section%20tries%20to%20diagnose.%20swap%20both%20occurrences%20to%20%60--model%3Dopenai%2Fgpt-5.5%20--variant%3Dmedium%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=ndycode%2Foc-codex-multi-auth&pr=202&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["docs: document remaining advanced surfac..."](https://github.com/ndycode/oc-codex-multi-auth/commit/6e9b6bb9923bbddf7505183a2936536722f76632) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45229674)</sub>

<!-- /greptile_comment -->