### PR TITLE
fix: persist rotated health-check tokens

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1378,6 +1378,13 @@ export const OpenAIOAuthPlugin: Plugin = async ({ client }: PluginInput) => {
 			}
 		};
 
+		const reloadCachedAccountManager = async (): Promise<void> => {
+			if (!cachedAccountManager) return;
+			const reloadedManager = await AccountManager.loadFromDisk();
+			cachedAccountManager = reloadedManager;
+			accountManagerPromise = Promise.resolve(reloadedManager);
+		};
+
 		const persistAuthenticatedSelections = async (
 			results: TokenSuccessWithAccount[],
 			replaceAll: boolean,
@@ -1480,6 +1487,7 @@ export const OpenAIOAuthPlugin: Plugin = async ({ client }: PluginInput) => {
 					accountManagerPromise = value;
 				},
 			},
+			reloadCachedAccountManager,
 			runtimeMetrics,
 			beginnerSafeModeRef: {
 				get current() {

--- a/index.ts
+++ b/index.ts
@@ -1380,9 +1380,33 @@ export const OpenAIOAuthPlugin: Plugin = async ({ client }: PluginInput) => {
 
 		const reloadCachedAccountManager = async (): Promise<void> => {
 			if (!cachedAccountManager) return;
-			const reloadedManager = await AccountManager.loadFromDisk();
-			cachedAccountManager = reloadedManager;
-			accountManagerPromise = Promise.resolve(reloadedManager);
+			const previous = cachedAccountManager;
+			// Flush the outgoing manager's pending debounced save BEFORE reading
+			// fresh disk state. Otherwise a queued save from `previous` can fire
+			// after this reload and silently overwrite the single-use refresh
+			// tokens codex-health/codex-refresh just persisted via
+			// withAccountStorageTransaction — a lost-update on rotated credentials.
+			// Mirrors invalidateAccountManagerCache above.
+			try {
+				await previous.flushPendingSave();
+			} catch (error) {
+				logWarn(
+					`Failed to flush pending save while reloading account manager: ${error instanceof Error ? error.message : String(error)}`,
+				);
+			}
+			try {
+				const reloadedManager = await AccountManager.loadFromDisk();
+				cachedAccountManager = reloadedManager;
+				accountManagerPromise = Promise.resolve(reloadedManager);
+				// Dispose only after the replacement is installed so we never leak
+				// the outgoing manager's shutdown handler on every reload, and so a
+				// load failure leaves the working manager intact.
+				previous.disposeShutdownHandler();
+			} catch (error) {
+				logWarn(
+					`Failed to reload account manager: ${error instanceof Error ? error.message : String(error)}`,
+				);
+			}
 		};
 
 		const persistAuthenticatedSelections = async (

--- a/index.ts
+++ b/index.ts
@@ -1471,13 +1471,9 @@ export const OpenAIOAuthPlugin: Plugin = async ({ client }: PluginInput) => {
                                 await saveAccounts(storage);
 								await clearPromptQuotaCache();
 
-                                // Reload manager from disk so we don't overwrite newer rotated
-                                // refresh tokens with stale in-memory state.
-                                if (cachedAccountManager) {
-                                        const reloadedManager = await AccountManager.loadFromDisk();
-                                        cachedAccountManager = reloadedManager;
-                                        accountManagerPromise = Promise.resolve(reloadedManager);
-                                }
+								// Reload manager from disk so we don't overwrite newer rotated
+								// refresh tokens with stale in-memory state.
+								await reloadCachedAccountManager();
 
                                 await showToast(`Switched to account ${index + 1}`, "info");
                         }

--- a/lib/tools/codex-doctor.ts
+++ b/lib/tools/codex-doctor.ts
@@ -68,11 +68,12 @@ export function createCodexDoctorTool(ctx: ToolContext): ToolDefinition {
 		formatDoctorSeverityText,
 		runtimeMetrics,
 		cachedAccountManagerRef,
-		accountManagerPromiseRef,
+		reloadCachedAccountManager,
 	} = ctx;
 
 	async function loadDiagnostics(
 		extraFindings: BeginnerDiagnosticFinding[] = [],
+		verificationFailureIdentities: RefreshAccountIdentity[] = [],
 	): Promise<DoctorDiagnostics> {
 		const storage = await loadAccounts();
 		const now = Date.now();
@@ -80,8 +81,17 @@ export function createCodexDoctorTool(ctx: ToolContext): ToolDefinition {
 			storage && storage.accounts.length > 0
 				? resolveActiveIndex(storage, "codex")
 				: 0;
+		const failedIndices = new Set(
+			verificationFailureIdentities
+				.map((identity) => findAccountIndexByIdentity(storage?.accounts ?? [], identity))
+				.filter((index) => index >= 0),
+		);
 		const snapshots = storage
 			? toBeginnerAccountSnapshots(storage, activeIndex, now)
+				.map((snapshot) => ({
+					...snapshot,
+					refreshVerificationFailed: failedIndices.has(snapshot.index),
+				}))
 			: [];
 		const runtime = getBeginnerRuntimeSnapshot();
 		const summary = summarizeBeginnerAccounts(snapshots, now);
@@ -173,7 +183,7 @@ export function createCodexDoctorTool(ctx: ToolContext): ToolDefinition {
 					identity: RefreshAccountIdentity;
 				}> = [];
 				const reloginNeeded: number[] = [];
-				let verificationFailures = 0;
+				const verificationFailureIdentities: RefreshAccountIdentity[] = [];
 				const inputs = buildRefreshInputs(diagnostics.storage.accounts);
 
 				for (const input of inputs) {
@@ -191,7 +201,7 @@ export function createCodexDoctorTool(ctx: ToolContext): ToolDefinition {
 						// remedy is `codex-remove`), and stale-state must never be cleared
 						// on an entry the user disabled on purpose.
 					} else {
-						verificationFailures += 1;
+						verificationFailureIdentities.push(outcome.identity);
 						reloginNeeded.push(outcome.index + 1);
 						fixErrors.push(
 							`Account ${outcome.index + 1}: ${outcome.error} — run \`opencode auth login\` to re-authenticate.`,
@@ -199,11 +209,11 @@ export function createCodexDoctorTool(ctx: ToolContext): ToolDefinition {
 					}
 				}
 
-				if (verificationFailures > 0) {
+				if (verificationFailureIdentities.length > 0) {
 					extraFindings.push({
 						severity: "error",
 						code: "refresh-verification-failed",
-						summary: `${verificationFailures} account(s) failed refresh-token verification.`,
+						summary: `${verificationFailureIdentities.length} account(s) failed refresh-token verification.`,
 						action: `Re-authenticate the affected account(s) with \`opencode auth login\` (slots: ${reloginNeeded.join(", ")}).`,
 					});
 				}
@@ -302,25 +312,42 @@ export function createCodexDoctorTool(ctx: ToolContext): ToolDefinition {
 							return b.tokensAvailable - a.tokensAvailable;
 						});
 					const best = eligible[0];
-					if (best) {
-						const switched = await withAccountStorageTransaction(
+					const bestAccount = best
+						? managerForFix.getAccountsSnapshot()[best.index]
+						: undefined;
+					if (best && bestAccount) {
+						const bestIdentity: RefreshAccountIdentity = {
+							organizationId: bestAccount.organizationId,
+							accountId: bestAccount.accountId,
+							refreshToken: bestAccount.refreshToken,
+						};
+						const switchResult = await withAccountStorageTransaction(
 							async (current, persist) => {
-								if (!current) return false;
+								if (!current) return "missing";
+								const freshBestIndex = findAccountIndexByIdentity(
+									current.accounts,
+									bestIdentity,
+								);
+								if (freshBestIndex < 0) return "missing";
 								const currentActive = resolveActiveIndex(current, "codex");
-								if (best.index === currentActive) return false;
-								current.activeIndex = best.index;
+								if (freshBestIndex === currentActive) return "unchanged";
+								current.activeIndex = freshBestIndex;
 								current.activeIndexByFamily =
 									current.activeIndexByFamily ?? {};
 								for (const family of MODEL_FAMILIES) {
-									current.activeIndexByFamily[family] = best.index;
+									current.activeIndexByFamily[family] = freshBestIndex;
 								}
 								await persist(current);
-								return true;
+								return "switched";
 							},
 						);
-						if (switched) {
+						if (switchResult === "switched") {
 							appliedFixes.push(
 								`Switched active account to ${best.index + 1} (best eligible).`,
+							);
+						} else if (switchResult === "missing") {
+							fixErrors.push(
+								"Selected account changed during auto-switch; no switch was applied.",
 							);
 						}
 					} else {
@@ -336,23 +363,15 @@ export function createCodexDoctorTool(ctx: ToolContext): ToolDefinition {
 					);
 				}
 
-				if (cachedAccountManagerRef.current) {
-					const reloadedManager = await AccountManager.loadFromDisk();
-					cachedAccountManagerRef.current = reloadedManager;
-					accountManagerPromiseRef.current =
-						Promise.resolve(reloadedManager);
-				}
+				await reloadCachedAccountManager();
 
 				// The initial diagnostics snapshot was taken before token verification.
 				// Reload after fixes so the reported health never contradicts live
 				// refresh results (e.g. "8 healthy" alongside eight invalid tokens).
-				diagnostics = await loadDiagnostics(extraFindings);
-				if (verificationFailures > 0 && diagnostics.summary.healthy > 0) {
-					diagnostics.summary.healthy = Math.max(
-						0,
-						diagnostics.summary.healthy - verificationFailures,
-					);
-				}
+				diagnostics = await loadDiagnostics(
+					extraFindings,
+					verificationFailureIdentities,
+				);
 			}
 
 			if (deep) {

--- a/lib/tools/codex-doctor.ts
+++ b/lib/tools/codex-doctor.ts
@@ -7,10 +7,10 @@ import { tool, type ToolDefinition } from "@opencode-ai/plugin/tool";
 import {
 	getStoragePath,
 	loadAccounts,
-	saveAccounts,
+	withAccountStorageTransaction,
+	type AccountStorageV3,
 } from "../storage.js";
 import { AccountManager } from "../accounts.js";
-import { queuedRefresh } from "../refresh-queue.js";
 import { MODEL_FAMILIES } from "../prompts/codex.js";
 import {
 	clearRefreshedAccountsStaleState,
@@ -23,6 +23,8 @@ import {
 	formatPromptCacheSnapshot,
 	recommendBeginnerNextAction,
 	summarizeBeginnerAccounts,
+	type BeginnerAccountSummary,
+	type BeginnerDiagnosticFinding,
 } from "../ui/beginner.js";
 import {
 	formatUiHeader,
@@ -35,7 +37,23 @@ import {
 	renderJsonOutput,
 	type RoutingVisibilitySnapshot,
 } from "../runtime.js";
+import {
+	buildRefreshInputs,
+	findAccountIndexByIdentity,
+	refreshAndPersistAccount,
+	type RefreshAccountIdentity,
+} from "./refresh-account.js";
 import type { ToolContext } from "./index.js";
+
+interface DoctorDiagnostics {
+	storage: AccountStorageV3 | null;
+	activeIndex: number;
+	snapshots: ReturnType<ToolContext["toBeginnerAccountSnapshots"]>;
+	runtime: ReturnType<ToolContext["getBeginnerRuntimeSnapshot"]>;
+	summary: BeginnerAccountSummary;
+	findings: BeginnerDiagnosticFinding[];
+	nextAction: string;
+}
 
 export function createCodexDoctorTool(ctx: ToolContext): ToolDefinition {
 	const {
@@ -52,6 +70,72 @@ export function createCodexDoctorTool(ctx: ToolContext): ToolDefinition {
 		cachedAccountManagerRef,
 		accountManagerPromiseRef,
 	} = ctx;
+
+	async function loadDiagnostics(
+		extraFindings: BeginnerDiagnosticFinding[] = [],
+	): Promise<DoctorDiagnostics> {
+		const storage = await loadAccounts();
+		const now = Date.now();
+		const activeIndex =
+			storage && storage.accounts.length > 0
+				? resolveActiveIndex(storage, "codex")
+				: 0;
+		const snapshots = storage
+			? toBeginnerAccountSnapshots(storage, activeIndex, now)
+			: [];
+		const runtime = getBeginnerRuntimeSnapshot();
+		const summary = summarizeBeginnerAccounts(snapshots, now);
+		const findings = buildBeginnerDoctorFindings({
+			accounts: snapshots,
+			now,
+			runtime,
+		});
+		const nextAction = recommendBeginnerNextAction({
+			accounts: snapshots,
+			now,
+			runtime,
+		});
+
+		// Surface disabled token-source duplicates that shadow an enabled,
+		// org-backed account by email (issue #171). These appear when a
+		// re-login mints a token-source entry instead of updating the org
+		// account; harmless for rotation but they pollute diagnostics. We flag
+		// rather than auto-remove because the only link between the two is
+		// email, and email-only merges must not blindly collapse multi-org
+		// accounts (#64).
+		const disabledTokenSourceDuplicates = storage
+			? findDisabledTokenSourceDuplicates(storage.accounts)
+			: [];
+		if (disabledTokenSourceDuplicates.length > 0) {
+			findings.push({
+				severity: "warning",
+				code: "disabled-token-source-duplicate",
+				summary: `${disabledTokenSourceDuplicates.length} disabled duplicate account entry(ies) shadow a real account.`,
+				action: `Remove the leftover entry(ies) with \`codex-remove\` (slots: ${disabledTokenSourceDuplicates
+					.map((index) => index + 1)
+					.join(", ")}).`,
+			});
+		}
+		// A user-disabled account that absorbed a fresh enabled re-login stays
+		// disabled (fail-closed) but is otherwise invisible to diagnostics (#171).
+		const disabledWithFreshCredential = storage
+			? findDisabledAccountsWithFreshCredential(storage.accounts)
+			: [];
+		if (disabledWithFreshCredential.length > 0) {
+			findings.push({
+				severity: "warning",
+				code: "disabled-account-fresh-credential",
+				summary: `${disabledWithFreshCredential.length} disabled account(s) hold a fresh login credential.`,
+				action: `A recent re-login landed on a disabled slot; re-enable it in oc-codex-multi-auth-accounts.json if intended (slots: ${disabledWithFreshCredential
+					.map((index) => index + 1)
+					.join(", ")}).`,
+			});
+		}
+		findings.push(...extraFindings);
+
+		return { storage, activeIndex, snapshots, runtime, summary, findings, nextAction };
+	}
+
 	return tool({
 		description: "Run beginner-friendly diagnostics with clear fixes.",
 		args: {
@@ -77,136 +161,90 @@ export function createCodexDoctorTool(ctx: ToolContext): ToolDefinition {
 		}: { deep?: boolean; fix?: boolean; format?: string } = {}) {
 			const ui = resolveUiRuntime();
 			const outputFormat = normalizeToolOutputFormat(format);
-			const storage = await loadAccounts();
-			const now = Date.now();
-			const activeIndex =
-				storage && storage.accounts.length > 0
-					? resolveActiveIndex(storage, "codex")
-					: 0;
-			const snapshots = storage
-				? toBeginnerAccountSnapshots(storage, activeIndex, now)
-				: [];
-			const runtime = getBeginnerRuntimeSnapshot();
-			const summary = summarizeBeginnerAccounts(snapshots, now);
-			const findings = buildBeginnerDoctorFindings({
-				accounts: snapshots,
-				now,
-				runtime,
-			});
-			const nextAction = recommendBeginnerNextAction({
-				accounts: snapshots,
-				now,
-				runtime,
-			});
-
-			// Surface disabled token-source duplicates that shadow an enabled,
-			// org-backed account by email (issue #171). These appear when a
-			// re-login mints a token-source entry instead of updating the org
-			// account; harmless for rotation but they pollute diagnostics. We flag
-			// rather than auto-remove because the only link between the two is
-			// email, and email-only merges must not blindly collapse multi-org
-			// accounts (#64).
-			const disabledTokenSourceDuplicates = storage
-				? findDisabledTokenSourceDuplicates(storage.accounts)
-				: [];
-			if (disabledTokenSourceDuplicates.length > 0) {
-				findings.push({
-					severity: "warning",
-					code: "disabled-token-source-duplicate",
-					summary: `${disabledTokenSourceDuplicates.length} disabled duplicate account entry(ies) shadow a real account.`,
-					action: `Remove the leftover entry(ies) with \`codex-remove\` (slots: ${disabledTokenSourceDuplicates
-						.map((index) => index + 1)
-						.join(", ")}).`,
-				});
-			}
-			// A user-disabled account that absorbed a fresh enabled re-login stays
-			// disabled (fail-closed) but is otherwise invisible to diagnostics (#171).
-			const disabledWithFreshCredential = storage
-				? findDisabledAccountsWithFreshCredential(storage.accounts)
-				: [];
-			if (disabledWithFreshCredential.length > 0) {
-				findings.push({
-					severity: "warning",
-					code: "disabled-account-fresh-credential",
-					summary: `${disabledWithFreshCredential.length} disabled account(s) hold a fresh login credential.`,
-					action: `A recent re-login landed on a disabled slot; re-enable it in oc-codex-multi-auth-accounts.json if intended (slots: ${disabledWithFreshCredential
-						.map((index) => index + 1)
-						.join(", ")}).`,
-				});
-			}
-			let routingVisibility: RoutingVisibilitySnapshot | null = null;
 			const appliedFixes: string[] = [];
 			const fixErrors: string[] = [];
+			const extraFindings: BeginnerDiagnosticFinding[] = [];
+			let routingVisibility: RoutingVisibilitySnapshot | null = null;
+			let diagnostics = await loadDiagnostics();
 
-			if (fix && storage && storage.accounts.length > 0) {
-				let changedByRefresh = false;
-				let refreshedCount = 0;
-				const refreshedAccounts: typeof storage.accounts = [];
+			if (fix && diagnostics.storage && diagnostics.storage.accounts.length > 0) {
+				const refreshResults: Array<{
+					index: number;
+					identity: RefreshAccountIdentity;
+				}> = [];
 				const reloginNeeded: number[] = [];
-				for (let accountIndex = 0; accountIndex < storage.accounts.length; accountIndex++) {
-					const account = storage.accounts[accountIndex];
-					if (!account) continue;
-					// Skip intentionally-disabled accounts: refreshing them is wrong
-					// (e.g. the disabled token-source duplicate would get a spurious
-					// "re-login" directive when its dead token fails, when the correct
-					// remedy is `codex-remove`), and stale-state must never be cleared
-					// on an entry the user disabled on purpose.
-					if (account.enabled === false) continue;
-					try {
-						const refreshResult = await queuedRefresh(account.refreshToken);
-						if (refreshResult.type === "success") {
-							account.refreshToken = refreshResult.refresh;
-							account.accessToken = refreshResult.access;
-							account.expiresAt = refreshResult.expires;
-							changedByRefresh = true;
-							refreshedCount += 1;
-							refreshedAccounts.push(account);
-						} else {
-							// A failed refresh (vs. a thrown error) means the stored
-							// credential is genuinely dead — re-login is required. Surface
-							// it explicitly so an all-dark pool with expired tokens does not
-							// fail silently (issue #171: "surface this state"). We do NOT
-							// clear stale state for these accounts: they really are blocked.
-							const detail =
-								refreshResult.message ?? refreshResult.reason ?? "token refresh failed";
-							reloginNeeded.push(accountIndex + 1);
-							fixErrors.push(
-								`Account ${accountIndex + 1}: ${detail} — run \`opencode auth login\` to re-authenticate.`,
-							);
-						}
-					} catch (error) {
+				let verificationFailures = 0;
+				const inputs = buildRefreshInputs(diagnostics.storage.accounts);
+
+				for (const input of inputs) {
+					if (!input) continue;
+					const outcome = await refreshAndPersistAccount(input);
+					if (outcome.status === "refreshed") {
+						refreshResults.push({
+							index: outcome.index,
+							identity: outcome.result.identity,
+						});
+					} else if (outcome.status === "skipped") {
+						// Skip intentionally-disabled accounts: refreshing them is wrong
+						// (e.g. the disabled token-source duplicate would get a spurious
+						// "re-login" directive when its dead token fails, when the correct
+						// remedy is `codex-remove`), and stale-state must never be cleared
+						// on an entry the user disabled on purpose.
+					} else {
+						verificationFailures += 1;
+						reloginNeeded.push(outcome.index + 1);
 						fixErrors.push(
-							error instanceof Error ? error.message : String(error),
+							`Account ${outcome.index + 1}: ${outcome.error} — run \`opencode auth login\` to re-authenticate.`,
 						);
 					}
 				}
 
-				// A successful refresh proves the credential is alive, so clear any
-				// stale cooldown / rate-limit state that would otherwise keep the
-				// recovered account out of rotation (issue #171). Without this, the
-				// auto-switch below finds no eligible account and the dead routing
-				// persists across restarts. The summary is computed here but only
-				// reported after saveAccounts succeeds, so we never tell the user a
-				// fix landed while the on-disk state still carries the stale block.
-				let staleSummary = { cooldownsCleared: 0, rateLimitKeysCleared: 0 };
-				if (refreshedAccounts.length > 0) {
-					staleSummary = clearRefreshedAccountsStaleState(refreshedAccounts);
-					if (staleSummary.cooldownsCleared > 0 || staleSummary.rateLimitKeysCleared > 0) {
-						changedByRefresh = true;
-					}
+				if (verificationFailures > 0) {
+					extraFindings.push({
+						severity: "error",
+						code: "refresh-verification-failed",
+						summary: `${verificationFailures} account(s) failed refresh-token verification.`,
+						action: `Re-authenticate the affected account(s) with \`opencode auth login\` (slots: ${reloginNeeded.join(", ")}).`,
+					});
 				}
 
-				if (changedByRefresh) {
+				if (refreshResults.length > 0) {
+					appliedFixes.push(
+						`Refreshed and persisted ${refreshResults.length} account token(s).`,
+					);
+
+					// A successful refresh proves the credential is alive, so clear any
+					// stale cooldown / rate-limit state that would otherwise keep the
+					// recovered account out of rotation (issue #171). Apply this to a
+					// fresh storage snapshot so non-credential state written by other
+					// processes is preserved.
 					try {
-						await saveAccounts(storage);
-						// Only report applied fixes once the write to disk has actually
-						// succeeded, otherwise a failed persist would still print
-						// "Cleared ..." and mislead the user into thinking it landed.
-						if (refreshedCount > 0) {
-							appliedFixes.push(
-								`Refreshed ${refreshedCount} account token(s).`,
-							);
-						}
+						const staleSummary = await withAccountStorageTransaction(
+							async (current, persist) => {
+								if (!current) {
+									throw new Error("Account storage is unavailable");
+								}
+								const refreshedRecords = [];
+								for (const refreshed of refreshResults) {
+									const idx = findAccountIndexByIdentity(
+										current.accounts,
+										refreshed.identity,
+									);
+									const record = idx >= 0 ? current.accounts[idx] : undefined;
+									if (record && record.enabled !== false) {
+										refreshedRecords.push(record);
+									}
+								}
+								const summary = clearRefreshedAccountsStaleState(refreshedRecords);
+								if (
+									summary.cooldownsCleared > 0 ||
+									summary.rateLimitKeysCleared > 0
+								) {
+									await persist(current);
+								}
+								return summary;
+							},
+						);
 						if (staleSummary.cooldownsCleared > 0) {
 							appliedFixes.push(
 								`Cleared cooldown on ${staleSummary.cooldownsCleared} recovered account(s).`,
@@ -219,18 +257,14 @@ export function createCodexDoctorTool(ctx: ToolContext): ToolDefinition {
 						}
 					} catch (error) {
 						fixErrors.push(
-							`Failed to persist refresh updates: ${
+							`Failed to persist stale-state repairs: ${
 								error instanceof Error ? error.message : String(error)
 							}`,
 						);
 					}
-				}
 
-				// Stale TUI quota cache can reference an account index/count that no
-				// longer matches the pool, making diagnostics misleading (#171).
-				// Only clear it when the repair actually changed account state, so a
-				// run where every refresh failed does not report a phantom fix.
-				if (changedByRefresh) {
+					// Stale TUI quota cache can reference an account index/count that no
+					// longer matches the pool, making diagnostics misleading (#171).
 					try {
 						await clearTuiQuotaSnapshot();
 						appliedFixes.push("Cleared stale TUI quota cache.");
@@ -245,9 +279,6 @@ export function createCodexDoctorTool(ctx: ToolContext): ToolDefinition {
 					}
 				}
 
-				// Surface a clear next step when one or more accounts could not be
-				// refreshed: the credential is dead and only re-login fixes it. Without
-				// this the user sees no eligible account but no cause (issue #171).
 				if (reloginNeeded.length > 0) {
 					// Re-login is a MANUAL action, not an applied fix — keep it in fixErrors
 					// so JSON consumers reading autoFix.appliedFixes are not misled.
@@ -272,15 +303,22 @@ export function createCodexDoctorTool(ctx: ToolContext): ToolDefinition {
 						});
 					const best = eligible[0];
 					if (best) {
-						const currentActive = resolveActiveIndex(storage, "codex");
-						if (best.index !== currentActive) {
-							storage.activeIndex = best.index;
-							storage.activeIndexByFamily =
-								storage.activeIndexByFamily ?? {};
-							for (const family of MODEL_FAMILIES) {
-								storage.activeIndexByFamily[family] = best.index;
-							}
-							await saveAccounts(storage);
+						const switched = await withAccountStorageTransaction(
+							async (current, persist) => {
+								if (!current) return false;
+								const currentActive = resolveActiveIndex(current, "codex");
+								if (best.index === currentActive) return false;
+								current.activeIndex = best.index;
+								current.activeIndexByFamily =
+									current.activeIndexByFamily ?? {};
+								for (const family of MODEL_FAMILIES) {
+									current.activeIndexByFamily[family] = best.index;
+								}
+								await persist(current);
+								return true;
+							},
+						);
+						if (switched) {
 							appliedFixes.push(
 								`Switched active account to ${best.index + 1} (best eligible).`,
 							);
@@ -304,7 +342,19 @@ export function createCodexDoctorTool(ctx: ToolContext): ToolDefinition {
 					accountManagerPromiseRef.current =
 						Promise.resolve(reloadedManager);
 				}
+
+				// The initial diagnostics snapshot was taken before token verification.
+				// Reload after fixes so the reported health never contradicts live
+				// refresh results (e.g. "8 healthy" alongside eight invalid tokens).
+				diagnostics = await loadDiagnostics(extraFindings);
+				if (verificationFailures > 0 && diagnostics.summary.healthy > 0) {
+					diagnostics.summary.healthy = Math.max(
+						0,
+						diagnostics.summary.healthy - verificationFailures,
+					);
+				}
 			}
+
 			if (deep) {
 				const managerForRouting =
 					cachedAccountManagerRef.current ??
@@ -322,8 +372,8 @@ export function createCodexDoctorTool(ctx: ToolContext): ToolDefinition {
 						Date.now(),
 					);
 				const routingActiveIndex =
-					storage && storage.accounts.length > 0
-						? resolveActiveIndex(storage, routingFamily)
+					diagnostics.storage && diagnostics.storage.accounts.length > 0
+						? resolveActiveIndex(diagnostics.storage, routingFamily)
 						: null;
 				routingVisibility = buildRoutingVisibilitySnapshot({
 					modelFamily: routingFamily,
@@ -335,6 +385,8 @@ export function createCodexDoctorTool(ctx: ToolContext): ToolDefinition {
 					selectionExplainability: routingExplainability,
 				});
 			}
+
+			const { runtime, summary, findings, nextAction } = diagnostics;
 			if (outputFormat === "json") {
 				return renderJsonOutput({
 					summary: {

--- a/lib/tools/codex-health.ts
+++ b/lib/tools/codex-health.ts
@@ -5,7 +5,6 @@
 
 import { tool, type ToolDefinition } from "@opencode-ai/plugin/tool";
 import { loadAccounts } from "../storage.js";
-import { AccountManager } from "../accounts.js";
 import {
 	findDisabledAccountsWithFreshCredential,
 	findDisabledTokenSourceDuplicates,
@@ -26,8 +25,7 @@ export function createCodexHealthTool(ctx: ToolContext): ToolDefinition {
 		resolveMaskEmail,
 		getStatusMarker,
 		buildJsonAccountIdentity,
-		cachedAccountManagerRef,
-		accountManagerPromiseRef,
+		reloadCachedAccountManager,
 	} = ctx;
 	return tool({
 		description:
@@ -142,11 +140,7 @@ export function createCodexHealthTool(ctx: ToolContext): ToolDefinition {
 				}
 			}
 
-			if (cachedAccountManagerRef.current) {
-				const reloadedManager = await AccountManager.loadFromDisk();
-				cachedAccountManagerRef.current = reloadedManager;
-				accountManagerPromiseRef.current = Promise.resolve(reloadedManager);
-			}
+			await reloadCachedAccountManager();
 
 			results.push("");
 			results.push(

--- a/lib/tools/codex-health.ts
+++ b/lib/tools/codex-health.ts
@@ -5,7 +5,7 @@
 
 import { tool, type ToolDefinition } from "@opencode-ai/plugin/tool";
 import { loadAccounts } from "../storage.js";
-import { queuedRefresh } from "../refresh-queue.js";
+import { AccountManager } from "../accounts.js";
 import {
 	findDisabledAccountsWithFreshCredential,
 	findDisabledTokenSourceDuplicates,
@@ -13,6 +13,10 @@ import {
 } from "../accounts/stale-state.js";
 import { formatUiHeader, formatUiItem, paintUiText } from "../ui/format.js";
 import { normalizeToolOutputFormat, renderJsonOutput } from "../runtime.js";
+import {
+	buildRefreshInputs,
+	refreshAndPersistAccount,
+} from "./refresh-account.js";
 import type { ToolContext } from "./index.js";
 
 export function createCodexHealthTool(ctx: ToolContext): ToolDefinition {
@@ -22,6 +26,8 @@ export function createCodexHealthTool(ctx: ToolContext): ToolDefinition {
 		resolveMaskEmail,
 		getStatusMarker,
 		buildJsonAccountIdentity,
+		cachedAccountManagerRef,
+		accountManagerPromiseRef,
 	} = ctx;
 	return tool({
 		description:
@@ -58,6 +64,7 @@ export function createCodexHealthTool(ctx: ToolContext): ToolDefinition {
 						totalAccounts: 0,
 						healthyCount: 0,
 						unhealthyCount: 0,
+						skippedCount: 0,
 						accounts: [],
 					});
 				}
@@ -79,46 +86,46 @@ export function createCodexHealthTool(ctx: ToolContext): ToolDefinition {
 
 			let healthyCount = 0;
 			let unhealthyCount = 0;
+			let skippedCount = 0;
+			const inputs = buildRefreshInputs(storage.accounts);
 
-			for (let i = 0; i < storage.accounts.length; i++) {
+			for (let i = 0; i < inputs.length; i++) {
+				const input = inputs[i];
 				const account = storage.accounts[i];
-				if (!account) continue;
+				if (!input || !account) continue;
 
 				const label = formatCommandAccountLabel(account, i);
 				const displayLabel = formatCommandAccountLabel(account, i, { maskEmail });
-				try {
-					const refreshResult = await queuedRefresh(account.refreshToken);
-					if (refreshResult.type === "success") {
-						jsonAccounts.push({
-							...buildJsonAccountIdentity(i, {
-								includeSensitive: includeSensitiveOutput,
-								account,
-								label,
-							}),
-							status: "healthy",
-						});
-						results.push(
-							`  ${getStatusMarker(ui, "ok")} ${displayLabel}: Healthy`,
-						);
-						healthyCount++;
-					} else {
-						jsonAccounts.push({
-							...buildJsonAccountIdentity(i, {
-								includeSensitive: includeSensitiveOutput,
-								account,
-								label,
-							}),
-							status: "unhealthy",
-							error: refreshResult.message ?? refreshResult.reason,
-						});
-						results.push(
-							`  ${getStatusMarker(ui, "error")} ${displayLabel}: Token refresh failed`,
-						);
-						unhealthyCount++;
-					}
-				} catch (error) {
-					const errorMsg =
-						error instanceof Error ? error.message : String(error);
+				const outcome = await refreshAndPersistAccount(input);
+
+				if (outcome.status === "refreshed") {
+					jsonAccounts.push({
+						...buildJsonAccountIdentity(i, {
+							includeSensitive: includeSensitiveOutput,
+							account,
+							label,
+						}),
+						status: "healthy",
+					});
+					results.push(
+						`  ${getStatusMarker(ui, "ok")} ${displayLabel}: Healthy`,
+					);
+					healthyCount++;
+				} else if (outcome.status === "skipped") {
+					jsonAccounts.push({
+						...buildJsonAccountIdentity(i, {
+							includeSensitive: includeSensitiveOutput,
+							account,
+							label,
+						}),
+						status: "skipped",
+						error: "Account is disabled",
+					});
+					results.push(
+						`  ${getStatusMarker(ui, "warning")} ${displayLabel}: Skipped (disabled)`,
+					);
+					skippedCount++;
+				} else {
 					jsonAccounts.push({
 						...buildJsonAccountIdentity(i, {
 							includeSensitive: includeSensitiveOutput,
@@ -126,23 +133,29 @@ export function createCodexHealthTool(ctx: ToolContext): ToolDefinition {
 							label,
 						}),
 						status: "unhealthy",
-						error: errorMsg.slice(0, 120),
+						error: outcome.error,
 					});
 					results.push(
-						`  ${getStatusMarker(ui, "error")} ${displayLabel}: Error - ${errorMsg.slice(0, 120)}`,
+						`  ${getStatusMarker(ui, "error")} ${displayLabel}: ${outcome.error}`,
 					);
 					unhealthyCount++;
 				}
 			}
 
+			if (cachedAccountManagerRef.current) {
+				const reloadedManager = await AccountManager.loadFromDisk();
+				cachedAccountManagerRef.current = reloadedManager;
+				accountManagerPromiseRef.current = Promise.resolve(reloadedManager);
+			}
+
 			results.push("");
 			results.push(
-				`Summary: ${healthyCount} healthy, ${unhealthyCount} unhealthy`,
+				`Summary: ${healthyCount} healthy, ${unhealthyCount} unhealthy, ${skippedCount} skipped`,
 			);
 
 			// Surface recoverable stale state and disabled token-source duplicates
-			// (issue #171). codex-health is read-only, so it points the user at the
-			// repair (`codex-doctor --fix` / `codex-remove`) rather than mutating.
+			// (issue #171). Token verification is destructive to single-use refresh
+			// tokens, but this tool persists rotations before reporting health.
 			const staleRecoverable = findStaleRecoverableAccounts(storage.accounts);
 			const duplicateSlots = findDisabledTokenSourceDuplicates(storage.accounts);
 			const staleSlots = staleRecoverable.map((index) => index + 1);
@@ -170,6 +183,7 @@ export function createCodexHealthTool(ctx: ToolContext): ToolDefinition {
 					totalAccounts: storage.accounts.length,
 					healthyCount,
 					unhealthyCount,
+					skippedCount,
 					staleRecoverableSlots: staleSlots,
 					disabledDuplicateSlots: dupSlots,
 					disabledWithFreshCredentialSlots: absorbedSlots,

--- a/lib/tools/codex-refresh.ts
+++ b/lib/tools/codex-refresh.ts
@@ -5,7 +5,6 @@
 
 import { tool, type ToolDefinition } from "@opencode-ai/plugin/tool";
 import { loadAccounts } from "../storage.js";
-import { AccountManager } from "../accounts.js";
 import { formatUiHeader, formatUiItem, paintUiText } from "../ui/format.js";
 import {
 	buildRefreshInputs,
@@ -19,8 +18,7 @@ export function createCodexRefreshTool(ctx: ToolContext): ToolDefinition {
 		formatCommandAccountLabel,
 		resolveMaskEmail,
 		getStatusMarker,
-		cachedAccountManagerRef,
-		accountManagerPromiseRef,
+		reloadCachedAccountManager,
 	} = ctx;
 	return tool({
 		description:
@@ -74,11 +72,7 @@ export function createCodexRefreshTool(ctx: ToolContext): ToolDefinition {
 				}
 			}
 
-			if (cachedAccountManagerRef.current) {
-				const reloadedManager = await AccountManager.loadFromDisk();
-				cachedAccountManagerRef.current = reloadedManager;
-				accountManagerPromiseRef.current = Promise.resolve(reloadedManager);
-			}
+			await reloadCachedAccountManager();
 			results.push("");
 			if (skippedCount > 0) {
 				results.push(

--- a/lib/tools/codex-refresh.ts
+++ b/lib/tools/codex-refresh.ts
@@ -4,77 +4,14 @@
  */
 
 import { tool, type ToolDefinition } from "@opencode-ai/plugin/tool";
-import { loadAccounts, withAccountStorageTransaction } from "../storage.js";
+import { loadAccounts } from "../storage.js";
 import { AccountManager } from "../accounts.js";
-import { queuedRefresh } from "../refresh-queue.js";
 import { formatUiHeader, formatUiItem, paintUiText } from "../ui/format.js";
+import {
+	buildRefreshInputs,
+	refreshAndPersistAccount,
+} from "./refresh-account.js";
 import type { ToolContext } from "./index.js";
-
-/**
- * Identity used to re-locate an account in a freshly re-read storage
- * snapshot after a (possibly slow, network-bound) refresh completes.
- * Captured BEFORE the refresh mutates the local copy's refreshToken, so the
- * refreshToken here is the pre-refresh value -- which is what the on-disk
- * record will still show for legacy accounts that have no organizationId/
- * accountId of their own.
- */
-interface RefreshAccountIdentity {
-	organizationId?: string;
-	accountId?: string;
-	refreshToken: string;
-}
-
-interface RefreshOutcome {
-	identity: RefreshAccountIdentity;
-	refreshToken: string;
-	accessToken: string;
-	expiresAt: number;
-	/**
-	 * Set to the wall-clock time the refresh settled, but ONLY when the
-	 * refresh actually rotated the token (refreshResult.refresh differs from
-	 * the pre-refresh token in `identity.refreshToken`). Left undefined for
-	 * a same-token refresh so the transaction below leaves the account's
-	 * existing `tokenRotatedAt` untouched. Without this stamp, tool-driven
-	 * rotations are invisible to the credential-clobber guard in
-	 * `lib/accounts/persistence.ts`, which compares `tokenRotatedAt ?? 0` --
-	 * a rotation that never stamps a value loses that comparison to any
-	 * stale in-memory snapshot that saves afterward.
-	 */
-	rotatedAt?: number;
-}
-
-/**
- * Finds the index of the account matching `identity` in `accounts`, using
- * the same organizationId -> accountId -> refreshToken priority order the
- * storage layer's dedup/identity helpers use elsewhere (see
- * `lib/storage/identity.ts`). Kept local rather than importing the shared
- * helper because the barrel does not currently re-export it.
- */
-function findAccountIndexByIdentity(
-	accounts: RefreshAccountIdentity[],
-	identity: RefreshAccountIdentity,
-): number {
-	const organizationId = identity.organizationId?.trim();
-	if (organizationId) {
-		const idx = accounts.findIndex(
-			(a) => a.organizationId?.trim() === organizationId,
-		);
-		if (idx >= 0) return idx;
-	}
-	const accountId = identity.accountId?.trim();
-	if (accountId) {
-		const idx = accounts.findIndex((a) => a.accountId?.trim() === accountId);
-		if (idx >= 0) return idx;
-	}
-	const refreshToken = identity.refreshToken?.trim();
-	if (refreshToken) {
-		const idx = accounts.findIndex(
-			(a) => a.refreshToken?.trim() === refreshToken,
-		);
-		if (idx >= 0) return idx;
-	}
-	return -1;
-}
 
 export function createCodexRefreshTool(ctx: ToolContext): ToolDefinition {
 	const {
@@ -111,82 +48,30 @@ export function createCodexRefreshTool(ctx: ToolContext): ToolDefinition {
 
 			let refreshedCount = 0;
 			let failedCount = 0;
-			// Collected here, applied to a freshly re-read snapshot in a single
-			// transaction after all (network-bound, multi-second) refreshes
-			// complete -- see the module doc comment on RefreshOutcome. Holding
-			// the storage lock across queuedRefresh calls would block every
-			// other tool/rotation for the full duration of this loop, and
-			// mutating `storage` in place and saving it at the end (the old
-			// behavior) silently clobbered any rate-limit/cooldown/activeIndex
-			// state a concurrent rotation persisted while this loop was running.
-			const refreshedAccounts: RefreshOutcome[] = [];
+			let skippedCount = 0;
+			const inputs = buildRefreshInputs(storage.accounts);
 
-			for (let i = 0; i < storage.accounts.length; i++) {
+			for (let i = 0; i < inputs.length; i++) {
+				const input = inputs[i];
 				const account = storage.accounts[i];
-				if (!account) continue;
+				if (!input || !account) continue;
 				const label = formatCommandAccountLabel(account, i, { maskEmail });
-				const identity: RefreshAccountIdentity = {
-					organizationId: account.organizationId,
-					accountId: account.accountId,
-					refreshToken: account.refreshToken,
-				};
+				const outcome = await refreshAndPersistAccount(input);
 
-				try {
-					const refreshResult = await queuedRefresh(account.refreshToken);
-					if (refreshResult.type === "success") {
-						const rotated = refreshResult.refresh !== account.refreshToken;
-						refreshedAccounts.push({
-							identity,
-							refreshToken: refreshResult.refresh,
-							accessToken: refreshResult.access,
-							expiresAt: refreshResult.expires,
-							rotatedAt: rotated ? Date.now() : undefined,
-						});
-						results.push(`  ${getStatusMarker(ui, "ok")} ${label}: Refreshed`);
-						refreshedCount++;
-					} else {
-						results.push(
-							`  ${getStatusMarker(ui, "error")} ${label}: Failed - ${refreshResult.message ?? refreshResult.reason}`,
-						);
-						failedCount++;
-					}
-				} catch (error) {
-					const errorMsg =
-						error instanceof Error ? error.message : String(error);
+				if (outcome.status === "refreshed") {
+					results.push(`  ${getStatusMarker(ui, "ok")} ${label}: Refreshed`);
+					refreshedCount++;
+				} else if (outcome.status === "skipped") {
 					results.push(
-						`  ${getStatusMarker(ui, "error")} ${label}: Error - ${errorMsg.slice(0, 120)}`,
+						`  ${getStatusMarker(ui, "warning")} ${label}: Skipped (disabled)`,
+					);
+					skippedCount++;
+				} else {
+					results.push(
+						`  ${getStatusMarker(ui, "error")} ${label}: Failed - ${outcome.error}`,
 					);
 					failedCount++;
 				}
-			}
-
-			if (refreshedAccounts.length > 0) {
-				await withAccountStorageTransaction(async (current, persist) => {
-					if (!current) return;
-					for (const outcome of refreshedAccounts) {
-						const idx = findAccountIndexByIdentity(
-							current.accounts,
-							outcome.identity,
-						);
-						if (idx < 0) continue; // Account removed concurrently; nothing to apply.
-						const target = current.accounts[idx];
-						if (!target) continue;
-						// The refresh was keyed off `outcome.identity.refreshToken` (the
-						// pre-refresh value). If the on-disk refreshToken no longer
-						// matches it, another process rotated this account mid-flight
-						// while our (network-bound) refresh was in progress -- we
-						// cannot know which resulting chain is the live one, so skip
-						// rather than clobber whatever that other process wrote.
-						if (target.refreshToken !== outcome.identity.refreshToken) continue;
-						target.refreshToken = outcome.refreshToken;
-						target.accessToken = outcome.accessToken;
-						target.expiresAt = outcome.expiresAt;
-						if (outcome.rotatedAt !== undefined) {
-							target.tokenRotatedAt = outcome.rotatedAt;
-						}
-					}
-					await persist(current);
-				});
 			}
 
 			if (cachedAccountManagerRef.current) {
@@ -195,9 +80,15 @@ export function createCodexRefreshTool(ctx: ToolContext): ToolDefinition {
 				accountManagerPromiseRef.current = Promise.resolve(reloadedManager);
 			}
 			results.push("");
-			results.push(
-				`Summary: ${refreshedCount} refreshed, ${failedCount} failed`,
-			);
+			if (skippedCount > 0) {
+				results.push(
+					`Summary: ${refreshedCount} refreshed, ${failedCount} failed, ${skippedCount} skipped`,
+				);
+			} else {
+				results.push(
+					`Summary: ${refreshedCount} refreshed, ${failedCount} failed`,
+				);
+			}
 			if (ui.v2Enabled) {
 				return [
 					...formatUiHeader(ui, "Refresh accounts"),

--- a/lib/tools/index.ts
+++ b/lib/tools/index.ts
@@ -92,6 +92,7 @@ export interface ToolContext {
 	// --- Mutable plugin-closure state ---------------------------------------
 	cachedAccountManagerRef: MutableRef<AccountManager | null>;
 	accountManagerPromiseRef: MutableRef<Promise<AccountManager> | null>;
+	reloadCachedAccountManager: () => Promise<void>;
 
 	// --- Read-only plugin-closure state -------------------------------------
 	runtimeMetrics: RuntimeMetrics;

--- a/lib/tools/refresh-account.ts
+++ b/lib/tools/refresh-account.ts
@@ -12,6 +12,10 @@ import {
 	withAccountStorageTransaction,
 	type AccountMetadataV3,
 } from "../storage.js";
+import {
+	findAccountIndexByIdentityKeys,
+	toAccountIdentityKeys,
+} from "../storage/identity.js";
 import type { TokenResult } from "../types.js";
 
 export interface RefreshAccountIdentity {
@@ -42,37 +46,11 @@ export type AccountRefreshOutcome =
 	| { status: "failed"; index: number; identity: RefreshAccountIdentity; error: string }
 	| { status: "refreshed"; index: number; result: PersistedRefreshResult };
 
-/**
- * Finds the index of the account matching `identity`, using the same
- * organizationId -> accountId -> refreshToken priority order the storage
- * layer's dedup/identity helpers use elsewhere (see
- * `lib/storage/identity.ts`). Kept local rather than importing the shared
- * helper because the barrel does not currently re-export it.
- */
 export function findAccountIndexByIdentity(
 	accounts: RefreshAccountIdentity[],
 	identity: RefreshAccountIdentity,
 ): number {
-	const organizationId = identity.organizationId?.trim();
-	if (organizationId) {
-		const idx = accounts.findIndex(
-			(a) => a.organizationId?.trim() === organizationId,
-		);
-		if (idx >= 0) return idx;
-	}
-	const accountId = identity.accountId?.trim();
-	if (accountId) {
-		const idx = accounts.findIndex((a) => a.accountId?.trim() === accountId);
-		if (idx >= 0) return idx;
-	}
-	const refreshToken = identity.refreshToken?.trim();
-	if (refreshToken) {
-		const idx = accounts.findIndex(
-			(a) => a.refreshToken?.trim() === refreshToken,
-		);
-		if (idx >= 0) return idx;
-	}
-	return -1;
+	return findAccountIndexByIdentityKeys(accounts, toAccountIdentityKeys(identity));
 }
 
 /**
@@ -133,29 +111,6 @@ export async function persistRefreshResult(
 				// non-credential state in the fresh snapshot.
 				target.accessToken = refreshResult.access;
 				target.expiresAt = refreshResult.expires;
-			} else if (rotated) {
-				const replacementCount = current.accounts.filter(
-					(account) => account.refreshToken === refreshResult.refresh,
-				).length;
-				// The queued refresh can hand the exact same rotation result to every
-				// sibling sharing a consumed token. After the first sibling persists,
-				// later siblings should accept that propagated replacement and attach
-				// their own workspace-specific access token. The target may have been
-				// located by a stale workspace id (access tokens can re-mint account
-				// ids), so a consumed token elsewhere in storage must not make us
-				// treat this rotation as already propagated to the target.
-				const rotationAlreadyPersisted = replacementCount > 0;
-				if (!rotationAlreadyPersisted) {
-					throw new Error(
-						"Refresh token changed concurrently while verification was in progress",
-					);
-				}
-				target.refreshToken = refreshResult.refresh;
-				target.accessToken = refreshResult.access;
-				target.expiresAt = refreshResult.expires;
-				if (rotatedAt !== undefined) {
-					target.tokenRotatedAt = rotatedAt;
-				}
 			} else {
 				// The refresh was keyed off `identity.refreshToken` (the consumed,
 				// pre-rotation value). If storage carries neither that token nor the

--- a/lib/tools/refresh-account.ts
+++ b/lib/tools/refresh-account.ts
@@ -1,0 +1,257 @@
+/**
+ * Shared token refresh persistence for the account-management tools.
+ *
+ * OpenAI refresh tokens are single-use and rotate on exchange. Any tool that
+ * calls `queuedRefresh()` must persist the rotated credential immediately;
+ * otherwise the on-disk refresh token is already consumed and the next load
+ * reports `refresh_token_reused` for every account.
+ */
+
+import { queuedRefresh } from "../refresh-queue.js";
+import {
+	withAccountStorageTransaction,
+	type AccountMetadataV3,
+} from "../storage.js";
+import type { TokenResult } from "../types.js";
+
+export interface RefreshAccountIdentity {
+	organizationId?: string;
+	accountId?: string;
+	refreshToken: string;
+}
+
+export interface RefreshAccountInput {
+	index: number;
+	identity: RefreshAccountIdentity;
+	enabled?: boolean;
+}
+
+export interface PersistedRefreshResult {
+	index: number;
+	identity: RefreshAccountIdentity;
+	refreshToken: string;
+	accessToken: string;
+	expiresAt: number;
+	rotatedAt?: number;
+	persisted: boolean;
+	persistError?: string;
+}
+
+export type AccountRefreshOutcome =
+	| { status: "skipped"; index: number; identity: RefreshAccountIdentity }
+	| { status: "failed"; index: number; identity: RefreshAccountIdentity; error: string }
+	| { status: "refreshed"; index: number; result: PersistedRefreshResult };
+
+/**
+ * Finds the index of the account matching `identity`, using the same
+ * organizationId -> accountId -> refreshToken priority order the storage
+ * layer's dedup/identity helpers use elsewhere (see
+ * `lib/storage/identity.ts`). Kept local rather than importing the shared
+ * helper because the barrel does not currently re-export it.
+ */
+export function findAccountIndexByIdentity(
+	accounts: RefreshAccountIdentity[],
+	identity: RefreshAccountIdentity,
+): number {
+	const organizationId = identity.organizationId?.trim();
+	if (organizationId) {
+		const idx = accounts.findIndex(
+			(a) => a.organizationId?.trim() === organizationId,
+		);
+		if (idx >= 0) return idx;
+	}
+	const accountId = identity.accountId?.trim();
+	if (accountId) {
+		const idx = accounts.findIndex((a) => a.accountId?.trim() === accountId);
+		if (idx >= 0) return idx;
+	}
+	const refreshToken = identity.refreshToken?.trim();
+	if (refreshToken) {
+		const idx = accounts.findIndex(
+			(a) => a.refreshToken?.trim() === refreshToken,
+		);
+		if (idx >= 0) return idx;
+	}
+	return -1;
+}
+
+/**
+ * Persists one successful refresh in a short storage transaction. The account
+ * is re-located from a freshly re-read snapshot, and sibling accounts that
+ * share the consumed single-use refresh token are rotated atomically with it.
+ */
+export async function persistRefreshResult(
+	index: number,
+	identity: RefreshAccountIdentity,
+	refreshResult: Extract<TokenResult, { type: "success" }>,
+): Promise<PersistedRefreshResult> {
+	const rotated = refreshResult.refresh !== identity.refreshToken;
+	const rotatedAt = rotated ? Date.now() : undefined;
+
+	try {
+		return await withAccountStorageTransaction(async (current, persist) => {
+			if (!current) {
+				throw new Error("Account storage is unavailable");
+			}
+			const idx = findAccountIndexByIdentity(current.accounts, identity);
+			if (idx < 0) {
+				throw new Error("Account was removed while its token was refreshing");
+			}
+			const target = current.accounts[idx];
+			if (!target) {
+				throw new Error("Account was removed while its token was refreshing");
+			}
+			if (target.refreshToken === identity.refreshToken) {
+				if (rotated) {
+					// A login can produce sibling org/workspace records sharing one
+					// single-use refresh token. Mirror the account-state propagation used
+					// by request-time refresh: update those records with the new token and
+					// expire their workspace-specific access tokens so they refresh cleanly.
+					// Do this before assigning the target, since siblings are matched by
+					// the consumed token and the target starts with that token too.
+					for (const sibling of current.accounts) {
+						if (sibling === target) continue;
+						if (sibling.refreshToken !== identity.refreshToken) continue;
+						sibling.refreshToken = refreshResult.refresh;
+						sibling.expiresAt = 0;
+						if (rotatedAt !== undefined) {
+							sibling.tokenRotatedAt = rotatedAt;
+						}
+					}
+				}
+
+				target.refreshToken = refreshResult.refresh;
+				target.accessToken = refreshResult.access;
+				target.expiresAt = refreshResult.expires;
+				if (rotatedAt !== undefined) {
+					target.tokenRotatedAt = rotatedAt;
+				}
+			} else if (target.refreshToken === refreshResult.refresh) {
+				// A sibling account in this process just persisted the same rotation
+				// and propagated the new token to this workspace record. Apply only
+				// this workspace's freshly returned access token; do not overwrite
+				// non-credential state in the fresh snapshot.
+				target.accessToken = refreshResult.access;
+				target.expiresAt = refreshResult.expires;
+			} else if (rotated) {
+				const replacementCount = current.accounts.filter(
+					(account) => account.refreshToken === refreshResult.refresh,
+				).length;
+				// The queued refresh can hand the exact same rotation result to every
+				// sibling sharing a consumed token. After the first sibling persists,
+				// later siblings should accept that propagated replacement and attach
+				// their own workspace-specific access token. The target may have been
+				// located by a stale workspace id (access tokens can re-mint account
+				// ids), so a consumed token elsewhere in storage must not make us
+				// treat this rotation as already propagated to the target.
+				const rotationAlreadyPersisted = replacementCount > 0;
+				if (!rotationAlreadyPersisted) {
+					throw new Error(
+						"Refresh token changed concurrently while verification was in progress",
+					);
+				}
+				target.refreshToken = refreshResult.refresh;
+				target.accessToken = refreshResult.access;
+				target.expiresAt = refreshResult.expires;
+				if (rotatedAt !== undefined) {
+					target.tokenRotatedAt = rotatedAt;
+				}
+			} else {
+				// The refresh was keyed off `identity.refreshToken` (the consumed,
+				// pre-rotation value). If storage carries neither that token nor the
+				// exact rotation returned by this refresh, another process rotated
+				// this credential while this network-bound refresh was in flight. We
+				// cannot know which resulting chain is live, so fail this
+				// verification rather than clobber whatever the other process wrote.
+				throw new Error(
+					"Refresh token changed concurrently while verification was in progress",
+				);
+			}
+
+			await persist(current);
+			return {
+				index,
+				identity,
+				refreshToken: refreshResult.refresh,
+				accessToken: refreshResult.access,
+				expiresAt: refreshResult.expires,
+				rotatedAt,
+				persisted: true,
+			};
+		});
+	} catch (error) {
+		return {
+			index,
+			identity,
+			refreshToken: refreshResult.refresh,
+			accessToken: refreshResult.access,
+			expiresAt: refreshResult.expires,
+			rotatedAt,
+			persisted: false,
+			persistError: error instanceof Error ? error.message : String(error),
+		};
+	}
+}
+
+/**
+ * Refreshes one account and persists the rotated credential before reporting
+ * success. Disabled standalone accounts are skipped: refreshing them is wrong
+ * (they may intentionally retain a dead duplicate credential), while disabled
+ * siblings sharing an enabled account's consumed token are still updated by
+ * `persistRefreshResult()` so the shared credential remains consistent.
+ */
+export async function refreshAndPersistAccount(
+	account: RefreshAccountInput,
+): Promise<AccountRefreshOutcome> {
+	const { index, identity } = account;
+	if (account.enabled === false) {
+		return { status: "skipped", index, identity };
+	}
+
+	let refreshResult: TokenResult;
+	try {
+		refreshResult = await queuedRefresh(identity.refreshToken);
+	} catch (error) {
+		return {
+			status: "failed",
+			index,
+			identity,
+			error: error instanceof Error ? error.message : String(error),
+		};
+	}
+
+	if (refreshResult.type !== "success") {
+		return {
+			status: "failed",
+			index,
+			identity,
+			error:
+				refreshResult.message ?? refreshResult.reason ?? "token refresh failed",
+		};
+	}
+
+	const persisted = await persistRefreshResult(index, identity, refreshResult);
+	if (!persisted.persisted) {
+		return {
+			status: "failed",
+			index,
+			identity,
+			error: persisted.persistError ?? "Failed to persist rotated credential",
+		};
+	}
+	return { status: "refreshed", index, result: persisted };
+}
+
+export function buildRefreshInputs(
+	accounts: AccountMetadataV3[],
+): RefreshAccountInput[] {
+	return accounts.map((account, index) => ({
+		index,
+		enabled: account.enabled,
+		identity: {
+			organizationId: account.organizationId,
+			accountId: account.accountId,
+			refreshToken: account.refreshToken,
+		},
+	}));
+}

--- a/lib/ui/beginner.ts
+++ b/lib/ui/beginner.ts
@@ -256,14 +256,11 @@ export function buildBeginnerDoctorFindings(input: {
 		});
 	}
 
-	if (input.accounts.some((account) => account.refreshVerificationFailed)) {
-		findings.push({
-			severity: "error",
-			code: "refresh-verification-failed",
-			summary: "One or more accounts failed refresh-token verification.",
-			action: "Re-authenticate the affected account(s) with `opencode auth login`.",
-		});
-	}
+	// NOTE: the `refresh-verification-failed` finding is emitted by the
+	// codex-doctor fix path (with the affected slot numbers) via extraFindings.
+	// Do not also generate a generic copy here off `refreshVerificationFailed`,
+	// or `codex-doctor --fix` reports the same-coded finding twice. The flag is
+	// still consumed above (blocked count) and below (recommended next action).
 
 	if (input.runtime.authRefreshFailures > 0) {
 		findings.push({

--- a/lib/ui/beginner.ts
+++ b/lib/ui/beginner.ts
@@ -10,6 +10,7 @@ export interface BeginnerAccountSnapshot {
 	isActive: boolean;
 	rateLimitedUntil: number | null;
 	coolingDownUntil: number | null;
+	refreshVerificationFailed?: boolean;
 }
 
 export interface BeginnerRuntimeSnapshot {
@@ -94,7 +95,11 @@ export function summarizeBeginnerAccounts(
 		if (isRateLimited) rateLimited += 1;
 		if (isCoolingDown) coolingDown += 1;
 
-		const isBlocked = !account.enabled || isRateLimited || isCoolingDown;
+		const isBlocked =
+			!account.enabled ||
+			isRateLimited ||
+			isCoolingDown ||
+			account.refreshVerificationFailed === true;
 		if (isBlocked) blocked += 1;
 		else healthy += 1;
 	}
@@ -251,6 +256,15 @@ export function buildBeginnerDoctorFindings(input: {
 		});
 	}
 
+	if (input.accounts.some((account) => account.refreshVerificationFailed)) {
+		findings.push({
+			severity: "error",
+			code: "refresh-verification-failed",
+			summary: "One or more accounts failed refresh-token verification.",
+			action: "Re-authenticate the affected account(s) with `opencode auth login`.",
+		});
+	}
+
 	if (input.runtime.authRefreshFailures > 0) {
 		findings.push({
 			severity: "warning",
@@ -331,6 +345,9 @@ export function recommendBeginnerNextAction(input: {
 	}
 	if (summary.healthy === 0) {
 		return "Run `codex-health`, then re-login or switch to a healthy account.";
+	}
+	if (input.accounts.some((account) => account.refreshVerificationFailed)) {
+		return "Re-authenticate the affected account(s) with `opencode auth login`.";
 	}
 	if (summary.rateLimited > 0) {
 		return "Use `codex-switch index=2` to move away from rate-limited accounts.";

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -2081,6 +2081,128 @@ describe("OpenAIOAuthPlugin", () => {
 			}));
 		});
 
+		it("keeps successful accounts healthy and recommends re-login after mixed verification results", async () => {
+			mockStorage.accounts = [
+				{ refreshToken: "alive-token", email: "alive@example.com" },
+				{ refreshToken: "dead-token", email: "dead@example.com" },
+			];
+			const { queuedRefresh } = await import("../lib/refresh-queue.js");
+			vi.mocked(queuedRefresh).mockImplementation(async (token: string) =>
+				token === "alive-token"
+					? {
+							type: "success" as const,
+							access: "alive-access",
+							refresh: "alive-refresh",
+							expires: Date.now() + 3_600_000,
+						}
+					: {
+							type: "failed" as const,
+							reason: "invalid_grant",
+							message: "refresh token expired",
+						},
+			);
+
+			const result = parseJsonOutput<{
+				summary: { healthyAccounts: number; blockedAccounts: number };
+				findings: Array<{ summary: string }>;
+				recommendedNextAction: string;
+			}>(await plugin.tool["codex-doctor"].execute({ fix: true, format: "json" }));
+			vi.mocked(queuedRefresh).mockImplementation(async () => ({
+				type: "success" as const,
+				access: "refreshed-access",
+				refresh: "refreshed-refresh",
+				expires: Date.now() + 3_600_000,
+			}));
+
+			expect(result.summary).toMatchObject({ healthyAccounts: 1, blockedAccounts: 1 });
+			expect(result.findings.some((finding) =>
+				finding.summary.includes("failed refresh-token verification"),
+			)).toBe(true);
+			expect(result.recommendedNextAction).toContain("opencode auth login");
+		});
+
+		it("re-resolves the selected account identity before auto-switching after storage reorder", async () => {
+			mockStorage.accounts = [
+				{
+					organizationId: "org-current",
+					accountId: "current",
+					refreshToken: "current-token",
+				},
+				{
+					organizationId: "org-best",
+					accountId: "best",
+					refreshToken: "best-token",
+				},
+			];
+			const { queuedRefresh } = await import("../lib/refresh-queue.js");
+			vi.mocked(queuedRefresh).mockImplementation(async () => ({
+				type: "success" as const,
+				access: "refreshed-access",
+				refresh: "refreshed-refresh",
+				expires: Date.now() + 3_600_000,
+			}));
+			const { AccountManager } = await import("../lib/accounts.js");
+			vi.spyOn(AccountManager, "loadFromDisk").mockResolvedValue({
+				getSelectionExplainability: () => [
+					{
+						index: 0,
+						enabled: true,
+						isCurrentForFamily: true,
+						eligible: true,
+						reasons: [],
+						healthScore: 1,
+						tokensAvailable: 1,
+						lastUsed: 1,
+					},
+					{
+						index: 1,
+						enabled: true,
+						isCurrentForFamily: false,
+						eligible: true,
+						reasons: [],
+						healthScore: 2,
+						tokensAvailable: 2,
+						lastUsed: 2,
+					},
+				],
+				getAccountsSnapshot: () => mockStorage.accounts.map((account) => ({
+					...account,
+					addedAt: account.addedAt ?? 0,
+					lastUsed: account.lastUsed ?? 0,
+					rateLimitResetTimes: account.rateLimitResetTimes ?? {},
+				})),
+			} as unknown as InstanceType<typeof AccountManager>);
+			const { withAccountStorageTransaction } = await import("../lib/storage.js");
+			const originalTransaction = vi.mocked(withAccountStorageTransaction).getMockImplementation();
+			let transactionCount = 0;
+			vi.mocked(withAccountStorageTransaction).mockImplementation(
+				async (callback) => {
+					transactionCount += 1;
+					if (transactionCount !== 4) {
+						return originalTransaction!(callback);
+					}
+					const reorderedStorage = {
+						...cloneMockStorage(),
+						accounts: [
+							{ refreshToken: "inserted-token" },
+							...cloneMockStorage().accounts,
+						],
+					};
+					return callback(reorderedStorage, async (nextStorage) => {
+						mockStorage.accounts = nextStorage.accounts.map(cloneAccount);
+						mockStorage.activeIndex = nextStorage.activeIndex;
+						mockStorage.activeIndexByFamily = { ...nextStorage.activeIndexByFamily };
+					});
+				},
+			);
+
+			await plugin.tool["codex-doctor"].execute({ fix: true });
+
+			expect(mockStorage.accounts[mockStorage.activeIndex]?.accountId).toBe("best");
+			expect(mockStorage.activeIndex).toBe(2);
+			vi.mocked(withAccountStorageTransaction).mockImplementation(originalTransaction);
+		});
+
 		it("persists rotated tokens transactionally during fix and preserves concurrent state", async () => {
 			mockStorage.accounts = [
 				{

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -449,6 +449,8 @@ vi.mock("../lib/accounts.js", () => {
 		}
 
 		saveToDiskDebounced() {}
+		async flushPendingSave() {}
+		disposeShutdownHandler() {}
 		updateFromAuth() {}
 		clearAuthFailures() {}
 		incrementAuthFailures() { return 1; }
@@ -2178,6 +2180,9 @@ describe("OpenAIOAuthPlugin", () => {
 			vi.mocked(withAccountStorageTransaction).mockImplementation(
 				async (callback) => {
 					transactionCount += 1;
+					// Two refresh persists and one stale-state clear precede the
+					// auto-switch persist, so transaction 4 must resolve identity
+					// against the reordered storage snapshot.
 					if (transactionCount !== 4) {
 						return originalTransaction!(callback);
 					}
@@ -2200,6 +2205,7 @@ describe("OpenAIOAuthPlugin", () => {
 
 			expect(mockStorage.accounts[mockStorage.activeIndex]?.accountId).toBe("best");
 			expect(mockStorage.activeIndex).toBe(2);
+			expect(transactionCount).toBe(4);
 			vi.mocked(withAccountStorageTransaction).mockImplementation(originalTransaction);
 		});
 
@@ -6140,12 +6146,14 @@ describe("OpenAIOAuthPlugin event handler edge cases", () => {
 		});
 	});
 
-	it("reloads account manager from disk when handling account.select", async () => {
+	it("flushes and disposes the cached manager when handling account.select", async () => {
 		const mockClient = createMockClient();
 		const { OpenAIOAuthPlugin } = await import("../index.js");
 		const plugin = await OpenAIOAuthPlugin({ client: mockClient } as never) as unknown as PluginType;
 		const { AccountManager } = await import("../lib/accounts.js");
 		const loadFromDiskSpy = vi.spyOn(AccountManager, "loadFromDisk");
+		const flushSpy = vi.spyOn(AccountManager.prototype, "flushPendingSave");
+		const disposeSpy = vi.spyOn(AccountManager.prototype, "disposeShutdownHandler");
 
 		const getAuth = async () => ({
 			type: "oauth" as const,
@@ -6157,12 +6165,62 @@ describe("OpenAIOAuthPlugin event handler edge cases", () => {
 
 		await plugin.auth.loader(getAuth, { options: {}, models: {} });
 		loadFromDiskSpy.mockClear();
+		flushSpy.mockClear();
+		disposeSpy.mockClear();
 
 		await plugin.event({
 			event: { type: "account.select", properties: { index: 1 } },
 		});
 
+		expect(flushSpy).toHaveBeenCalledTimes(1);
 		expect(loadFromDiskSpy).toHaveBeenCalledTimes(1);
+		expect(disposeSpy).toHaveBeenCalledTimes(1);
+		expect(flushSpy.mock.invocationCallOrder[0]).toBeLessThan(
+			loadFromDiskSpy.mock.invocationCallOrder[0]!,
+		);
+		expect(loadFromDiskSpy.mock.invocationCallOrder[0]).toBeLessThan(
+			disposeSpy.mock.invocationCallOrder[0]!,
+		);
+	});
+
+	it("keeps the cached manager when an account.select reload fails", async () => {
+		const mockClient = createMockClient();
+		const { OpenAIOAuthPlugin } = await import("../index.js");
+		const plugin = await OpenAIOAuthPlugin({ client: mockClient } as never) as unknown as PluginType;
+		const { AccountManager } = await import("../lib/accounts.js");
+		const loadFromDiskSpy = vi.spyOn(AccountManager, "loadFromDisk");
+		const flushSpy = vi.spyOn(AccountManager.prototype, "flushPendingSave");
+		const disposeSpy = vi.spyOn(AccountManager.prototype, "disposeShutdownHandler");
+
+		const getAuth = async () => ({
+			type: "oauth" as const,
+			access: "access-token",
+			refresh: "refresh-token",
+			expires: Date.now() + 60_000,
+			multiAccount: true,
+		});
+
+		await plugin.auth.loader(getAuth, { options: {}, models: {} });
+		loadFromDiskSpy.mockClear();
+		flushSpy.mockClear();
+		disposeSpy.mockClear();
+		loadFromDiskSpy.mockRejectedValueOnce(new Error("reload failed"));
+
+		await plugin.event({
+			event: { type: "account.select", properties: { index: 1 } },
+		});
+
+		expect(flushSpy).toHaveBeenCalledTimes(1);
+		expect(loadFromDiskSpy).toHaveBeenCalledTimes(1);
+		expect(disposeSpy).not.toHaveBeenCalled();
+
+		await plugin.event({
+			event: { type: "account.select", properties: { index: 0 } },
+		});
+
+		expect(flushSpy).toHaveBeenCalledTimes(2);
+		expect(loadFromDiskSpy).toHaveBeenCalledTimes(2);
+		expect(disposeSpy).toHaveBeenCalledTimes(1);
 	});
 
 	it("handles openai.account.select with openai provider", async () => {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1971,7 +1971,7 @@ describe("OpenAIOAuthPlugin", () => {
 		});
 
 
-		it("does not report cleared stale-state when saveAccounts fails during fix (issue #171)", async () => {
+		it("does not report cleared stale-state when its persist fails during fix (issue #171)", async () => {
 			mockStorage.accounts = [
 				{
 					refreshToken: "r1",
@@ -1985,17 +1985,55 @@ describe("OpenAIOAuthPlugin", () => {
 				},
 			];
 
-			const { saveAccounts } = await import("../lib/storage.js");
-			vi.mocked(saveAccounts).mockRejectedValueOnce(new Error("disk full"));
+			const { withAccountStorageTransaction } = await import("../lib/storage.js");
+			const originalTransaction = vi.mocked(withAccountStorageTransaction).getMockImplementation();
+			vi.mocked(withAccountStorageTransaction).mockImplementationOnce(
+				async <T>(
+					callback: (
+						loadedStorage: typeof mockStorage,
+						persist: (nextStorage: typeof mockStorage) => Promise<void>,
+					) => Promise<T>,
+				) => {
+					const loadedStorage = cloneMockStorage();
+					const persist = async (nextStorage: typeof mockStorage) => {
+						mockStorage.version = nextStorage.version;
+						mockStorage.accounts = nextStorage.accounts.map(cloneAccount);
+						mockStorage.activeIndex = nextStorage.activeIndex;
+						mockStorage.activeIndexByFamily = { ...nextStorage.activeIndexByFamily };
+					};
+					return callback(loadedStorage, persist);
+				},
+			);
+			vi.mocked(withAccountStorageTransaction).mockImplementationOnce(
+				async <T>(
+					callback: (
+						loadedStorage: typeof mockStorage,
+						persist: (nextStorage: typeof mockStorage) => Promise<void>,
+					) => Promise<T>,
+				) => {
+					const loadedStorage = cloneMockStorage();
+					const persist = async () => {
+						throw new Error("disk full");
+					};
+					return callback(loadedStorage, persist);
+				},
+			);
+			vi.mocked(withAccountStorageTransaction).mockImplementation(
+				originalTransaction,
+			);
 
 			const result = await plugin.tool["codex-doctor"].execute({ fix: true });
 
-			// The persist failed, so no "Cleared ..." message may be emitted —
-			// otherwise the user would believe the repair landed when the on-disk
-			// state still carries the stale cooldown/rate-limit block.
+			// The token credential may have been refreshed before the later stale-state
+			// transaction failed, but no "Cleared ..." stale-state fix may be emitted —
+			// otherwise the user would believe that repair landed when it did not.
 			expect(result).not.toContain("Cleared cooldown");
 			expect(result).not.toContain("stale rate-limit marker");
-			expect(result).toContain("Failed to persist refresh updates");
+			expect(result).toContain("Failed to persist stale-state repairs");
+			expect(mockStorage.accounts[0]?.coolingDownUntil).toBeGreaterThan(Date.now());
+			expect(mockStorage.accounts[0]?.rateLimitResetTimes).toEqual({
+				"gpt-5.4": expect.any(Number),
+			});
 		});
 
 		it("surfaces re-login-required when a refresh fails during fix (issue #171)", async () => {
@@ -2014,6 +2052,97 @@ describe("OpenAIOAuthPlugin", () => {
 			// A failed refresh must not be silent: the user is told to re-login.
 			expect(result).toContain("opencode auth login");
 			expect(result).toMatch(/need re-login|re-authenticate/i);
+		});
+
+		it("never reports every account healthy after all refresh verifications fail", async () => {
+			mockStorage.accounts = Array.from({ length: 8 }, (_, index) => ({
+				refreshToken: `dead-${index + 1}`,
+				email: `user${index + 1}@example.com`,
+			}));
+			const { queuedRefresh } = await import("../lib/refresh-queue.js");
+			vi.mocked(queuedRefresh).mockResolvedValue({
+				type: "failed",
+				reason: "invalid_grant",
+				message: "refresh_token_reused",
+			});
+
+			const result = (await plugin.tool["codex-doctor"].execute({ fix: true })) as string;
+
+			expect(result).toContain("healthy=0");
+			expect(result).not.toContain("healthy=8");
+			expect(result).toContain("8 account(s) failed refresh-token verification");
+			expect(result).toContain("8 account(s) need re-login");
+
+			vi.mocked(queuedRefresh).mockImplementation(async () => ({
+				type: "success" as const,
+				access: "refreshed-access",
+				refresh: "refreshed-refresh",
+				expires: Date.now() + 3_600_000,
+			}));
+		});
+
+		it("persists rotated tokens transactionally during fix and preserves concurrent state", async () => {
+			mockStorage.accounts = [
+				{
+					refreshToken: "old-refresh",
+					email: "user@example.com",
+					coolingDownUntil: Date.now() + 600_000,
+					cooldownReason: "auth-failure",
+					rateLimitResetTimes: { "gpt-5.4": Date.now() + 3_600_000 },
+				},
+			];
+			const { queuedRefresh } = await import("../lib/refresh-queue.js");
+			vi.mocked(queuedRefresh).mockResolvedValueOnce({
+				type: "success" as const,
+				access: "rotated-access",
+				refresh: "rotated-refresh",
+				expires: Date.now() + 3_600_000,
+			});
+			const { withAccountStorageTransaction } = await import("../lib/storage.js");
+			const originalTransaction = vi.mocked(withAccountStorageTransaction).getMockImplementation();
+			const persistSnapshot = async (nextStorage: typeof mockStorage) => {
+				mockStorage.version = nextStorage.version;
+				mockStorage.accounts = nextStorage.accounts.map(cloneAccount);
+				mockStorage.activeIndex = nextStorage.activeIndex;
+				mockStorage.activeIndexByFamily = { ...nextStorage.activeIndexByFamily };
+			};
+			vi.mocked(withAccountStorageTransaction)
+				// Credential transaction: the fresh snapshot carries a concurrent
+				// rate-limit update, but no concurrent cooldown.
+				.mockImplementationOnce(
+					async <T>(
+						callback: (
+							loadedStorage: typeof mockStorage,
+							persist: (nextStorage: typeof mockStorage) => Promise<void>,
+						) => Promise<T>,
+					) => {
+						const loadedStorage = cloneMockStorage();
+						loadedStorage.accounts[0]!.rateLimitResetTimes = {
+							"gpt-5.4-mini": Date.now() + 1_800_000,
+						};
+						delete loadedStorage.accounts[0]!.coolingDownUntil;
+						delete loadedStorage.accounts[0]!.cooldownReason;
+						return callback(loadedStorage, persistSnapshot);
+					},
+				);
+			vi.mocked(withAccountStorageTransaction).mockImplementation(
+				originalTransaction,
+			);
+
+			const result = (await plugin.tool["codex-doctor"].execute({ fix: true })) as string;
+
+			expect(result).toContain("Refreshed and persisted 1 account token(s)");
+			expect(mockStorage.accounts[0]?.refreshToken).toBe("rotated-refresh");
+			expect(mockStorage.accounts[0]?.accessToken).toBe("rotated-access");
+			expect(mockStorage.accounts[0]?.tokenRotatedAt).toBeGreaterThan(0);
+			// The stale repair starts from the post-credential snapshot, so it can
+			// clear the original cooldown while retaining the newer rate-limit
+			// marker. The absent concurrent cooldown was a concurrent recovery and
+			// remains cleared.
+			expect(mockStorage.accounts[0]?.rateLimitResetTimes).toEqual({
+				"gpt-5.4-mini": expect.any(Number),
+			});
+			expect(mockStorage.accounts[0]?.coolingDownUntil).toBeUndefined();
 		});
 
 		it("recovers the reporter's exact composite 3-account pool on fix (issue #171)", async () => {
@@ -2207,6 +2336,149 @@ describe("OpenAIOAuthPlugin", () => {
 			const result = await plugin.tool["codex-health"].execute();
 			expect(result).toContain("Health Check");
 			expect(result).toContain("Healthy");
+
+			// Deterministic per-token rotations keep the shared credential tests
+			// independent of this test's rotated mock storage.
+			const { queuedRefresh } = await import("../lib/refresh-queue.js");
+			vi.mocked(queuedRefresh).mockImplementation(async (token: string) => ({
+				type: "success" as const,
+				access: `${token}-access`,
+				refresh: `${token}-new`,
+				expires: Date.now() + 3_600_000,
+			}));
+		});
+
+		it("persists rotated tokens so a restart does not report refresh_token_reused", async () => {
+			mockStorage.accounts = [
+				{ refreshToken: "old-r1", email: "one@example.com" },
+				{ refreshToken: "old-r2", email: "two@example.com" },
+			];
+			const { queuedRefresh } = await import("../lib/refresh-queue.js");
+			vi.mocked(queuedRefresh).mockImplementation(async (token: string) => ({
+				type: "success" as const,
+				access: `${token}-access`,
+				refresh: `${token}-new`,
+				expires: Date.now() + 3_600_000,
+			}));
+
+			const first = await plugin.tool["codex-health"].execute();
+			expect(first).toContain("2 healthy, 0 unhealthy");
+			expect(mockStorage.accounts.map((account) => account.refreshToken)).toEqual([
+				"old-r1-new",
+				"old-r2-new",
+			]);
+			expect(mockStorage.accounts[0]?.tokenRotatedAt).toBeGreaterThan(0);
+			expect(mockStorage.accounts[1]?.tokenRotatedAt).toBeGreaterThan(0);
+
+			// A restart loads the persisted tokens. Verification rotates them again;
+			// the previous regression left `old-*` on disk, producing refresh_token_reused.
+			const second = await plugin.tool["codex-health"].execute();
+			expect(second).toContain("2 healthy, 0 unhealthy");
+			expect(mockStorage.accounts.map((account) => account.refreshToken)).toEqual([
+				"old-r1-new-new",
+				"old-r2-new-new",
+			]);
+		});
+
+		it("propagates a shared rotated token to workspace sibling records", async () => {
+			mockStorage.accounts = [
+				{
+					refreshToken: "shared-old",
+					email: "one@example.com",
+					organizationId: "org-A",
+					accountId: "org-A",
+					accountIdSource: "org",
+					expiresAt: Date.now() + 3_600_000,
+				},
+				{
+					refreshToken: "shared-old",
+					email: "two@example.com",
+					organizationId: "org-B",
+					accountId: "org-B",
+					accountIdSource: "org",
+					expiresAt: Date.now() + 3_600_000,
+				},
+			];
+			const { queuedRefresh } = await import("../lib/refresh-queue.js");
+			vi.mocked(queuedRefresh)
+				.mockResolvedValueOnce({
+					type: "success" as const,
+					access: "workspace-a-access",
+					refresh: "shared-new",
+					expires: Date.now() + 3_600_000,
+				})
+				.mockResolvedValueOnce({
+					type: "success" as const,
+					access: "workspace-b-access",
+					refresh: "shared-new",
+					expires: Date.now() + 3_600_000,
+				});
+
+			const result = await plugin.tool["codex-health"].execute();
+
+			expect(result).toContain("2 healthy, 0 unhealthy");
+			expect(queuedRefresh).toHaveBeenCalledTimes(2);
+			expect(mockStorage.accounts[0]?.refreshToken).toBe("shared-new");
+			expect(mockStorage.accounts[0]?.accessToken).toBe("workspace-a-access");
+			expect(mockStorage.accounts[1]?.refreshToken).toBe("shared-new");
+			expect(mockStorage.accounts[1]?.accessToken).toBe("workspace-b-access");
+			expect(mockStorage.accounts[1]?.expiresAt).toBeGreaterThan(Date.now());
+		});
+
+		it("skips an independently disabled account without consuming its token", async () => {
+			mockStorage.accounts = [
+				{ refreshToken: "active-old", email: "active@example.com" },
+				{ refreshToken: "disabled-old", email: "disabled@example.com", enabled: false },
+			];
+			const { queuedRefresh } = await import("../lib/refresh-queue.js");
+
+			const result = parseJsonOutput<{
+				healthyCount: number;
+				unhealthyCount: number;
+				skippedCount: number;
+				accounts: Array<{ status: string }>;
+			}>(await plugin.tool["codex-health"].execute({ format: "json" }));
+
+			expect(queuedRefresh).toHaveBeenCalledTimes(1);
+			expect(queuedRefresh).toHaveBeenCalledWith("active-old");
+			expect(result.healthyCount).toBe(1);
+			expect(result.unhealthyCount).toBe(0);
+			expect(result.skippedCount).toBe(1);
+			expect(result.accounts[1]?.status).toBe("skipped");
+			expect(mockStorage.accounts[1]?.refreshToken).toBe("disabled-old");
+		});
+
+		it("reports persistence failure instead of healthy when a rotated token cannot be saved", async () => {
+			mockStorage.accounts = [
+				{ refreshToken: "old-r1", email: "one@example.com" },
+			];
+			const { withAccountStorageTransaction } = await import("../lib/storage.js");
+			vi.mocked(withAccountStorageTransaction).mockImplementationOnce(
+				async <T>(
+					callback: (
+						loadedStorage: typeof mockStorage,
+						persist: (nextStorage: typeof mockStorage) => Promise<void>,
+					) => Promise<T>,
+				) => {
+					const loadedStorage = cloneMockStorage();
+					const persist = async () => {
+						throw new Error("disk full");
+					};
+					return callback(loadedStorage, persist);
+				},
+			);
+
+			const result = parseJsonOutput<{
+				healthyCount: number;
+				unhealthyCount: number;
+				accounts: Array<{ status: string; error?: string }>;
+			}>(await plugin.tool["codex-health"].execute({ format: "json" }));
+
+			expect(result.healthyCount).toBe(0);
+			expect(result.unhealthyCount).toBe(1);
+			expect(result.accounts[0]?.status).toBe("unhealthy");
+			expect(result.accounts[0]?.error).toContain("disk full");
+			expect(mockStorage.accounts[0]?.refreshToken).toBe("old-r1");
 		});
 
 		it("surfaces stale-state and duplicate findings (issue #171)", async () => {
@@ -2839,7 +3111,7 @@ describe("OpenAIOAuthPlugin edge cases", () => {
 		const plugin = await OpenAIOAuthPlugin({ client: mockClient } as never) as unknown as PluginType;
 
 		const result = await plugin.tool["codex-health"].execute();
-		expect(result).toContain("Error");
+		expect(result).toContain("Network error");
 		expect(result).toContain("0 healthy, 1 unhealthy");
 	});
 
@@ -2874,8 +3146,7 @@ describe("OpenAIOAuthPlugin edge cases", () => {
 		const plugin = await OpenAIOAuthPlugin({ client: mockClient } as never) as unknown as PluginType;
 
 		const result = await plugin.tool["codex-refresh"].execute();
-		expect(result).toContain("Error");
-		expect(result).toContain("Network timeout");
+		expect(result).toContain("Failed - Network timeout");
 	});
 
 	it("handles storage errors in codex-remove", async () => {

--- a/test/tools-codex-refresh.test.ts
+++ b/test/tools-codex-refresh.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ToolContext } from "../lib/tools/index.js";
 import type { AccountStorageV3 } from "../lib/storage.js";
 import { createCodexRefreshTool } from "../lib/tools/codex-refresh.js";
+import { persistRefreshResult } from "../lib/tools/refresh-account.js";
 import { resolveDisplayEmail } from "../lib/account-display.js";
 
 vi.mock("../lib/storage.js", () => ({
@@ -58,6 +59,7 @@ function buildCtx(maskEmail: boolean): ToolContext {
 		getStatusMarker: () => "[ok]",
 		cachedAccountManagerRef: { current: null },
 		accountManagerPromiseRef: { current: null },
+		reloadCachedAccountManager: async () => {},
 	};
 	return ctx as unknown as ToolContext;
 }
@@ -259,5 +261,47 @@ describe("codex-refresh tool concurrency (lost-update regression)", () => {
 		expect(concurrentStorage.accounts[0]?.tokenRotatedAt).toBe(999);
 		expect(output).toContain("Refresh token changed concurrently");
 		expect(output).toContain("0 refreshed, 1 failed");
+	});
+
+	it("does not overwrite a concurrent re-login when a sibling already holds the rotated token", async () => {
+		const concurrentStorage: AccountStorageV3 = {
+			version: 3,
+			activeIndex: 0,
+			accounts: [
+				{
+					accountId: "target",
+					refreshToken: "fresh-login-token",
+					accessToken: "fresh-login-access",
+					expiresAt: 1_800_000_000_000,
+				},
+				{
+					accountId: "sibling",
+					refreshToken: "new-refresh",
+				},
+			],
+		};
+		const persist = vi.fn(async () => {});
+		vi.mocked(withAccountStorageTransaction).mockImplementation(
+			async (handler) => handler(concurrentStorage, persist),
+		);
+
+		const result = await persistRefreshResult(
+			0,
+			{ accountId: "target", refreshToken: "old-refresh" },
+			{
+				type: "success",
+				access: "stale-rotation-access",
+				refresh: "new-refresh",
+				expires: 1_700_000_000_000,
+			},
+		);
+
+		expect(result.persisted).toBe(false);
+		expect(result.persistError).toContain("changed concurrently");
+		expect(persist).not.toHaveBeenCalled();
+		expect(concurrentStorage.accounts[0]).toMatchObject({
+			refreshToken: "fresh-login-token",
+			accessToken: "fresh-login-access",
+		});
 	});
 });

--- a/test/tools-codex-refresh.test.ts
+++ b/test/tools-codex-refresh.test.ts
@@ -74,6 +74,17 @@ describe("codex-refresh tool masking", () => {
 			activeIndex: 0,
 			accounts: [{ email: "user@example.com", refreshToken: "r1" }],
 		} as never);
+		vi.mocked(withAccountStorageTransaction).mockImplementation(
+			async (handler) =>
+				handler(
+					{
+						version: 3,
+						activeIndex: 0,
+						accounts: [{ email: "user@example.com", refreshToken: "r1" }],
+					} as never,
+					async () => {},
+				),
+		);
 
 		const tool = createCodexRefreshTool(buildCtx(true));
 		const output = (await tool.execute({}, {} as never)) as string;
@@ -88,6 +99,17 @@ describe("codex-refresh tool masking", () => {
 			activeIndex: 0,
 			accounts: [{ email: "user@example.com", refreshToken: "r1" }],
 		} as never);
+		vi.mocked(withAccountStorageTransaction).mockImplementation(
+			async (handler) =>
+				handler(
+					{
+						version: 3,
+						activeIndex: 0,
+						accounts: [{ email: "user@example.com", refreshToken: "r1" }],
+					} as never,
+					async () => {},
+				),
+		);
 
 		const tool = createCodexRefreshTool(buildCtx(false));
 		const output = (await tool.execute({}, {} as never)) as string;
@@ -225,14 +247,17 @@ describe("codex-refresh tool concurrency (lost-update regression)", () => {
 		);
 
 		const tool = createCodexRefreshTool(buildCtx(false));
-		await tool.execute({}, {} as never);
-
-		expect(persisted).toBeDefined();
-		const persistedAccount = persisted!.accounts[0]!;
+		const output = (await tool.execute({}, {} as never)) as string;
 
 		// The stale outcome (keyed on "old-refresh") must NOT overwrite the
-		// externally-rotated token -- we cannot know which chain is live.
-		expect(persistedAccount.refreshToken).toBe("externally-rotated-refresh");
-		expect(persistedAccount.tokenRotatedAt).toBe(999);
+		// externally-rotated token -- we cannot know which chain is live. The
+		// transaction rejects without persisting, and the tool reports a failure.
+		expect(persisted).toBeUndefined();
+		expect(concurrentStorage.accounts[0]?.refreshToken).toBe(
+			"externally-rotated-refresh",
+		);
+		expect(concurrentStorage.accounts[0]?.tokenRotatedAt).toBe(999);
+		expect(output).toContain("Refresh token changed concurrently");
+		expect(output).toContain("0 refreshed, 1 failed");
 	});
 });


### PR DESCRIPTION
## Summary

- Persist rotated, single-use OAuth refresh tokens before reporting account health.
- Share transactional refresh persistence across health, refresh, and doctor tools.
- Keep doctor diagnostics and auto-switching correct when refresh results or storage change concurrently.

## Testing

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm test`
- [x] `npm run build`

## Compliance Confirmation

- [x] This change stays within the repository scope and OpenAI Terms of Service expectations.
- [x] This change uses official authentication flows only and does not add bypass, scraping, or credential-sharing behavior.
- [x] I updated tests and documentation when the change affected users, maintainers, or repository behavior.

## Notes

- Linked issue: none.
- Follow-up work or rollout notes: includes regressions for token rotation persistence, concurrent re-login protection, doctor mixed verification results, and storage reordering.\n\n<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a refresh-verification-failure indicator that blocks affected accounts and triggers an immediate re-authentication next action.
  - Health/refresh reporting now distinguishes refreshed, skipped (disabled), and failed accounts, including skipped-count reporting in JSON/UI.

- **Bug Fixes**
  - Improved refresh-token rotation persistence across related workspace records while preserving concurrent updates during repair/fix flows.
  - Doctor/health/refresh now reload cached account-manager state after refresh so results match live outcomes.

- **Tests**
  - Expanded transactional persistence and refresh-verification edge-case coverage; refined concurrency and exact error-message assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

this pr persists rotated oauth refresh tokens before reporting account health. the main changes are:

- shared transactional refresh persistence across health, refresh, and doctor tools.
- cache reloads after token storage changes.
- refreshed doctor diagnostics and identity-based auto-switching.
- expanded coverage for token safety and concurrent storage changes.

<h3>Confidence Score: 5/5</h3>

the latest fixes look safe to merge.

- concurrent re-login credentials are preserved.
- doctor results are rebuilt from current storage.
- account switching no longer writes a stale array index.
- no additional blocking issue qualifies for this follow-up round.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/tools/refresh-account.ts | adds shared transactional refresh persistence with concurrent credential-change protection. |
| lib/tools/codex-doctor.ts | reloads diagnostics after verification and resolves auto-switch targets by identity. |
| lib/tools/codex-health.ts | persists rotated tokens before reporting health and reports disabled accounts separately. |
| lib/tools/codex-refresh.ts | moves manual refreshes onto the shared persistence path. |
| index.ts | adds cache reload logic that flushes pending saves before reading updated storage. |

<sub>Reviews (4): Last reviewed commit: ["fix: reuse safe account manager reload"](https://github.com/ndycode/oc-codex-multi-auth/commit/9e04513b6d509515d4bf1ffc263535f67c99fe25) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46575136)</sub>

**Context used:**

- Context used - speak in lowercase, concise sentences. act like th... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->