### PR TITLE
feat(config): add accountToasts opt-out for the account-selection toast (#203)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -187,6 +187,7 @@ advanced settings go in `~/.opencode/openai-codex-auth-config.json`:
   "perProjectAccounts": true,
   "autoUpdate": true,
   "toastDurationMs": 5000,
+  "accountToasts": true,
   "retryAllAccountsRateLimited": true,
   "retryAllAccountsMaxWaitMs": 0,
   "retryAllAccountsMaxRetries": 3,
@@ -235,6 +236,7 @@ The sample above intentionally sets `"retryAllAccountsMaxRetries": 3` as a bound
 | `perProjectAccounts` | `true` | each project gets its own account storage |
 | `autoUpdate` | `true` | check npm daily and clear the OpenCode-managed plugin cache on exit when a newer version is available; restart OpenCode to install it |
 | `toastDurationMs` | `5000` | how long toast notifications stay visible (ms) |
+| `accountToasts` | `true` | show the transient `Using <account> (N/N)` account-selection toast; set `false` to hide only this informational toast (rate-limit/auth/recovery warnings and errors still show) |
 | `retryAllAccountsRateLimited` | `true` | wait and retry when all accounts hit rate limits |
 | `retryAllAccountsMaxWaitMs` | `0` | max wait time in ms (0 = unlimited) |
 | `retryAllAccountsMaxRetries` | `Infinity` | max retry attempts (omit this key for unlimited retries) |
@@ -353,6 +355,7 @@ override any config with env vars (boolean values are truthy only for `"1"`):
 | `CODEX_AUTH_PID_OFFSET_ENABLED=1` | enable PID-based hybrid score offset |
 | `CODEX_AUTH_AUTO_UPDATE=0` | disable automatic OpenCode plugin cache refresh when npm has a newer plugin version |
 | `CODEX_AUTH_TOAST_DURATION_MS=8000` | set toast duration |
+| `CODEX_AUTH_ACCOUNT_TOASTS=0` | hide the `Using <account> (N/N)` account-selection toast (warnings and errors still show) |
 | `CODEX_AUTH_RETRY_ALL_RATE_LIMITED=0` | disable wait-and-retry |
 | `CODEX_AUTH_RETRY_ALL_MAX_WAIT_MS=30000` | set max wait time |
 | `CODEX_AUTH_RETRY_ALL_MAX_RETRIES=1` | set max retries |

--- a/index.ts
+++ b/index.ts
@@ -72,6 +72,7 @@ import {
 	getAutoResume,
 	getAutoUpdate,
 	getToastDurationMs,
+	getAccountToastsEnabled,
 	getPerProjectAccounts,
 	getEmptyResponseMaxRetries,
 	getEmptyResponseRetryDelayMs,
@@ -1645,6 +1646,7 @@ export const OpenAIOAuthPlugin: Plugin = async ({ client }: PluginInput) => {
 				const unsupportedCodexFallbackChain =
 					getUnsupportedCodexFallbackChain(pluginConfig);
 				const toastDurationMs = getToastDurationMs(pluginConfig);
+				const accountToastsEnabled = getAccountToastsEnabled(pluginConfig);
 				const fetchTimeoutMs = getFetchTimeoutMs(pluginConfig);
 				const streamStallTimeoutMs = getStreamStallTimeoutMs(pluginConfig);
 
@@ -2148,6 +2150,7 @@ export const OpenAIOAuthPlugin: Plugin = async ({ client }: PluginInput) => {
 											accountManager.saveToDiskDebounced();
 
 											if (
+												accountToastsEnabled &&
 												accountCount > 1 &&
 												accountManager.shouldShowAccountToast(
 													account.index,

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -70,6 +70,7 @@ const DEFAULT_CONFIG: PluginConfig = {
 	tokenRefreshSkewMs: 60_000,
 	rateLimitToastDebounceMs: 60_000,
 	toastDurationMs: 5_000,
+	accountToasts: true,
 	perProjectAccounts: true,
 	sessionRecovery: true,
 	autoResume: true,
@@ -738,6 +739,19 @@ export function getToastDurationMs(pluginConfig: PluginConfig): number {
 		pluginConfig.toastDurationMs,
 		5_000,
 		{ min: 1_000 },
+	);
+}
+
+/**
+ * Gates only the informational "Using <account> (N/N)" account-selection toast.
+ * Warning/error toasts (rate limits, expired auth, recovery, retries) are never
+ * affected by this setting.
+ */
+export function getAccountToastsEnabled(pluginConfig: PluginConfig): boolean {
+	return resolveBooleanSetting(
+		"CODEX_AUTH_ACCOUNT_TOASTS",
+		pluginConfig.accountToasts,
+		true,
 	);
 }
 

--- a/lib/schemas.ts
+++ b/lib/schemas.ts
@@ -49,6 +49,7 @@ export const PluginConfigSchema = z.object({
 	tokenRefreshSkewMs: z.number().min(0).optional(),
 	rateLimitToastDebounceMs: z.number().min(0).optional(),
 	toastDurationMs: z.number().min(1000).optional(),
+	accountToasts: z.boolean().optional(),
 	perProjectAccounts: z.boolean().optional(),
 	sessionRecovery: z.boolean().optional(),
 	autoResume: z.boolean().optional(),

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -128,7 +128,7 @@ vi.mock("../lib/config.js", () => ({
 	getAutoResume: () => false,
 	getAutoUpdate: () => true,
 	getToastDurationMs: () => 5000,
-	getAccountToastsEnabled: () => true,
+	getAccountToastsEnabled: vi.fn(() => true),
 	getPerProjectAccounts: () => false,
 	getEmptyResponseMaxRetries: () => 2,
 	getEmptyResponseRetryDelayMs: () => 1000,
@@ -3006,6 +3006,117 @@ describe("OpenAIOAuthPlugin fetch handler", () => {
 		});
 
 		expect(response.status).toBe(200);
+	});
+
+	// issue #203: gate the informational "Using <account> (N/N)" toast behind
+	// the accountToasts opt-out, without affecting warning/error toasts. These
+	// tests drive a real request through the selection path and OBSERVE whether
+	// the toast reaches client.tui.showToast.
+	describe("issue #203: account-selection toast opt-out", () => {
+		const buildMultiAccountManager = () => {
+			const account = {
+				index: 0,
+				accountId: "acc-1",
+				email: "user@example.com",
+				refreshToken: "refresh-1",
+			};
+			return {
+				getAccountCount: () => 2,
+				getCurrentOrNextForFamilyHybrid: () => account,
+				getAccountForStrategy: () => account,
+				getSelectionExplainability: () => [
+					{
+						index: 0,
+						enabled: true,
+						isCurrentForFamily: true,
+						eligible: true,
+						reasons: ["eligible"],
+						healthScore: 100,
+						tokensAvailable: 50,
+						lastUsed: 1,
+					},
+				],
+				toAuthDetails: () => ({
+					type: "oauth" as const,
+					access: "access-1",
+					refresh: account.refreshToken,
+					expires: 2,
+				}),
+				hasRefreshToken: () => true,
+				saveToDiskDebounced: vi.fn(),
+				updateFromAuth: vi.fn(),
+				clearAuthFailures: vi.fn(),
+				incrementAuthFailures: vi.fn(() => 1),
+				markAccountCoolingDown: vi.fn(),
+				markRateLimitedWithReason: vi.fn(),
+				recordRateLimit: vi.fn(),
+				consumeToken: vi.fn(() => true),
+				refundToken: vi.fn(),
+				markSwitched: vi.fn(),
+				removeAccount: vi.fn(() => false),
+				removeAccountsWithSameRefreshToken: vi.fn(() => 0),
+				recordFailure: vi.fn(),
+				recordSuccess: vi.fn(),
+				getMinWaitTimeForFamily: vi.fn(() => 0),
+				shouldShowAccountToast: vi.fn(() => true),
+				markToastShown: vi.fn(),
+				setActiveIndex: vi.fn(() => account),
+				getAccountsSnapshot: vi.fn(() => [account]),
+			};
+		};
+
+		const usingToastCalls = (client: ReturnType<typeof createMockClient>) =>
+			client.tui.showToast.mock.calls.filter((call) => {
+				const message = (call[0] as { body?: { message?: string } })?.body?.message;
+				return typeof message === "string" && /^Using .+ \(\d+\/\d+\)$/.test(message);
+			});
+
+		it("shows the account-selection toast when accountToasts is enabled", async () => {
+			const configModule = await import("../lib/config.js");
+			vi.mocked(configModule.getAccountToastsEnabled).mockReturnValue(true);
+
+			const { AccountManager } = await import("../lib/accounts.js");
+			const manager = buildMultiAccountManager();
+			vi.spyOn(AccountManager, "loadFromDisk").mockResolvedValueOnce(manager as never);
+			globalThis.fetch = vi
+				.fn()
+				.mockResolvedValue(new Response(JSON.stringify({ content: "ok" }), { status: 200 }));
+
+			const { sdk, mockClient } = await setupPlugin();
+			const response = await sdk.fetch!("https://api.openai.com/v1/chat", {
+				method: "POST",
+				body: JSON.stringify({ model: "gpt-5.1" }),
+			});
+
+			expect(response.status).toBe(200);
+			expect(usingToastCalls(mockClient)).toHaveLength(1);
+			expect(manager.markToastShown).toHaveBeenCalledTimes(1);
+		});
+
+		it("suppresses ONLY the selection toast when accountToasts is disabled", async () => {
+			const configModule = await import("../lib/config.js");
+			vi.mocked(configModule.getAccountToastsEnabled).mockReturnValue(false);
+
+			const { AccountManager } = await import("../lib/accounts.js");
+			const manager = buildMultiAccountManager();
+			vi.spyOn(AccountManager, "loadFromDisk").mockResolvedValueOnce(manager as never);
+			globalThis.fetch = vi
+				.fn()
+				.mockResolvedValue(new Response(JSON.stringify({ content: "ok" }), { status: 200 }));
+
+			const { sdk, mockClient } = await setupPlugin();
+			const response = await sdk.fetch!("https://api.openai.com/v1/chat", {
+				method: "POST",
+				body: JSON.stringify({ model: "gpt-5.1" }),
+			});
+
+			// Request still succeeds; the toast is the only thing suppressed.
+			expect(response.status).toBe(200);
+			expect(usingToastCalls(mockClient)).toHaveLength(0);
+			// The info toast is skipped, so its debounce marker is never consumed —
+			// which keeps warning toasts fully eligible rather than suppressing them.
+			expect(manager.markToastShown).not.toHaveBeenCalled();
+		});
 	});
 
 	it.each([

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -128,6 +128,7 @@ vi.mock("../lib/config.js", () => ({
 	getAutoResume: () => false,
 	getAutoUpdate: () => true,
 	getToastDurationMs: () => 5000,
+	getAccountToastsEnabled: () => true,
 	getPerProjectAccounts: () => false,
 	getEmptyResponseMaxRetries: () => 2,
 	getEmptyResponseRetryDelayMs: () => 1000,

--- a/test/plugin-config.test.ts
+++ b/test/plugin-config.test.ts
@@ -23,6 +23,7 @@ import {
 	getFetchTimeoutMs,
 	getStreamStallTimeoutMs,
 	getAutoUpdate,
+	getAccountToastsEnabled,
 } from '../lib/config.js';
 import type { PluginConfig } from '../lib/types.js';
 import * as fs from 'node:fs';
@@ -69,6 +70,7 @@ describe('Plugin Configuration', () => {
 		'CODEX_AUTH_FALLBACK_UNSUPPORTED_MODEL',
 		'CODEX_AUTH_FALLBACK_GPT53_TO_GPT52',
 		'CODEX_AUTH_AUTO_UPDATE',
+		'CODEX_AUTH_ACCOUNT_TOASTS',
 	] as const;
 	const originalEnv: Partial<Record<(typeof envKeys)[number], string | undefined>> = {};
 
@@ -121,6 +123,7 @@ describe('Plugin Configuration', () => {
 				tokenRefreshSkewMs: 60_000,
 				rateLimitToastDebounceMs: 60_000,
 				toastDurationMs: 5_000,
+				accountToasts: true,
 				perProjectAccounts: true,
 				sessionRecovery: true,
 				autoResume: true,
@@ -169,6 +172,7 @@ describe('Plugin Configuration', () => {
 				tokenRefreshSkewMs: 60_000,
 				rateLimitToastDebounceMs: 60_000,
 				toastDurationMs: 5_000,
+				accountToasts: true,
 				perProjectAccounts: true,
 				sessionRecovery: true,
 				autoResume: true,
@@ -214,6 +218,7 @@ describe('Plugin Configuration', () => {
 				tokenRefreshSkewMs: 60_000,
 				rateLimitToastDebounceMs: 60_000,
 				toastDurationMs: 5_000,
+				accountToasts: true,
 				perProjectAccounts: true,
 				sessionRecovery: true,
 				autoResume: true,
@@ -270,6 +275,7 @@ describe('Plugin Configuration', () => {
 		tokenRefreshSkewMs: 60_000,
 		rateLimitToastDebounceMs: 60_000,
 		toastDurationMs: 5_000,
+		accountToasts: true,
 		perProjectAccounts: true,
 		sessionRecovery: true,
 		autoResume: true,
@@ -320,6 +326,7 @@ describe('Plugin Configuration', () => {
 			tokenRefreshSkewMs: 60_000,
 			rateLimitToastDebounceMs: 60_000,
 			toastDurationMs: 5_000,
+			accountToasts: true,
 			perProjectAccounts: true,
 			sessionRecovery: true,
 			autoResume: true,
@@ -536,6 +543,25 @@ describe('Plugin Configuration', () => {
 			expect(getAutoUpdate({ autoUpdate: true })).toBe(false);
 			process.env.CODEX_AUTH_AUTO_UPDATE = '1';
 			expect(getAutoUpdate({ autoUpdate: false })).toBe(true);
+		});
+	});
+
+	describe('getAccountToastsEnabled', () => {
+		it('should default to true', () => {
+			delete process.env.CODEX_AUTH_ACCOUNT_TOASTS;
+			expect(getAccountToastsEnabled({})).toBe(true);
+		});
+
+		it('should use config value when env var not set', () => {
+			delete process.env.CODEX_AUTH_ACCOUNT_TOASTS;
+			expect(getAccountToastsEnabled({ accountToasts: false })).toBe(false);
+		});
+
+		it('should prioritize env var over config', () => {
+			process.env.CODEX_AUTH_ACCOUNT_TOASTS = '0';
+			expect(getAccountToastsEnabled({ accountToasts: true })).toBe(false);
+			process.env.CODEX_AUTH_ACCOUNT_TOASTS = '1';
+			expect(getAccountToastsEnabled({ accountToasts: false })).toBe(true);
 		});
 	});
 

--- a/test/schemas.test.ts
+++ b/test/schemas.test.ts
@@ -48,6 +48,7 @@ describe("PluginConfigSchema", () => {
 			tokenRefreshSkewMs: 60000,
 			rateLimitToastDebounceMs: 30000,
 			toastDurationMs: 5000,
+			accountToasts: true,
 			perProjectAccounts: true,
 			sessionRecovery: true,
 			autoResume: false,


### PR DESCRIPTION
## What & why

Closes #203. During account rotation the main auth plugin shows a floating `Using <account> (N/N)` toast (severity `info`). Because OpenCode renders it over the output rather than reserving layout space, it overlays several lines of a paused diff and makes them unreadable — especially on narrow terminals. There was no way to turn it off: `CODEX_AUTH_TOAST_DURATION_MS` has a 1000 ms floor, the debounce only suppresses repeats, and removing the TUI quota plugin doesn't help because this toast comes from the *main* auth plugin.

This adds a durable opt-out that gates **only** that informational toast.

## Changes

- **New setting `accountToasts`** (default `true`) with env override **`CODEX_AUTH_ACCOUNT_TOASTS`** (`=0` to disable), resolved via the existing `resolveBooleanSetting` env-over-config pattern — same shape as `getAutoUpdate` / `getCodexTuiMaskEmail`.
  - `lib/schemas.ts`: `accountToasts: z.boolean().optional()` on `PluginConfigSchema` (the `PluginConfig` type is `z.infer` of the schema, so it propagates automatically).
  - `lib/config.ts`: `accountToasts: true` in `DEFAULT_CONFIG` + new `getAccountToastsEnabled()` getter (JSDoc notes it only affects the info toast).
  - `index.ts`: resolve `accountToastsEnabled` once per request (next to `toastDurationMs`) and prepend it to the guard around the single `"info"` `Using ${accountLabel} (N/N)` toast.
- **Warnings/errors stay visible.** The three `"warning"` toasts that also call `shouldShowAccountToast` — rate-limited retry, "Rate limited. Switching accounts", and "sign-in expired" — are intentionally left untouched, per the issue.
- **Docs** (`docs/configuration.md`): config-table row, env-var row, and JSON example.
- **Tests**: `getAccountToastsEnabled` unit tests (default / config / env-over-config), config mock in `test/index.test.ts`, and the exhaustive `loadPluginConfig()` + schema config-shape assertions.

## Upgrade persistence

No installer change is required. These settings live in the user's `~/.opencode/openai-codex-auth-config.json`, which the installer never rewrites — so `accountToasts: false` (or the env var) already survives plugin upgrades.

## Notes

- Env parsing follows the repo-wide convention: `=0` disables, `=1` enables (same as every other boolean env var). Default is `true`, so behavior is unchanged unless a user opts out.
- No CHANGELOG entry here — per this repo's convention the `## Added` entry is written as part of the `chore(release)` cut, not on feature branches.

## Verification

- `npm run typecheck` — clean
- `npm run lint` — 0 errors
- `npx vitest run` — **2809 passed, 1 skipped** (113 files)
- `npm run build` — exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SasnUwEzkz4L6eDMRWcZst

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an `accountToasts` configuration option (default `true`) to control the informational per-account “Using … (N/N)” toast.
  * Added support for `CODEX_AUTH_ACCOUNT_TOASTS` to hide only these informational toasts while still showing warnings/errors.
* **Documentation**
  * Updated configuration docs and examples to include `accountToasts` and `CODEX_AUTH_ACCOUNT_TOASTS`.
* **Tests**
  * Added regression coverage to verify the toast is shown/suppressed based on config/env, and that the flow still succeeds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

adds `accountToasts` / `CODEX_AUTH_ACCOUNT_TOASTS` as a durable opt-out that suppresses only the informational "Using <account> (N/N)" toast emitted by the main auth plugin during account rotation, leaving all warning and error toasts untouched.

- `lib/schemas.ts` + `lib/config.ts`: schema field, `DEFAULT_CONFIG` entry, and `getAccountToastsEnabled()` getter following the `resolveBooleanSetting` env-over-config pattern exactly as other boolean settings.
- `index.ts`: `accountToastsEnabled &&` short-circuits the single `"info"` toast guard; warning-path toasts and `markToastShown` side-effects are deliberately left outside that guard.
- tests: unit tests in `plugin-config.test.ts` cover default / config / env-over-config, and two new integration tests in `index.test.ts` exercise both the enabled and disabled paths end-to-end through a live request.

<h3>Confidence Score: 5/5</h3>

safe to merge — the change is additive, default-true, and touches only the info toast path; no token handling, file I/O, or shared state is modified

the guard is a single boolean short-circuit prepended to an existing condition, resolved fresh on each request with no side-effects when false; warning and error toasts are structurally outside the new condition and cannot be accidentally suppressed; unit and integration tests cover both branches end-to-end

no files require special attention

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| index.ts | resolves accountToastsEnabled once per request and prepends it to the info-toast guard; warning toasts are correctly left outside the new condition |
| lib/config.ts | adds getAccountToastsEnabled() via resolveBooleanSetting, default true — consistent with every other boolean getter in this file |
| lib/schemas.ts | adds accountToasts: z.boolean().optional() to PluginConfigSchema, consistent with the existing optional-boolean pattern |
| test/index.test.ts | mock updated to vi.fn(() => true) so per-test mockReturnValue works; two new integration tests cover enabled and disabled paths end-to-end, addressing the previous review thread |
| test/plugin-config.test.ts | three unit tests added for getAccountToastsEnabled covering default, config-only, and env-over-config cases; DEFAULT_CONFIG snapshot updated in all affected fixture assertions |
| test/schemas.test.ts | accountToasts: true added to the full-config fixture in the schema round-trip test |
| docs/configuration.md | docs updated with config-table row, env-var table row, and JSON example — accurate and consistent with the implementation |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant R as Request
    participant P as Plugin (index.ts)
    participant C as config.ts
    participant AM as AccountManager
    participant TUI as client.tui

    R->>P: sdk.fetch()
    P->>C: getAccountToastsEnabled(pluginConfig)
    C-->>P: accountToastsEnabled (bool)
    P->>AM: shouldShowAccountToast(index, debounceMs)
    AM-->>P: true/false

    alt "accountToastsEnabled and accountCount > 1 and shouldShow"
        P->>TUI: showToast("Using account (N/N)", "info")
        P->>AM: markToastShown(index)
    else "accountToastsEnabled=false or single account or debounced"
        Note over P: info toast suppressed
    end

    Note over P,TUI: warning and error toasts always reach TUI
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant R as Request
    participant P as Plugin (index.ts)
    participant C as config.ts
    participant AM as AccountManager
    participant TUI as client.tui

    R->>P: sdk.fetch()
    P->>C: getAccountToastsEnabled(pluginConfig)
    C-->>P: accountToastsEnabled (bool)
    P->>AM: shouldShowAccountToast(index, debounceMs)
    AM-->>P: true/false

    alt "accountToastsEnabled and accountCount > 1 and shouldShow"
        P->>TUI: showToast("Using account (N/N)", "info")
        P->>AM: markToastShown(index)
    else "accountToastsEnabled=false or single account or debounced"
        Note over P: info toast suppressed
    end

    Note over P,TUI: warning and error toasts always reach TUI
```

</a>

<sub>Reviews (3): Last reviewed commit: ["test(index): prove accountToasts gate su..."](https://github.com/ndycode/oc-codex-multi-auth/commit/ef197e4b1e21bb47415d5bd74775ec896f3f9c8a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45458446)</sub>

<!-- /greptile_comment -->