### PR TITLE
fix: render styled OAuth success screen

### DIFF
--- a/lib/auth/server.ts
+++ b/lib/auth/server.ts
@@ -1,7 +1,8 @@
 import http from "node:http";
+import { randomBytes } from "node:crypto";
 import type { OAuthServerInfo } from "../types.js";
 import { logError, logWarn } from "../logger.js";
-import { oauthSuccessHtml } from "../oauth-success.js";
+import { renderOAuthSuccessHtml } from "../oauth-success.js";
 import {
 	OAUTH_CALLBACK_BIND_HOSTS,
 	OAUTH_CALLBACK_BIND_URL,
@@ -53,12 +54,18 @@ export async function startLocalOAuthServer({ state }: { state: string }): Promi
 				res.end("Missing authorization code");
 				return;
 			}
+			const styleNonce = randomBytes(18).toString("base64");
 			res.statusCode = 200;
 			res.setHeader("Content-Type", "text/html; charset=utf-8");
+			res.setHeader("Cache-Control", "no-store");
+			res.setHeader("Referrer-Policy", "no-referrer");
 			res.setHeader("X-Frame-Options", "DENY");
 			res.setHeader("X-Content-Type-Options", "nosniff");
-			res.setHeader("Content-Security-Policy", "default-src 'self'; script-src 'none'");
-			res.end(oauthSuccessHtml);
+			res.setHeader(
+				"Content-Security-Policy",
+				`default-src 'none'; style-src 'nonce-${styleNonce}'; script-src 'none'; frame-ancestors 'none'; base-uri 'none'; form-action 'none'`,
+			);
+			res.end(renderOAuthSuccessHtml(styleNonce));
 			lastCode = code;
 			for (const server of allServers) {
 				server._lastCode = code;

--- a/lib/oauth-success.ts
+++ b/lib/oauth-success.ts
@@ -1,713 +1,209 @@
-export const oauthSuccessHtml = String.raw`<!DOCTYPE html>
+export function renderOAuthSuccessHtml(styleNonce: string): string {
+	return `<!doctype html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>OpenCode - Authentication Successful</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;1,100;1,200;1,300;1,400;1,500;1,600;1,700&display=swap" rel="stylesheet">
-    <style>
-        * {
-            margin: 0;
-            padding: 0;
-            box-sizing: border-box;
-        }
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<meta name="color-scheme" content="dark">
+	<title>OpenCode - Authentication complete</title>
+	<style nonce="${styleNonce}">
+		:root {
+			color-scheme: dark;
+			font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+			font-synthesis: none;
+		}
 
-        body {
-            font-family: "IBM Plex Mono", monospace;
-            font-weight: 400;
-            background: #0a0a0a;
-            color: #B7B1B1;
-            overflow: hidden;
-            height: 100vh;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            position: relative;
-        }
+		* {
+			box-sizing: border-box;
+		}
 
-        /* Matrix rain background */
-        .matrix {
-            position: fixed;
-            top: 0;
-            left: 0;
-            width: 100%;
-            height: 100%;
-            z-index: 1;
-            opacity: 0.35;
-        }
+		body {
+			min-width: 320px;
+			min-height: 100vh;
+			margin: 0;
+			display: grid;
+			place-items: center;
+			padding: 32px 20px;
+			background:
+				radial-gradient(circle at 50% 0%, rgba(42, 195, 126, 0.12), transparent 38rem),
+				#080b0a;
+			color: #f2f5f3;
+		}
 
-        /* Scan lines effect */
-        .scanline {
-            position: fixed;
-            top: 0;
-            left: 0;
-            width: 100%;
-            height: 100%;
-            background: linear-gradient(
-                transparent 50%,
-                rgba(0, 0, 0, 0.1) 50%
-            );
-            background-size: 100% 4px;
-            z-index: 2;
-            pointer-events: none;
-            animation: scan 8s linear infinite;
-        }
+		main {
+			width: min(100%, 540px);
+		}
 
-        @keyframes scan {
-            0% { transform: translateY(0); }
-            100% { transform: translateY(4px); }
-        }
+		.brand {
+			display: flex;
+			align-items: center;
+			gap: 12px;
+			margin: 0 0 18px 4px;
+			color: #aab5af;
+			font-size: 13px;
+			font-weight: 600;
+			letter-spacing: 0.08em;
+			text-transform: uppercase;
+		}
 
-        /* Vignette effect */
-        .vignette {
-            position: fixed;
-            top: 0;
-            left: 0;
-            width: 100%;
-            height: 100%;
-            box-shadow: inset 0 0 200px rgba(0, 0, 0, 0.8);
-            z-index: 2;
-            pointer-events: none;
-        }
+		.brand-mark {
+			width: 24px;
+			height: 24px;
+			display: grid;
+			grid-template-columns: repeat(2, 1fr);
+			gap: 3px;
+			padding: 3px;
+			border: 1px solid #405048;
+			border-radius: 6px;
+		}
 
-        .container {
-            width: 90%;
-            max-width: 650px;
-            text-align: center;
-            z-index: 10;
-            position: relative;
-            animation: fadeIn 0.8s ease-out;
-        }
+		.brand-mark span {
+			background: #d9e1dd;
+			border-radius: 1px;
+		}
 
-        @keyframes fadeIn {
-            from {
-                opacity: 0;
-                transform: scale(0.95);
-            }
-            to {
-                opacity: 1;
-                transform: scale(1);
-            }
-        }
+		.card {
+			position: relative;
+			overflow: hidden;
+			padding: 44px;
+			border: 1px solid #26312c;
+			border-radius: 20px;
+			background: linear-gradient(145deg, rgba(22, 28, 25, 0.98), rgba(13, 17, 15, 0.98));
+			box-shadow: 0 24px 80px rgba(0, 0, 0, 0.45);
+		}
 
-        .logo {
-            margin-bottom: 60px;
-            opacity: 0;
-            animation: logoEntrance 1.2s cubic-bezier(0.34, 1.56, 0.64, 1) 0.3s forwards;
-            position: relative;
-        }
+		.card::before {
+			content: "";
+			position: absolute;
+			inset: 0 0 auto;
+			height: 1px;
+			background: linear-gradient(90deg, transparent, rgba(86, 224, 157, 0.7), transparent);
+		}
 
-        @keyframes logoEntrance {
-            0% {
-                opacity: 0;
-                transform: translateY(-50px) rotateX(90deg);
-            }
-            100% {
-                opacity: 1;
-                transform: translateY(0) rotateX(0);
-            }
-        }
+		.success-icon {
+			width: 58px;
+			height: 58px;
+			display: grid;
+			place-items: center;
+			margin-bottom: 28px;
+			border: 1px solid rgba(86, 224, 157, 0.45);
+			border-radius: 16px;
+			background: rgba(42, 195, 126, 0.1);
+			color: #56e09d;
+			box-shadow: inset 0 0 28px rgba(42, 195, 126, 0.08);
+		}
 
-        .logo svg {
-            width: 300px;
-            height: auto;
-            filter: drop-shadow(0 0 30px rgba(241, 236, 236, 0.3));
-            animation: pulse 3s ease-in-out infinite;
-        }
+		.success-icon svg {
+			width: 28px;
+			height: 28px;
+		}
 
-        @keyframes pulse {
-            0%, 100% {
-                filter: drop-shadow(0 0 30px rgba(241, 236, 236, 0.3));
-            }
-            50% {
-                filter: drop-shadow(0 0 50px rgba(241, 236, 236, 0.5));
-            }
-        }
+		h1 {
+			margin: 0;
+			font-family: ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+			font-size: clamp(28px, 6vw, 38px);
+			font-weight: 650;
+			letter-spacing: -0.035em;
+			line-height: 1.12;
+		}
 
-        /* Glowing orb behind logo */
-        .logo::before {
-            content: '';
-            position: absolute;
-            top: 50%;
-            left: 50%;
-            transform: translate(-50%, -50%);
-            width: 200px;
-            height: 200px;
-            background: radial-gradient(circle, rgba(241, 236, 236, 0.1) 0%, transparent 70%);
-            border-radius: 50%;
-            animation: orbPulse 4s ease-in-out infinite;
-            z-index: -1;
-        }
+		.lead {
+			margin: 16px 0 0;
+			color: #aeb8b3;
+			font-family: ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+			font-size: 17px;
+			line-height: 1.6;
+		}
 
-        @keyframes orbPulse {
-            0%, 100% {
-                transform: translate(-50%, -50%) scale(1);
-                opacity: 0.3;
-            }
-            50% {
-                transform: translate(-50%, -50%) scale(1.2);
-                opacity: 0.6;
-            }
-        }
+		.status {
+			display: flex;
+			align-items: center;
+			gap: 12px;
+			margin-top: 30px;
+			padding: 15px 16px;
+			border: 1px solid #29362f;
+			border-radius: 12px;
+			background: #0b100d;
+			color: #c9d2cd;
+			font-size: 13px;
+			line-height: 1.5;
+		}
 
-        .terminal-window {
-            background: rgba(26, 26, 26, 0.95);
-            backdrop-filter: blur(10px);
-            -webkit-backdrop-filter: blur(10px);
-            border: 1px solid rgba(75, 70, 70, 0.3);
-            border-radius: 12px;
-            margin: 30px 0;
-            opacity: 0;
-            animation: boxEntrance 0.8s cubic-bezier(0.34, 1.56, 0.64, 1) 0.6s forwards;
-            position: relative;
-            overflow: hidden;
-            box-shadow:
-                0 0 60px rgba(0, 0, 0, 0.5),
-                inset 0 1px 0 rgba(255, 255, 255, 0.05);
-        }
+		.status-dot {
+			width: 8px;
+			height: 8px;
+			flex: 0 0 auto;
+			border-radius: 50%;
+			background: #56e09d;
+			box-shadow: 0 0 0 4px rgba(86, 224, 157, 0.1);
+		}
 
-        .terminal-header {
-            background: rgba(15, 15, 15, 0.9);
-            padding: 14px 18px;
-            display: flex;
-            align-items: center;
-            gap: 8px;
-            border-bottom: 1px solid rgba(75, 70, 70, 0.3);
-            position: relative;
-        }
+		.next-step {
+			margin: 24px 0 0;
+			color: #7f8c85;
+			font-size: 13px;
+			line-height: 1.6;
+		}
 
-        .terminal-button {
-            width: 12px;
-            height: 12px;
-            border-radius: 50%;
-            transition: transform 0.2s;
-        }
+		.next-step strong {
+			color: #b9c3be;
+			font-weight: 600;
+		}
 
-        .terminal-button:hover {
-            transform: scale(1.2);
-        }
+		@media (max-width: 520px) {
+			body {
+				padding: 24px 16px;
+			}
 
-        .terminal-button.red {
-            background: #ff5f56;
-            box-shadow: 0 0 10px rgba(255, 95, 86, 0.3);
-            animation: pulse 2s infinite;
-        }
+			.card {
+				padding: 32px 24px;
+				border-radius: 16px;
+			}
 
-        .terminal-button.yellow {
-            background: #ffbd2e;
-            box-shadow: 0 0 10px rgba(255, 189, 46, 0.3);
-            animation: pulse 2s infinite 0.3s;
-        }
+			.success-icon {
+				width: 52px;
+				height: 52px;
+				margin-bottom: 24px;
+			}
+		}
 
-        .terminal-button.green {
-            background: #27c93f;
-            box-shadow: 0 0 10px rgba(39, 201, 63, 0.3);
-            animation: pulse 2s infinite 0.6s;
-        }
-
-        @keyframes pulse {
-            0%, 100% { opacity: 1; }
-            50% { opacity: 0.6; }
-        }
-
-        .terminal-title {
-            flex: 1;
-            text-align: center;
-            font-size: 12px;
-            color: #6a6565;
-            opacity: 0.8;
-            letter-spacing: 0.5px;
-        }
-
-        .status-box {
-            padding: 50px 40px;
-            position: relative;
-        }
-
-        @keyframes boxEntrance {
-            from {
-                opacity: 0;
-                transform: translateY(30px);
-            }
-            to {
-                opacity: 1;
-                transform: translateY(0);
-            }
-        }
-
-        /* Animated border gradient */
-        .terminal-window::before {
-            content: '';
-            position: absolute;
-            top: -2px;
-            left: -2px;
-            right: -2px;
-            bottom: -2px;
-            background: linear-gradient(
-                45deg,
-                transparent,
-                rgba(241, 236, 236, 0.1),
-                transparent,
-                rgba(241, 236, 236, 0.1)
-            );
-            background-size: 400% 400%;
-            border-radius: 12px;
-            z-index: -1;
-            animation: gradientShift 8s ease infinite;
-        }
-
-        @keyframes gradientShift {
-            0%, 100% { background-position: 0% 50%; }
-            50% { background-position: 100% 50%; }
-        }
-
-        .checkmark-container {
-            width: 100px;
-            height: 100px;
-            margin: 0 auto 40px;
-            position: relative;
-        }
-
-        .checkmark-circle {
-            width: 100px;
-            height: 100px;
-            border-radius: 50%;
-            border: 4px solid transparent;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            position: relative;
-            animation: circleAppear 0.6s ease-out 1s both;
-        }
-
-        @keyframes circleAppear {
-            from {
-                transform: scale(0) rotate(-180deg);
-                border-color: transparent;
-            }
-            to {
-                transform: scale(1) rotate(0);
-                border-color: #4B4646;
-            }
-        }
-
-        /* Spinning rings around checkmark */
-        .checkmark-circle::before,
-        .checkmark-circle::after {
-            content: '';
-            position: absolute;
-            width: 120%;
-            height: 120%;
-            border: 2px solid transparent;
-            border-top-color: rgba(241, 236, 236, 0.2);
-            border-radius: 50%;
-            animation: rotate 3s linear infinite;
-        }
-
-        .checkmark-circle::after {
-            width: 140%;
-            height: 140%;
-            border-top-color: rgba(183, 177, 177, 0.1);
-            animation: rotate 4s linear infinite reverse;
-        }
-
-        @keyframes rotate {
-            to { transform: rotate(360deg); }
-        }
-
-        .checkmark {
-            width: 35px;
-            height: 18px;
-            border-left: 5px solid #F1ECEC;
-            border-bottom: 5px solid #F1ECEC;
-            transform: rotate(-45deg) scale(0);
-            animation: checkmarkDraw 0.5s cubic-bezier(0.65, 0, 0.45, 1) 1.3s forwards;
-            filter: drop-shadow(0 0 10px rgba(241, 236, 236, 0.5));
-        }
-
-        @keyframes checkmarkDraw {
-            0% {
-                transform: rotate(-45deg) scale(0);
-            }
-            50% {
-                transform: rotate(-45deg) scale(1.1);
-            }
-            100% {
-                transform: rotate(-45deg) scale(1);
-            }
-        }
-
-        .title {
-            font-size: 32px;
-            color: #00ff41;
-            margin-bottom: 20px;
-            font-weight: 500;
-            letter-spacing: 1px;
-            text-shadow: 0 0 20px rgba(0, 255, 65, 0.5);
-            opacity: 0;
-            animation: fadeInUp 0.6s ease-out 1.8s forwards;
-        }
-
-        @keyframes fadeInUp {
-            from {
-                opacity: 0;
-                transform: translateY(20px);
-            }
-            to {
-                opacity: 1;
-                transform: translateY(0);
-            }
-        }
-
-        .message {
-            font-size: 16px;
-            color: #9a9595;
-            line-height: 1.8;
-            margin-bottom: 30px;
-            opacity: 0;
-            animation: fadeInUp 0.6s ease-out 2s forwards;
-        }
-
-        .terminal-output {
-            background: rgba(10, 10, 10, 0.6);
-            border: 1px solid rgba(75, 70, 70, 0.2);
-            border-radius: 8px;
-            padding: 25px;
-            text-align: left;
-            font-size: 14px;
-            line-height: 2;
-            margin-top: 25px;
-            position: relative;
-            overflow: hidden;
-        }
-
-        /* Terminal typing effect */
-        .terminal-output::before {
-            content: '';
-            position: absolute;
-            top: 0;
-            left: 0;
-            width: 100%;
-            height: 2px;
-            background: linear-gradient(90deg, transparent, #4B4646, transparent);
-            animation: scanProgress 2s ease-out 2.2s forwards;
-        }
-
-        @keyframes scanProgress {
-            from {
-                transform: translateX(-100%);
-            }
-            to {
-                transform: translateX(100%);
-            }
-        }
-
-        .terminal-line {
-            opacity: 0;
-            transform: translateX(-20px);
-            animation: terminalType 0.4s ease-out forwards;
-            display: flex;
-            align-items: center;
-            gap: 12px;
-        }
-
-        .terminal-line:nth-child(1) { animation-delay: 2.2s; }
-        .terminal-line:nth-child(2) { animation-delay: 2.4s; }
-        .terminal-line:nth-child(3) { animation-delay: 2.6s; }
-        .terminal-line:nth-child(4) { animation-delay: 2.8s; }
-
-        @keyframes terminalType {
-            to {
-                opacity: 1;
-                transform: translateX(0);
-            }
-        }
-
-        .prompt {
-            color: #6a6565;
-            font-weight: 500;
-        }
-
-        .success {
-            color: #B7B1B1;
-        }
-
-        .terminal-line::after {
-            content: '';
-            flex: 1;
-            height: 1px;
-            background: linear-gradient(90deg, rgba(75, 70, 70, 0.3), transparent);
-        }
-
-        .footer {
-            margin-top: 40px;
-            font-size: 14px;
-            color: #6a6565;
-            opacity: 0;
-            animation: fadeInUp 0.6s ease-out 3.2s forwards;
-            text-shadow: 0 0 10px rgba(106, 101, 101, 0.5);
-        }
-
-        .cursor {
-            display: inline-block;
-            width: 2px;
-            height: 16px;
-            background: #8a8585;
-            margin-left: 6px;
-            animation: blink 1s infinite;
-            box-shadow: 0 0 8px #8a8585;
-        }
-
-        @keyframes blink {
-            0%, 49% { opacity: 1; }
-            50%, 100% { opacity: 0; }
-        }
-
-        /* Floating particles */
-        .particle {
-            position: fixed;
-            width: 2px;
-            height: 2px;
-            background: rgba(183, 177, 177, 0.3);
-            border-radius: 50%;
-            pointer-events: none;
-            z-index: 5;
-            animation: float 8s linear infinite;
-        }
-
-        @keyframes float {
-            0% {
-                transform: translateY(100vh) translateX(0) scale(0);
-                opacity: 0;
-            }
-            10% {
-                opacity: 1;
-                transform: translateY(90vh) translateX(10px) scale(1);
-            }
-            90% {
-                opacity: 1;
-            }
-            100% {
-                transform: translateY(-10vh) translateX(-10px) scale(0);
-                opacity: 0;
-            }
-        }
-
-        /* Success glow effect */
-        @keyframes successGlow {
-            0%, 100% {
-                box-shadow:
-                    0 0 60px rgba(0, 0, 0, 0.5),
-                    inset 0 1px 0 rgba(255, 255, 255, 0.05);
-            }
-            50% {
-                box-shadow:
-                    0 0 80px rgba(241, 236, 236, 0.1),
-                    inset 0 1px 0 rgba(255, 255, 255, 0.05);
-            }
-        }
-
-        .terminal-window {
-            animation:
-                boxEntrance 0.8s cubic-bezier(0.34, 1.56, 0.64, 1) 0.6s forwards,
-                successGlow 4s ease-in-out 2s infinite;
-        }
-    </style>
+		@media (prefers-reduced-motion: reduce) {
+			*, *::before, *::after {
+				scroll-behavior: auto !important;
+				animation-duration: 0.01ms !important;
+				animation-iteration-count: 1 !important;
+			}
+		}
+	</style>
 </head>
 <body>
-    <canvas class="matrix" id="matrix"></canvas>
-    <div class="scanline"></div>
-    <div class="vignette"></div>
+	<main>
+		<div class="brand" aria-label="OpenCode">
+			<span class="brand-mark" aria-hidden="true"><span></span><span></span><span></span><span></span></span>
+			<span>OpenCode</span>
+		</div>
 
-    <div class="container">
-        <div class="logo">
-            <svg width="300" height="54" viewBox="0 0 234 42" fill="none" xmlns="http://www.w3.org/2000/svg">
-                <path d="M18 30H6V18H18V30Z" fill="#4B4646"/>
-                <path d="M18 12H6V30H18V12ZM24 36H0V6H24V36Z" fill="#B7B1B1"/>
-                <path d="M48 30H36V18H48V30Z" fill="#4B4646"/>
-                <path d="M36 30H48V12H36V30ZM54 36H36V42H30V6H54V36Z" fill="#B7B1B1"/>
-                <path d="M84 24V30H66V24H84Z" fill="#4B4646"/>
-                <path d="M84 24H66V30H84V36H60V6H84V24ZM66 18H78V12H66V18Z" fill="#B7B1B1"/>
-                <path d="M108 36H96V18H108V36Z" fill="#4B4646"/>
-                <path d="M108 12H96V36H90V6H108V12ZM114 36H108V12H114V36Z" fill="#B7B1B1"/>
-                <path d="M144 30H126V18H144V30Z" fill="#4B4646"/>
-                <path d="M144 12H126V30H144V36H120V6H144V12Z" fill="#F1ECEC"/>
-                <path d="M168 30H156V18H168V30Z" fill="#4B4646"/>
-                <path d="M168 12H156V30H168V12ZM174 36H150V6H174V36Z" fill="#F1ECEC"/>
-                <path d="M198 30H186V18H198V30Z" fill="#4B4646"/>
-                <path d="M198 12H186V30H198V12ZM204 36H180V6H198V0H204V36Z" fill="#F1ECEC"/>
-                <path d="M234 24V30H216V24H234Z" fill="#4B4646"/>
-                <path d="M216 12V18H228V12H216ZM234 24H216V30H234V36H210V6H234V24Z" fill="#F1ECEC"/>
-            </svg>
-        </div>
+		<section class="card" aria-labelledby="success-title">
+			<div class="success-icon" aria-hidden="true">
+				<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+					<path d="M5 12.5 9.25 17 19 7" stroke="currentColor" stroke-width="2.25" stroke-linecap="round" stroke-linejoin="round"/>
+				</svg>
+			</div>
 
-        <div class="terminal-window">
-            <div class="terminal-header">
-                <div class="terminal-button red"></div>
-                <div class="terminal-button yellow"></div>
-                <div class="terminal-button green"></div>
-                <div class="terminal-title">oc-codex-multi-auth — OAuth Authentication</div>
-            </div>
+			<h1 id="success-title">Authentication complete</h1>
+			<p class="lead">Your OpenAI account is connected securely and ready to use with OpenCode.</p>
 
-            <div class="status-box">
-                <div class="checkmark-container">
-                    <div class="checkmark-circle">
-                        <div class="checkmark"></div>
-                    </div>
-                </div>
+			<div class="status" role="status">
+				<span class="status-dot" aria-hidden="true"></span>
+				<span>Credentials encrypted and stored</span>
+			</div>
 
-                <div class="title">ACCESS GRANTED</div>
-                <div class="message">
-                    OpenAI ChatGPT authentication successful<br>
-                    Your credentials have been securely stored
-                </div>
-
-                <div class="terminal-output">
-                    <div class="terminal-line">
-                        <span class="prompt">▸</span>
-                        <span class="success">Initializing OAuth handshake...</span>
-                    </div>
-                    <div class="terminal-line">
-                        <span class="prompt">▸</span>
-                        <span class="success">Token exchange verified</span>
-                    </div>
-                    <div class="terminal-line">
-                        <span class="prompt">▸</span>
-                        <span class="success">Credentials encrypted & stored</span>
-                    </div>
-                    <div class="terminal-line">
-                        <span class="prompt">✓</span>
-                        <span class="success">OpenCode ready for deployment</span>
-                    </div>
-                </div>
-            </div>
-        </div>
-
-        <div class="footer">
-            Return to your terminal to continue<span class="cursor"></span>
-        </div>
-    </div>
-
-    <script>
-        // Enhanced Matrix rain effect with mouse interaction
-        const canvas = document.getElementById('matrix');
-        const ctx = canvas.getContext('2d');
-
-        canvas.width = window.innerWidth;
-        canvas.height = window.innerHeight;
-
-        // Mix of characters including OpenCode themed ones
-        const chars = 'OPENCODE▸✓▹▸◂◃◄►◀▶←→↑↓⟨⟩∧∨∩∪⊂⊃⊆⊇∈∉∀∃∄∅∞≡≠≤≥±∓⊕⊗⊙01';
-        const fontSize = 16;
-        const columns = Math.floor(canvas.width / fontSize);
-
-        const drops = Array(columns).fill(1);
-        const speeds = Array(columns).fill(0).map(() => Math.random() * 0.5 + 0.5);
-
-        // Track mouse position
-        let mouseX = -1000;
-        let mouseY = -1000;
-
-        canvas.addEventListener('mousemove', (e) => {
-            mouseX = e.clientX;
-            mouseY = e.clientY;
-        });
-
-        canvas.addEventListener('mouseleave', () => {
-            mouseX = -1000;
-            mouseY = -1000;
-        });
-
-        function drawMatrix() {
-            ctx.fillStyle = 'rgba(10, 10, 10, 0.08)';
-            ctx.fillRect(0, 0, canvas.width, canvas.height);
-
-            ctx.font = fontSize + 'px "IBM Plex Mono"';
-
-            for (let i = 0; i < drops.length; i++) {
-                const text = chars[Math.floor(Math.random() * chars.length)];
-                const x = i * fontSize;
-                const y = drops[i] * fontSize;
-
-                // Check distance from mouse
-                const distanceFromMouse = Math.sqrt(
-                    Math.pow(x - mouseX, 2) + Math.pow(y - mouseY, 2)
-                );
-
-                const hoverRadius = 80;
-                const isNearMouse = distanceFromMouse < hoverRadius;
-
-                if (isNearMouse) {
-                    // Matrix green color when near mouse
-                    const intensity = 1 - (distanceFromMouse / hoverRadius);
-                    ctx.fillStyle = \`rgba(0, 255, 65, \${intensity * 0.95})\`;
-                    ctx.shadowBlur = 20 * intensity;
-                    ctx.shadowColor = '#00ff41';
-                } else {
-                    // Bright white gradient by default
-                    const gradient = ctx.createLinearGradient(0, y - fontSize * 10, 0, y);
-                    gradient.addColorStop(0, 'rgba(200, 200, 200, 0)');
-                    gradient.addColorStop(0.5, 'rgba(241, 236, 236, 0.8)');
-                    gradient.addColorStop(1, 'rgba(255, 255, 255, 1)');
-                    ctx.fillStyle = gradient;
-                    ctx.shadowBlur = 0;
-                }
-
-                ctx.fillText(text, x, y);
-
-                // Randomly reset drops
-                if (drops[i] * fontSize > canvas.height && Math.random() > 0.98) {
-                    drops[i] = 0;
-                    speeds[i] = Math.random() * 0.5 + 0.5;
-                }
-
-                drops[i] += speeds[i];
-            }
-
-            // Reset shadow for next frame
-            ctx.shadowBlur = 0;
-        }
-
-        setInterval(drawMatrix, 40);
-
-        // Create floating particles
-        function createParticle() {
-            const particle = document.createElement('div');
-            particle.className = 'particle';
-            particle.style.left = Math.random() * 100 + '%';
-            particle.style.animationDelay = Math.random() * 8 + 's';
-            particle.style.animationDuration = (Math.random() * 4 + 6) + 's';
-            document.body.appendChild(particle);
-
-            setTimeout(() => particle.remove(), 10000);
-        }
-
-        // Generate particles periodically
-        for (let i = 0; i < 20; i++) {
-            setTimeout(createParticle, i * 400);
-        }
-
-        setInterval(() => {
-            if (Math.random() > 0.7) createParticle();
-        }, 2000);
-
-        // Resize handler
-        window.addEventListener('resize', () => {
-            canvas.width = window.innerWidth;
-            canvas.height = window.innerHeight;
-        });
-
-        // Add subtle mouse parallax effect
-        document.addEventListener('mousemove', (e) => {
-            const moveX = (e.clientX - window.innerWidth / 2) / 50;
-            const moveY = (e.clientY - window.innerHeight / 2) / 50;
-
-            document.querySelector('.container').style.transform =
-                \`translate(\${moveX}px, \${moveY}px)\`;
-        });
-    </script>
+			<p class="next-step"><strong>You can close this tab.</strong> Return to your terminal to continue.</p>
+		</section>
+	</main>
 </body>
-</html>
-`;
+</html>`;
+}
+
+// Retained for the standalone HTML artifact generated by the package build.
+export const oauthSuccessHtml = renderOAuthSuccessHtml("");

--- a/lib/oauth-success.ts
+++ b/lib/oauth-success.ts
@@ -36,30 +36,13 @@ export function renderOAuthSuccessHtml(styleNonce: string): string {
 
 		.brand {
 			display: flex;
-			align-items: center;
-			gap: 12px;
-			margin: 0 0 18px 4px;
-			color: #aab5af;
-			font-size: 13px;
-			font-weight: 600;
-			letter-spacing: 0.08em;
-			text-transform: uppercase;
+			margin: 0 0 24px 0;
+			justify-content: center;
 		}
 
-		.brand-mark {
-			width: 24px;
-			height: 24px;
-			display: grid;
-			grid-template-columns: repeat(2, 1fr);
-			gap: 3px;
-			padding: 3px;
-			border: 1px solid #405048;
-			border-radius: 6px;
-		}
-
-		.brand-mark span {
-			background: #d9e1dd;
-			border-radius: 1px;
+		.brand svg {
+			height: 22px;
+			width: auto;
 		}
 
 		.card {
@@ -179,8 +162,24 @@ export function renderOAuthSuccessHtml(styleNonce: string): string {
 <body>
 	<main>
 		<div class="brand" aria-label="OpenCode">
-			<span class="brand-mark" aria-hidden="true"><span></span><span></span><span></span><span></span></span>
-			<span>OpenCode</span>
+			<svg width="234" height="42" viewBox="0 0 234 42" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+				<path d="M18 30H6V18H18V30Z" fill="#4B4646"/>
+				<path d="M18 12H6V30H18V12ZM24 36H0V6H24V36Z" fill="#B7B1B1"/>
+				<path d="M48 30H36V18H48V30Z" fill="#4B4646"/>
+				<path d="M36 30H48V12H36V30ZM54 36H36V42H30V6H54V36Z" fill="#B7B1B1"/>
+				<path d="M84 24V30H66V24H84Z" fill="#4B4646"/>
+				<path d="M84 24H66V30H84V36H60V6H84V24ZM66 18H78V12H66V18Z" fill="#B7B1B1"/>
+				<path d="M108 36H96V18H108V36Z" fill="#4B4646"/>
+				<path d="M108 12H96V36H90V6H108V12ZM114 36H108V12H114V36Z" fill="#B7B1B1"/>
+				<path d="M144 30H126V18H144V30Z" fill="#4B4646"/>
+				<path d="M144 12H126V30H144V36H120V6H144V12Z" fill="#F1ECEC"/>
+				<path d="M168 30H156V18H168V30Z" fill="#4B4646"/>
+				<path d="M168 12H156V30H168V12ZM174 36H150V6H174V36Z" fill="#F1ECEC"/>
+				<path d="M198 30H186V18H198V30Z" fill="#4B4646"/>
+				<path d="M198 12H186V30H198V12ZM204 36H180V6H198V0H204V36Z" fill="#F1ECEC"/>
+				<path d="M234 24V30H216V24H234Z" fill="#4B4646"/>
+				<path d="M216 12V18H228V12H216ZM234 24H216V30H234V36H210V6H234V24Z" fill="#F1ECEC"/>
+			</svg>
 		</div>
 
 		<section class="card" aria-labelledby="success-title">

--- a/test/oauth-server.integration.test.ts
+++ b/test/oauth-server.integration.test.ts
@@ -30,7 +30,24 @@ describe("OAuth Server Integration", () => {
 		const response = await fetch(callbackUrl);
 		expect(response.status).toBe(200);
 		expect(response.headers.get("content-type")).toContain("text/html");
-		expect(await response.text()).toContain("ACCESS GRANTED");
+		expect(response.headers.get("cache-control")).toBe("no-store");
+		expect(response.headers.get("referrer-policy")).toBe("no-referrer");
+
+		const contentSecurityPolicy = response.headers.get("content-security-policy");
+		expect(contentSecurityPolicy).toContain("default-src 'none'");
+		expect(contentSecurityPolicy).toContain("script-src 'none'");
+		expect(contentSecurityPolicy).toContain("frame-ancestors 'none'");
+
+		const nonce = contentSecurityPolicy?.match(/style-src 'nonce-([^']+)'/)?.[1];
+		expect(nonce).toBeTruthy();
+
+		const body = await response.text();
+		expect(body).toContain(`<style nonce="${nonce}">`);
+		expect(body).toContain("Authentication complete");
+		expect(body).toContain("You can close this tab.");
+		expect(body).not.toContain("<script");
+		expect(body).not.toContain("fonts.googleapis.com");
+		expect(body).not.toMatch(/\\u[0-9a-f]{4}/i);
 
 		// Server should have captured the code
 		const result = await serverInfo.waitForCode(testState);

--- a/test/server.unit.test.ts
+++ b/test/server.unit.test.ts
@@ -80,7 +80,7 @@ vi.mock('node:http', () => {
 });
 
 vi.mock('../lib/oauth-success.js', () => ({
-	oauthSuccessHtml: '<html>Success</html>',
+	renderOAuthSuccessHtml: () => '<html>Success</html>',
 }));
 
 vi.mock('../lib/logger.js', () => ({
@@ -216,11 +216,15 @@ describe('OAuth Server Unit Tests', () => {
 
 			expect(res.statusCode).toBe(200);
 			expect(res.setHeader).toHaveBeenCalledWith('Content-Type', 'text/html; charset=utf-8');
+			expect(res.setHeader).toHaveBeenCalledWith('Cache-Control', 'no-store');
+			expect(res.setHeader).toHaveBeenCalledWith('Referrer-Policy', 'no-referrer');
 			expect(res.setHeader).toHaveBeenCalledWith('X-Frame-Options', 'DENY');
 			expect(res.setHeader).toHaveBeenCalledWith('X-Content-Type-Options', 'nosniff');
 			expect(res.setHeader).toHaveBeenCalledWith(
 				'Content-Security-Policy',
-				"default-src 'self'; script-src 'none'"
+				expect.stringMatching(
+					/^default-src 'none'; style-src 'nonce-[^']+'; script-src 'none'; frame-ancestors 'none'; base-uri 'none'; form-action 'none'$/
+				)
 			);
 			expect(res.end).toHaveBeenCalledWith('<html>Success</html>');
 		});


### PR DESCRIPTION

<img width="1440" height="900" alt="Screenshot 2026-07-23 at 1 05 28 PM" src="https://github.com/user-attachments/assets/b3cd57d1-4e83-4f80-bc1c-73570508d1c1" />
<img width="1440" height="900" alt="Screenshot 2026-07-23 at 12 37 57 PM" src="https://github.com/user-attachments/assets/d78956e5-d731-4fbe-895d-2844b71b64dc" />
## Description

The previous layout relied on inline scripts, external fonts, and inline styles that were completely broken by the strict `Content-Security-Policy` headers required during the OAuth flow. This resulted in an unstyled white page exposing raw unicode escape sequences.

This PR:
- Replaces the entire layout with a compact, static HTML page.
- Implements a dynamic CSS nonce generated on each callback to satisfy a strict, secure CSP (no external fonts, scripts, or unsafe inline styles).
- Adds proper `Cache-Control: no-store` and `Referrer-Policy: no-referrer` headers to the OAuth callback response.
- Replaces placeholder UI with the official OpenCode vector logomark.
- Includes integration tests verifying the CSP headers, nonce binding, and absence of external assets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved the OAuth completion page with a simpler, responsive design.
  * Added stronger privacy and security protections to OAuth callback responses, including restricted caching, referrer handling, and content policies.

* **Bug Fixes**
  * Prevented scripts, external fonts, and unintended content from loading on the authentication success page.

* **Tests**
  * Expanded coverage for OAuth response headers, security policies, and page content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

This PR replaces the OAuth success page with a CSP-compatible static design. The main changes are:

- Generates a per-request nonce for the inline stylesheet.
- Adds strict CSP, cache-control, and referrer-policy headers.
- Removes scripts, external fonts, and animation-heavy markup.
- Adds Vitest coverage for headers, nonce binding, and external assets.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.
- The CSP nonce is generated per response and matches the rendered stylesheet.
- The callback keeps token data out of the HTML and adds no-store protection.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lib/auth/server.ts | Generates the stylesheet nonce and adds hardened OAuth callback response headers. |
| lib/oauth-success.ts | Replaces the old scripted page with static HTML, inline SVG, and nonce-bound CSS. |
| test/oauth-server.integration.test.ts | Covers response headers, nonce binding, visible content, and removal of external assets. |
| test/server.unit.test.ts | Updates the renderer mock and callback header assertions. |

<sub>Reviews (1): Last reviewed commit: ["style(oauth-success): use official OpenC..."](https://github.com/ndycode/oc-codex-multi-auth/commit/72a707df253942be3d9ae835c631fe0e7b3cfbec) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46593188)</sub>

<!-- /greptile_comment -->