### PR TITLE
fix(cli): warm 400 on retired model and empty limits output (#209, #210)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,11 +47,13 @@ jobs:
       - name: Lint
         run: npm run lint
 
-      - name: Test
-        run: npm test
-
+      # Build must precede Test: dist/ is gitignored, and the standalone CLI
+      # tests load the compiled warm/limits runtime out of dist/.
       - name: Build
         run: npm run build
+
+      - name: Test
+        run: npm test
 
   audit-ci:
     name: Dependency audit

--- a/lib/accounts/warm-request.ts
+++ b/lib/accounts/warm-request.ts
@@ -18,7 +18,9 @@ import { CODEX_BASE_URL } from "../constants.js";
 import {
 	createCodexHeaders,
 	resolveUnsupportedCodexFallbackModel,
+	DEFAULT_UNSUPPORTED_CODEX_FALLBACK_CHAIN,
 } from "../request/fetch-helpers.js";
+import { getReasoningConfig } from "../request/request-transformer.js";
 import { shapeBodyForModel } from "../request/helpers/responses-lite.js";
 import { GPT_55_MODEL_ID } from "../request/helpers/model-map.js";
 import { sanitizeCodexApiErrorMessage } from "../codex-usage.js";
@@ -41,31 +43,42 @@ const log = createLogger("warm-request");
 const WARM_MODEL: string = GPT_55_MODEL_ID;
 
 /**
- * Hard ceiling on how many models one warm ping will try (#210).
+ * Absolute ceiling on warm attempts, independent of the chain's shape.
  *
- * `warm.ts` fans out across every enabled account concurrently, so an
- * unbounded walk down the fallback chain would multiply the batch's request
- * count by the chain length on accounts that are entitled to none of it. Four
- * covers the deepest chain a warm ping can enter
- * (`gpt-5.5 -> gpt-5.4 -> gpt-5.4-mini -> gpt-5.4-nano`).
+ * `warm.ts` fans out across every enabled account concurrently, so attempts
+ * multiply by the account count. This bounds the batch even if the shared
+ * chain later grows a long tail.
  */
-const WARM_MAX_MODEL_ATTEMPTS = 4;
+export const WARM_ATTEMPT_HARD_CEILING = 6;
+
+let cachedMaxModelAttempts: number | undefined;
 
 /**
- * Models that accept `reasoning.effort: "none"`, mirroring the `supportsNone`
- * rule in `request-transformer.ts`. The warm body is built outside the request
- * transformer, so it has to apply the same clamp itself: sending "none" to a
- * model that rejects it is its own 400, which would turn a fallback hop into a
- * fresh failure. Anything not listed here gets the universally-accepted "low".
+ * How many models one warm ping will try before giving up (#210).
+ *
+ * Derived from the shared fallback chain rather than hardcoded, so extending
+ * `DEFAULT_UNSUPPORTED_CODEX_FALLBACK_CHAIN` cannot silently leave warming
+ * unable to reach an entitled model at the end of the chain.
+ *
+ * Resolved on first call, not at module scope: `fetch-helpers` and this module
+ * are mutually reachable through `codex-warm.ts`, so the chain is still
+ * uninitialized while this module's top level runs.
  */
-const WARM_EFFORT_NONE_MODELS: ReadonlySet<string> = new Set([
-	GPT_55_MODEL_ID,
-	"gpt-5.4",
-	"gpt-5.4-mini",
-	"gpt-5.4-nano",
-	"gpt-5.2",
-	"gpt-5.1",
-]);
+function getWarmMaxModelAttempts(): number {
+	if (cachedMaxModelAttempts !== undefined) return cachedMaxModelAttempts;
+	const seen = new Set<string>([WARM_MODEL]);
+	const queue: string[] = [WARM_MODEL];
+	while (queue.length > 0) {
+		const current = queue.shift() as string;
+		for (const target of DEFAULT_UNSUPPORTED_CODEX_FALLBACK_CHAIN[current] ?? []) {
+			if (seen.has(target)) continue;
+			seen.add(target);
+			queue.push(target);
+		}
+	}
+	cachedMaxModelAttempts = Math.min(seen.size, WARM_ATTEMPT_HARD_CEILING);
+	return cachedMaxModelAttempts;
+}
 
 /** Hard ceiling on a warm request so a hung upstream cannot wedge the batch. */
 const WARM_TIMEOUT_MS = 15_000;
@@ -113,10 +126,15 @@ export async function buildWarmRequestBody(model = WARM_MODEL): Promise<RequestB
 				content: [{ type: "input_text", text: "warm ping" }],
 			},
 		],
-		reasoning: {
-			effort: WARM_EFFORT_NONE_MODELS.has(model) ? "none" : "low",
-			summary: "auto",
-		},
+		// The warm body is built outside the request transformer, so it asks the
+		// transformer's canonical clamp what "none" resolves to on this model
+		// rather than keeping its own copy of the rule. Sending "none" to a model
+		// that rejects it is its own 400 — that would turn a fallback hop into a
+		// fresh failure.
+		reasoning: getReasoningConfig(model, {
+			reasoningEffort: "none",
+			reasoningSummary: "auto",
+		}),
 		text: { verbosity: "low" },
 	};
 }
@@ -232,7 +250,7 @@ async function attemptWarm(
  *
  * A 400 carrying `model_not_supported_with_chatgpt_account` is retried down the
  * shared unsupported-model fallback chain (bounded by
- * {@link WARM_MAX_MODEL_ATTEMPTS}) before the account is failed, mirroring the
+ * {@link getWarmMaxModelAttempts}) before the account is failed, mirroring the
  * live request path.
  */
 export async function warmAccountWindow(
@@ -242,7 +260,8 @@ export async function warmAccountWindow(
 	let model = WARM_MODEL;
 	let lastUnsupported: { kind: "unsupported-model"; errorBody: unknown; message: string } | undefined;
 
-	for (let i = 0; i < WARM_MAX_MODEL_ATTEMPTS; i += 1) {
+	const maxAttempts = getWarmMaxModelAttempts();
+	for (let i = 0; i < maxAttempts; i += 1) {
 		const attempt = await attemptWarm(params, model);
 		if (attempt.kind === "opened") return { status: "opened" };
 		if (attempt.kind === "exhausted") {

--- a/lib/accounts/warm-request.ts
+++ b/lib/accounts/warm-request.ts
@@ -15,7 +15,13 @@
  */
 
 import { CODEX_BASE_URL } from "../constants.js";
-import { createCodexHeaders } from "../request/fetch-helpers.js";
+import {
+	createCodexHeaders,
+	resolveUnsupportedCodexFallbackModel,
+} from "../request/fetch-helpers.js";
+import { shapeBodyForModel } from "../request/helpers/responses-lite.js";
+import { GPT_55_MODEL_ID } from "../request/helpers/model-map.js";
+import { sanitizeCodexApiErrorMessage } from "../codex-usage.js";
 import { getCodexInstructions } from "../prompts/codex.js";
 import { parseRateLimitReason } from "./rate-limits.js";
 import type { RequestBody } from "../types.js";
@@ -23,8 +29,43 @@ import { createLogger } from "../logger.js";
 
 const log = createLogger("warm-request");
 
-/** Model used for the warm ping. Mirrors the live quota-probe default. */
-const WARM_MODEL = "gpt-5.4";
+/**
+ * Model used for the warm ping.
+ *
+ * GPT-5.5 is the generally-available anchor the shared fallback chain degrades
+ * *toward* (every 5.6 preview tier lands on it), and it ships in the installer's
+ * model catalog. The previous entry point, `gpt-5.4`, was dropped from that
+ * catalog and is removed from user config as a stale key, so accounts without
+ * it got a hard `HTTP 400` on every warm ping (#210).
+ */
+const WARM_MODEL: string = GPT_55_MODEL_ID;
+
+/**
+ * Hard ceiling on how many models one warm ping will try (#210).
+ *
+ * `warm.ts` fans out across every enabled account concurrently, so an
+ * unbounded walk down the fallback chain would multiply the batch's request
+ * count by the chain length on accounts that are entitled to none of it. Four
+ * covers the deepest chain a warm ping can enter
+ * (`gpt-5.5 -> gpt-5.4 -> gpt-5.4-mini -> gpt-5.4-nano`).
+ */
+const WARM_MAX_MODEL_ATTEMPTS = 4;
+
+/**
+ * Models that accept `reasoning.effort: "none"`, mirroring the `supportsNone`
+ * rule in `request-transformer.ts`. The warm body is built outside the request
+ * transformer, so it has to apply the same clamp itself: sending "none" to a
+ * model that rejects it is its own 400, which would turn a fallback hop into a
+ * fresh failure. Anything not listed here gets the universally-accepted "low".
+ */
+const WARM_EFFORT_NONE_MODELS: ReadonlySet<string> = new Set([
+	GPT_55_MODEL_ID,
+	"gpt-5.4",
+	"gpt-5.4-mini",
+	"gpt-5.4-nano",
+	"gpt-5.2",
+	"gpt-5.1",
+]);
 
 /** Hard ceiling on a warm request so a hung upstream cannot wedge the batch. */
 const WARM_TIMEOUT_MS = 15_000;
@@ -72,7 +113,10 @@ export async function buildWarmRequestBody(model = WARM_MODEL): Promise<RequestB
 				content: [{ type: "input_text", text: "warm ping" }],
 			},
 		],
-		reasoning: { effort: "none", summary: "auto" },
+		reasoning: {
+			effort: WARM_EFFORT_NONE_MODELS.has(model) ? "none" : "low",
+			summary: "auto",
+		},
 		text: { verbosity: "low" },
 	};
 }
@@ -93,21 +137,23 @@ export interface WarmRequestResult {
 }
 
 /**
- * Send one warm request to open the account's usage window.
- *
- * Resolves with `{ status: "opened" }` when the upstream started/confirmed the
- * window (2xx, or a non-quota 429 meaning the window is already active), or
- * `{ status: "exhausted" }` for a quota/usage-limit 429 (window already spent).
- * Any other non-2xx, or a network/timeout error, throws so the caller records
- * the account as failed.
+ * Result of a single model attempt. `unsupported-model` is the only outcome the
+ * caller retries; everything else is terminal for the account.
  */
-export async function warmAccountWindow(
+type WarmAttempt =
+	| { kind: "opened" }
+	| { kind: "exhausted"; detail: string }
+	| { kind: "unsupported-model"; errorBody: unknown; message: string };
+
+/** Send one warm ping for exactly one model. */
+async function attemptWarm(
 	params: WarmRequestParams,
-): Promise<WarmRequestResult> {
+	model: string,
+): Promise<WarmAttempt> {
 	const doFetch = params.fetchImpl ?? fetch;
-	const body = await buildWarmRequestBody();
+	const body = await buildWarmRequestBody(model);
 	const headers = createCodexHeaders(undefined, params.accountId, params.accessToken, {
-		model: WARM_MODEL,
+		model,
 		organizationId: params.organizationId,
 	});
 
@@ -120,7 +166,9 @@ export async function warmAccountWindow(
 		const response = await doFetch(`${CODEX_BASE_URL}/codex/responses`, {
 			method: "POST",
 			headers,
-			body: JSON.stringify(body),
+			// A fallback target may be a responses-lite model, which takes a
+			// materially different wire shape than the classic body built above.
+			body: JSON.stringify(shapeBodyForModel(body)),
 			signal: controller.signal,
 		});
 
@@ -131,7 +179,7 @@ export async function warmAccountWindow(
 			} catch {
 				// Ignore cancellation failures.
 			}
-			return { status: "opened" };
+			return { kind: "opened" };
 		}
 
 		// Read the error body (small) BEFORE classifying so a 429 quota-exhausted
@@ -149,19 +197,93 @@ export async function warmAccountWindow(
 				log.debug("Warm ping hit 429 quota limit — account window already spent", {
 					accountId: params.accountId,
 				});
-				return { status: "exhausted", detail: "quota/usage limit reached" };
+				return { kind: "exhausted", detail: "quota/usage limit reached" };
 			}
 			// token/concurrent/unknown → the window is active and ticking.
 			log.debug("Warm ping hit 429 — window already active", {
 				accountId: params.accountId,
 				reason,
 			});
-			return { status: "opened" };
+			return { kind: "opened" };
 		}
 
-		throw new Error(`Warm request failed: HTTP ${response.status}`);
+		// The account is not entitled to `model`. The live request path degrades
+		// down the shared fallback chain here rather than failing (#210); warming
+		// does the same so an entitlement gap does not read as a broken account.
+		const message = sanitizeCodexApiErrorMessage(response.status, bodyText);
+		if (response.status === 400) {
+			return { kind: "unsupported-model", errorBody: parseErrorBody(bodyText), message };
+		}
+
+		throw new Error(`Warm request failed: ${message}`);
 	} finally {
 		clearTimeout(timeout);
+	}
+}
+
+/**
+ * Send a warm request to open the account's usage window.
+ *
+ * Resolves with `{ status: "opened" }` when the upstream started/confirmed the
+ * window (2xx, or a non-quota 429 meaning the window is already active), or
+ * `{ status: "exhausted" }` for a quota/usage-limit 429 (window already spent).
+ * Any other non-2xx, or a network/timeout error, throws so the caller records
+ * the account as failed.
+ *
+ * A 400 carrying `model_not_supported_with_chatgpt_account` is retried down the
+ * shared unsupported-model fallback chain (bounded by
+ * {@link WARM_MAX_MODEL_ATTEMPTS}) before the account is failed, mirroring the
+ * live request path.
+ */
+export async function warmAccountWindow(
+	params: WarmRequestParams,
+): Promise<WarmRequestResult> {
+	const attempted: string[] = [];
+	let model = WARM_MODEL;
+	let lastUnsupported: { kind: "unsupported-model"; errorBody: unknown; message: string } | undefined;
+
+	for (let i = 0; i < WARM_MAX_MODEL_ATTEMPTS; i += 1) {
+		const attempt = await attemptWarm(params, model);
+		if (attempt.kind === "opened") return { status: "opened" };
+		if (attempt.kind === "exhausted") {
+			return { status: "exhausted", detail: attempt.detail };
+		}
+
+		lastUnsupported = attempt;
+		attempted.push(model);
+		const next = resolveUnsupportedCodexFallbackModel({
+			requestedModel: model,
+			errorBody: attempt.errorBody,
+			attemptedModels: attempted,
+			// A warm ping picks its own model, so there is no user selection to
+			// respect — always take the chain when the backend rejects one.
+			fallbackOnUnsupportedCodexModel: true,
+			fallbackToGpt52OnUnsupportedGpt53: true,
+		});
+		if (!next) break;
+
+		log.debug("Warm ping model not entitled — falling back", {
+			accountId: params.accountId,
+			from: model,
+			to: next,
+		});
+		model = next;
+	}
+
+	const detail = attempted.length > 1 ? ` (tried ${attempted.join(", ")})` : "";
+	throw new Error(
+		`Warm request failed: ${lastUnsupported?.message ?? "HTTP 400"}${detail}`,
+	);
+}
+
+/** Parse an error body as JSON so the shared matchers can read its fields. */
+function parseErrorBody(bodyText: string): unknown {
+	if (!bodyText) return undefined;
+	try {
+		return JSON.parse(bodyText) as unknown;
+	} catch {
+		// Non-JSON bodies still match on the raw text.
+		return bodyText;
 	}
 }
 

--- a/scripts/install-oc-codex-multi-auth-core.js
+++ b/scripts/install-oc-codex-multi-auth-core.js
@@ -83,7 +83,7 @@ function printHelp() {
 		"  doctor              Run local account/config diagnostics\n" +
 		"  status              Show account/config status\n" +
 		"  list                List configured accounts\n" +
-		"  limits              Show stored rate-limit state\n" +
+		"  limits              Show live 5-hour and weekly usage for each account\n" +
 		"  dashboard           Print dashboard guidance\n" +
 		"  health              Check local token/account health\n" +
 		"  diag                Alias for doctor --deep\n" +
@@ -380,32 +380,52 @@ function printStandaloneResult(command, payload, json) {
 	if (payload.nextAction) console.log(`Next: ${payload.nextAction}`);
 }
 
-async function loadWarmRuntime(env) {
-	// Reuse the COMPILED warm logic from dist/ so the standalone CLI behaves
-	// identically to the in-conversation codex-warm tool. dist/ ships in the
-	// npm package (files allowlist) and none of these modules import the
-	// OpenCode plugin runtime, so they load cleanly in plain Node.
+/**
+ * Import compiled modules from dist/ so the standalone CLI behaves identically
+ * to the in-conversation tools. dist/ ships in the npm package (files
+ * allowlist) and none of these modules import the OpenCode plugin runtime, so
+ * they load cleanly in plain Node.
+ */
+async function loadDistModules(relativePaths, label) {
 	const distRoot = join(repoRoot, "dist", "lib");
 	const toUrl = (rel) => pathToFileURL(join(distRoot, rel)).href;
 	try {
-		const [storageMod, usageMod, warmReqMod, warmMod, shutdownMod] = await Promise.all([
-			import(toUrl("storage.js")),
-			import(toUrl("codex-usage.js")),
-			import(toUrl("accounts/warm-request.js")),
-			import(toUrl("accounts/warm.js")),
-			import(toUrl("shutdown.js")),
-		]);
-		// Unlike the plugin, this CLI *is* the process, so it owns termination:
-		// Ctrl+C must abort the warm run rather than wait for it to drain.
-		// Refreshing a token here persists credentials, which registers the
-		// shutdown handler via the storage lock.
-		shutdownMod.setShutdownOwnsProcess(true);
-		return { storageMod, usageMod, warmReqMod, warmMod, shutdownMod };
+		return await Promise.all(relativePaths.map((rel) => import(toUrl(rel))));
 	} catch (error) {
 		throw new Error(
-			`Could not load warm runtime from dist/. Build the package first (npm run build). Cause: ${formatErrorForLog(error)}`,
+			`Could not load ${label} runtime from dist/. Build the package first (npm run build). Cause: ${formatErrorForLog(error)}`,
 		);
 	}
+}
+
+async function loadWarmRuntime(env) {
+	const [storageMod, usageMod, warmReqMod, warmMod, shutdownMod] = await loadDistModules(
+		[
+			"storage.js",
+			"codex-usage.js",
+			"accounts/warm-request.js",
+			"accounts/warm.js",
+			"shutdown.js",
+		],
+		"warm",
+	);
+	// Unlike the plugin, this CLI *is* the process, so it owns termination:
+	// Ctrl+C must abort the warm run rather than wait for it to drain.
+	// Refreshing a token here persists credentials, which registers the
+	// shutdown handler via the storage lock.
+	shutdownMod.setShutdownOwnsProcess(true);
+	return { storageMod, usageMod, warmReqMod, warmMod, shutdownMod };
+}
+
+async function loadLimitsRuntime(env) {
+	const [storageMod, usageMod, shutdownMod] = await loadDistModules(
+		["storage.js", "codex-usage.js", "shutdown.js"],
+		"limits",
+	);
+	// Fetching usage can refresh (and therefore persist) a token, so the same
+	// process-owns-termination rule as `warm` applies.
+	shutdownMod.setShutdownOwnsProcess(true);
+	return { storageMod, usageMod, shutdownMod };
 }
 
 export async function runWarmCommand(parsed, options = {}) {
@@ -505,6 +525,129 @@ function printWarmResult(payload, json) {
 	if (payload.nextAction) console.log(`Next: ${payload.nextAction}`);
 }
 
+/**
+ * `limits` — show live 5-hour and weekly Codex usage per account (#209).
+ *
+ * Reuses the compiled `codex-usage` runtime so the CLI reports the same windows
+ * as the in-conversation `codex-limits` tool. The locally persisted
+ * `rateLimitResetTimes` is carried in the payload as well: it is the only
+ * rate-limit state available for an account whose live fetch fails, and
+ * `--json` consumers of the previous behavior still find the field.
+ */
+export async function runLimitsCommand(parsed, options = {}) {
+	const { env = process.env } = options;
+	const storagePath = getStandaloneStoragePath(parsed, env);
+
+	let runtime;
+	try {
+		runtime = await loadLimitsRuntime(env);
+	} catch (error) {
+		const payload = { command: "limits", storagePath, error: formatErrorForLog(error) };
+		printLimitsResult(payload, parsed.json);
+		return { exitCode: 1, action: "limits", storagePath };
+	}
+
+	const { storageMod, usageMod } = runtime;
+	// Point dist storage at the resolved accounts file so a refreshed token is
+	// persisted to the SAME file the rest of the toolchain reads.
+	storageMod.setStoragePathDirect(storagePath);
+
+	const storage = await storageMod.loadAccounts();
+	const accounts = Array.isArray(storage?.accounts) ? storage.accounts : [];
+	if (accounts.length === 0) {
+		const payload = {
+			command: "limits",
+			storagePath,
+			totalAccounts: 0,
+			accounts: [],
+			message: "No accounts configured.",
+			nextAction: "Run opencode auth login.",
+		};
+		printLimitsResult(payload, parsed.json);
+		return { exitCode: 0, action: "limits", storagePath };
+	}
+
+	// Same workspace dedupe the codex-limits tool applies, so two entries for one
+	// workspace are not billed and printed twice.
+	const indices = usageMod.deduplicateUsageAccountIndices(storage);
+	const results = [];
+	let failedCount = 0;
+
+	for (const index of indices) {
+		const account = accounts[index];
+		if (!account) continue;
+		const entry = {
+			index,
+			label: account.accountLabel ?? `Account ${index + 1}`,
+			email: maskValue(account.email, parsed.includeSensitive),
+			rateLimitResetTimes: account.rateLimitResetTimes ?? {},
+		};
+		try {
+			const { accessToken } = await usageMod.ensureCodexUsageAccessToken({ storage, account });
+			const accountId = usageMod.resolveCodexUsageAccountId({ account, accessToken });
+			if (!accountId) {
+				throw new Error("could not resolve account id (re-login may be required)");
+			}
+			const usage = usageMod.parseCodexUsagePayload(
+				await usageMod.fetchCodexUsage({
+					accountId,
+					accessToken,
+					organizationId: account.organizationId,
+				}),
+			);
+			entry.planType = usage.planType;
+			entry.credits = usage.credits;
+			entry.limits = usage.limits;
+		} catch (error) {
+			entry.error = formatErrorForLog(error).slice(0, 160);
+			failedCount += 1;
+		}
+		results.push(entry);
+	}
+
+	const payload = {
+		command: "limits",
+		storagePath,
+		totalAccounts: accounts.length,
+		shownAccounts: results.length,
+		accounts: results,
+	};
+	printLimitsResult(payload, parsed.json);
+	return { exitCode: failedCount > 0 ? 1 : 0, action: "limits", storagePath };
+}
+
+function printLimitsResult(payload, json) {
+	if (json) {
+		console.log(JSON.stringify(payload, null, 2));
+		return;
+	}
+	console.log(`oc-codex-multi-auth limits`);
+	if (payload.message) console.log(payload.message);
+	console.log(`Storage: ${payload.storagePath}`);
+	if (payload.error) {
+		console.log(`Error: ${payload.error}`);
+		return;
+	}
+	console.log(`Accounts: ${payload.totalAccounts}`);
+	for (const account of payload.accounts ?? []) {
+		const label = account.email ? `${account.label} (${account.email})` : account.label;
+		console.log(`- [${account.index}] ${label}`);
+		if (account.error) {
+			console.log(`  Error: ${account.error}`);
+			continue;
+		}
+		for (const limit of account.limits ?? []) {
+			console.log(`  ${limit.name}: ${limit.summary}`);
+		}
+		if ((account.limits ?? []).length === 0) {
+			console.log("  No usage windows reported yet.");
+		}
+		if (account.planType) console.log(`  Plan: ${account.planType}`);
+		if (account.credits) console.log(`  Credits: ${account.credits}`);
+	}
+	if (payload.nextAction) console.log(`Next: ${payload.nextAction}`);
+}
+
 export async function runStandaloneCommand(command, argv = [], options = {}) {
 	const parsed = parseStandaloneArgs(argv);
 	if (command === "diag") {
@@ -517,6 +660,9 @@ export async function runStandaloneCommand(command, argv = [], options = {}) {
 	}
 	if (command === "warm") {
 		return runWarmCommand(parsed, options);
+	}
+	if (command === "limits") {
+		return runLimitsCommand(parsed, options);
 	}
 	const { env = process.env } = options;
 	const storagePath = getStandaloneStoragePath(parsed, env);
@@ -541,8 +687,6 @@ export async function runStandaloneCommand(command, argv = [], options = {}) {
 		payload.deep = parsed.deep;
 		payload.fixApplied = parsed.fix ? false : undefined;
 		payload.nextAction = totalAccounts > 0 ? "Run oc-codex-multi-auth health --json for scriptable checks." : "Run opencode auth login.";
-	} else if (command === "limits") {
-		payload.rateLimits = accounts.map((account) => ({ index: account.index, rateLimitResetTimes: account.rateLimitResetTimes }));
 	} else if (command === "health") {
 		payload.healthyCount = accounts.filter((account) => account.enabled && account.hasRefreshToken).length;
 		payload.unhealthyCount = accounts.filter((account) => !account.enabled || !account.hasRefreshToken).length;

--- a/scripts/install-oc-codex-multi-auth-core.js
+++ b/scripts/install-oc-codex-multi-auth-core.js
@@ -418,14 +418,14 @@ async function loadWarmRuntime(env) {
 }
 
 async function loadLimitsRuntime(env) {
-	const [storageMod, usageMod, shutdownMod] = await loadDistModules(
-		["storage.js", "codex-usage.js", "shutdown.js"],
+	const [storageMod, usageMod, shutdownMod, loggerMod] = await loadDistModules(
+		["storage.js", "codex-usage.js", "shutdown.js", "logger.js"],
 		"limits",
 	);
 	// Fetching usage can refresh (and therefore persist) a token, so the same
 	// process-owns-termination rule as `warm` applies.
 	shutdownMod.setShutdownOwnsProcess(true);
-	return { storageMod, usageMod, shutdownMod };
+	return { storageMod, usageMod, shutdownMod, loggerMod };
 }
 
 export async function runWarmCommand(parsed, options = {}) {
@@ -547,7 +547,7 @@ export async function runLimitsCommand(parsed, options = {}) {
 		return { exitCode: 1, action: "limits", storagePath };
 	}
 
-	const { storageMod, usageMod } = runtime;
+	const { storageMod, usageMod, loggerMod } = runtime;
 	// Point dist storage at the resolved accounts file so a refreshed token is
 	// persisted to the SAME file the rest of the toolchain reads.
 	storageMod.setStoragePathDirect(storagePath);
@@ -570,12 +570,26 @@ export async function runLimitsCommand(parsed, options = {}) {
 	// Same workspace dedupe the codex-limits tool applies, so two entries for one
 	// workspace are not billed and printed twice.
 	const indices = usageMod.deduplicateUsageAccountIndices(storage);
+	// `--tag` must gate which accounts are contacted at all, not just which are
+	// printed: an untagged account would otherwise be billed a usage fetch and
+	// could have its refreshed credentials persisted.
+	const normalizedTag =
+		typeof parsed.tag === "string" ? parsed.tag.trim().toLowerCase() : "";
 	const results = [];
 	let failedCount = 0;
 
 	for (const index of indices) {
 		const account = accounts[index];
 		if (!account) continue;
+		if (
+			normalizedTag &&
+			!(
+				Array.isArray(account.accountTags) &&
+				account.accountTags.some((entry) => String(entry).toLowerCase() === normalizedTag)
+			)
+		) {
+			continue;
+		}
 		const entry = {
 			index,
 			label: account.accountLabel ?? `Account ${index + 1}`,
@@ -599,7 +613,11 @@ export async function runLimitsCommand(parsed, options = {}) {
 			entry.credits = usage.credits;
 			entry.limits = usage.limits;
 		} catch (error) {
-			entry.error = formatErrorForLog(error).slice(0, 160);
+			// `ensureCodexUsageAccessToken` can surface a raw OAuth refresh
+			// response, so the message is redacted through the logger's token
+			// patterns before it reaches stdout, JSON output, or CI logs.
+			// Truncation alone does not protect bearer/JWT/refresh-token material.
+			entry.error = loggerMod.maskString(formatErrorForLog(error)).slice(0, 160);
 			failedCount += 1;
 		}
 		results.push(entry);

--- a/test/accounts-warm-request.test.ts
+++ b/test/accounts-warm-request.test.ts
@@ -36,11 +36,23 @@ beforeEach(() => {
 describe("buildWarmRequestBody (#182)", () => {
 	it("builds a minimal billable /responses body", async () => {
 		const body = await buildWarmRequestBody();
-		expect(body.model).toBe("gpt-5.4");
+		expect(body.model).toBe("gpt-5.5");
 		expect(body.stream).toBe(true);
 		expect(body.store).toBe(false);
 		expect(body.reasoning).toEqual({ effort: "none", summary: "auto" });
 		expect(body.input?.[0]).toMatchObject({ role: "user", type: "message" });
+	});
+
+	it("keeps effort 'none' for every model the default chain can reach", async () => {
+		for (const model of ["gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano"]) {
+			const body = await buildWarmRequestBody(model);
+			expect(body.reasoning).toEqual({ effort: "none", summary: "auto" });
+		}
+	});
+
+	it("clamps effort to 'low' for a model that rejects 'none' (#210)", async () => {
+		const body = await buildWarmRequestBody("gpt-5.6-sol");
+		expect(body.reasoning).toMatchObject({ effort: "low" });
 	});
 });
 
@@ -114,6 +126,69 @@ describe("warmAccountWindow (#182)", () => {
 		const [, init] = fetchImpl.mock.calls[0] as [string, RequestInit];
 		const headers = init.headers as Headers;
 		expect(headers.get("openai-organization")).toBeNull();
+	});
+
+	it("falls back down the model chain on an unsupported-model 400 (#210)", async () => {
+		const fetchImpl = vi
+			.fn()
+			.mockResolvedValueOnce(
+				fakeResponse(
+					400,
+					JSON.stringify({
+						error: { code: "model_not_supported_with_chatgpt_account" },
+					}),
+				),
+			)
+			.mockResolvedValueOnce(fakeResponse(200));
+
+		const result = await warmAccountWindow({ ...PARAMS, fetchImpl });
+
+		expect(result.status).toBe("opened");
+		expect(fetchImpl).toHaveBeenCalledTimes(2);
+		const firstBody = JSON.parse(
+			(fetchImpl.mock.calls[0] as [string, RequestInit])[1].body as string,
+		);
+		const secondBody = JSON.parse(
+			(fetchImpl.mock.calls[1] as [string, RequestInit])[1].body as string,
+		);
+		expect(firstBody.model).toBe("gpt-5.5");
+		expect(secondBody.model).toBe("gpt-5.4");
+	});
+
+	it("stops after the bounded attempt budget when no model is entitled (#210)", async () => {
+		const unsupported = () =>
+			fakeResponse(
+				400,
+				JSON.stringify({
+					error: { code: "model_not_supported_with_chatgpt_account" },
+				}),
+			);
+		const fetchImpl = vi.fn(async () => unsupported());
+
+		await expect(warmAccountWindow({ ...PARAMS, fetchImpl })).rejects.toThrow(
+			/tried gpt-5\.5, gpt-5\.4, gpt-5\.4-mini, gpt-5\.4-nano/,
+		);
+		expect(fetchImpl).toHaveBeenCalledTimes(4);
+	});
+
+	it("does not retry a 400 that is not an entitlement error, and surfaces its detail", async () => {
+		const fetchImpl = vi.fn(async () =>
+			fakeResponse(400, JSON.stringify({ error: { message: "bad input" } })),
+		);
+
+		await expect(warmAccountWindow({ ...PARAMS, fetchImpl })).rejects.toThrow(
+			/HTTP 400.*bad input/,
+		);
+		expect(fetchImpl).toHaveBeenCalledTimes(1);
+	});
+
+	it("redacts bearer tokens leaked in an error body", async () => {
+		const fetchImpl = vi.fn(async () =>
+			fakeResponse(401, "Bearer sk-secret-token-value"),
+		);
+		await expect(warmAccountWindow({ ...PARAMS, fetchImpl })).rejects.toThrow(
+			/Bearer \[redacted\]/,
+		);
 	});
 
 	it("passes organizationId into the request headers when CODEX_AUTH_SEND_ORGANIZATION_HEADER=1", async () => {

--- a/test/accounts-warm-request.test.ts
+++ b/test/accounts-warm-request.test.ts
@@ -11,7 +11,10 @@ vi.mock("../lib/prompts/codex.js", async (importOriginal) => {
 import {
 	buildWarmRequestBody,
 	warmAccountWindow,
+	WARM_ATTEMPT_HARD_CEILING,
 } from "../lib/accounts/warm-request.js";
+import { DEFAULT_UNSUPPORTED_CODEX_FALLBACK_CHAIN } from "../lib/request/fetch-helpers.js";
+import { getReasoningConfig } from "../lib/request/request-transformer.js";
 import { CODEX_BASE_URL } from "../lib/constants.js";
 
 function fakeResponse(status: number, bodyText = ""): Response {
@@ -53,6 +56,50 @@ describe("buildWarmRequestBody (#182)", () => {
 	it("clamps effort to 'low' for a model that rejects 'none' (#210)", async () => {
 		const body = await buildWarmRequestBody("gpt-5.6-sol");
 		expect(body.reasoning).toMatchObject({ effort: "low" });
+	});
+
+	it("derives its effort from the transformer's canonical clamp, not a local copy", async () => {
+		for (const model of [
+			"gpt-5.5",
+			"gpt-5.4",
+			"gpt-5.4-mini",
+			"gpt-5.4-nano",
+			"gpt-5.6-sol",
+			"gpt-5.4-pro",
+			"gpt-5-codex",
+		]) {
+			const body = await buildWarmRequestBody(model);
+			expect(body.reasoning).toEqual(
+				getReasoningConfig(model, {
+					reasoningEffort: "none",
+					reasoningSummary: "auto",
+				}),
+			);
+		}
+	});
+});
+
+describe("warm fallback chain invariants (#210)", () => {
+	it("the attempt budget covers every model reachable from the warm entry point", () => {
+		const reachable = new Set<string>(["gpt-5.5"]);
+		const queue = ["gpt-5.5"];
+		while (queue.length > 0) {
+			const current = queue.shift() as string;
+			for (const target of DEFAULT_UNSUPPORTED_CODEX_FALLBACK_CHAIN[current] ?? []) {
+				if (reachable.has(target)) continue;
+				reachable.add(target);
+				queue.push(target);
+			}
+		}
+		// If this fails the default chain grew a tail past the warm attempt
+		// budget, so warming would stop before reaching an entitled model.
+		expect(reachable.size).toBeLessThanOrEqual(WARM_ATTEMPT_HARD_CEILING);
+		expect([...reachable]).toEqual([
+			"gpt-5.5",
+			"gpt-5.4",
+			"gpt-5.4-mini",
+			"gpt-5.4-nano",
+		]);
 	});
 });
 

--- a/test/standalone-cli.test.ts
+++ b/test/standalone-cli.test.ts
@@ -308,13 +308,46 @@ describe("standalone oc-codex-multi-auth CLI commands", () => {
 		expect(fetchSpy).toHaveBeenCalledTimes(1);
 	});
 
+	it("limits: --tag matches a workspace tagged on a deduplicated-away record", async () => {
+		vi.resetModules();
+		tempHome = await createTempHome();
+		// Both records are the same workspace (same accountId), so dedupe keeps
+		// only the later one — but the tag lives on the earlier record.
+		await writeAccounts(tempHome, [
+			freshAccount({ email: "old@example.com", accountTags: ["work"] }),
+			freshAccount({ email: "new@example.com", refreshToken: "rt-newer" }),
+		]);
+		const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue({
+			ok: true,
+			status: 200,
+			json: async () => usagePayload,
+			text: async () => JSON.stringify(usagePayload),
+		} as unknown as Response);
+		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const { runInstaller } = await import("../scripts/install-oc-codex-multi-auth-core.js");
+
+		await runInstaller(["limits", "--tag", "work", "--json"], {
+			env: { ...process.env, HOME: tempHome, USERPROFILE: tempHome },
+		});
+
+		const output = JSON.parse(String(logSpy.mock.calls.at(-1)?.[0]));
+		expect(output.accounts).toHaveLength(1);
+		expect(fetchSpy).toHaveBeenCalledTimes(1);
+	});
+
 	it("limits: redacts token material leaked by a failing refresh", async () => {
 		vi.resetModules();
 		tempHome = await createTempHome();
-		await writeAccounts(tempHome, [freshAccount()]);
+		// Expired, so ensureCodexUsageAccessToken actually performs the OAuth
+		// refresh — a future expiry would skip it and only exercise /wham/usage.
+		await writeAccounts(tempHome, [freshAccount({ expiresAt: Date.now() - 60_000 })]);
 		vi.spyOn(globalThis, "fetch").mockResolvedValue({
 			ok: false,
 			status: 401,
+			json: async () => ({
+				error: "invalid_grant",
+				refresh_token: "rt-super-secret-value",
+			}),
 			text: async () =>
 				'{"error":"invalid_grant","refresh_token":"rt-super-secret-value"}',
 		} as unknown as Response);

--- a/test/standalone-cli.test.ts
+++ b/test/standalone-cli.test.ts
@@ -191,5 +191,111 @@ describe("standalone oc-codex-multi-auth CLI commands", () => {
 		expect(output.results[0].email).not.toBe("warm@example.com");
 		expect(output.results[0].email).toContain("...");
 	});
+
+	const usagePayload = {
+		plan_type: "plus",
+		rate_limit: {
+			primary_window: {
+				used_percent: 18,
+				limit_window_seconds: 18_000,
+				reset_at: Math.floor(Date.now() / 1000) + 3_600,
+			},
+			secondary_window: {
+				used_percent: 42,
+				limit_window_seconds: 604_800,
+				reset_at: Math.floor(Date.now() / 1000) + 86_400,
+			},
+		},
+	};
+
+	it("limits: empty pool reports no accounts and exits 0 (#209)", async () => {
+		vi.resetModules();
+		tempHome = await createTempHome();
+		await writeAccounts(tempHome, []);
+		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const { runInstaller } = await import("../scripts/install-oc-codex-multi-auth-core.js");
+
+		await expect(
+			runInstaller(["limits", "--json"], {
+				env: { ...process.env, HOME: tempHome, USERPROFILE: tempHome },
+			}),
+		).resolves.toMatchObject({ action: "limits", exitCode: 0 });
+
+		const output = JSON.parse(String(logSpy.mock.calls.at(-1)?.[0]));
+		expect(output).toMatchObject({ totalAccounts: 0, accounts: [] });
+	});
+
+	it("limits: reports live 5h and weekly windows per account (#209)", async () => {
+		vi.resetModules();
+		tempHome = await createTempHome();
+		await writeAccounts(tempHome, [freshAccount()]);
+		const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue({
+			ok: true,
+			status: 200,
+			json: async () => usagePayload,
+			text: async () => JSON.stringify(usagePayload),
+		} as unknown as Response);
+		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const { runInstaller } = await import("../scripts/install-oc-codex-multi-auth-core.js");
+
+		await expect(
+			runInstaller(["limits", "--json"], {
+				env: { ...process.env, HOME: tempHome, USERPROFILE: tempHome },
+			}),
+		).resolves.toMatchObject({ action: "limits", exitCode: 0 });
+
+		const output = JSON.parse(String(logSpy.mock.calls.at(-1)?.[0]));
+		expect(output.totalAccounts).toBe(1);
+		const names = output.accounts[0].limits.map((limit: { name: string }) => limit.name);
+		expect(names).toContain("5h limit");
+		expect(names).toContain("Weekly limit");
+		expect(output.accounts[0].limits[0].leftPercent).toBe(82);
+		expect(output.accounts[0].planType).toBe("plus");
+		expect(String(fetchSpy.mock.calls.at(-1)?.[0])).toContain("/wham/usage");
+	});
+
+	it("limits: renders the windows in text output rather than a bare account list (#209)", async () => {
+		vi.resetModules();
+		tempHome = await createTempHome();
+		await writeAccounts(tempHome, [freshAccount()]);
+		vi.spyOn(globalThis, "fetch").mockResolvedValue({
+			ok: true,
+			status: 200,
+			json: async () => usagePayload,
+			text: async () => JSON.stringify(usagePayload),
+		} as unknown as Response);
+		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const { runInstaller } = await import("../scripts/install-oc-codex-multi-auth-core.js");
+
+		await runInstaller(["limits"], {
+			env: { ...process.env, HOME: tempHome, USERPROFILE: tempHome },
+		});
+
+		const printed = logSpy.mock.calls.map((call) => String(call[0])).join("\n");
+		expect(printed).toContain("5h limit: 82% left");
+		expect(printed).toContain("Weekly limit: 58% left");
+	});
+
+	it("limits: an account whose usage fetch fails is reported and exits 1 (#209)", async () => {
+		vi.resetModules();
+		tempHome = await createTempHome();
+		await writeAccounts(tempHome, [freshAccount()]);
+		vi.spyOn(globalThis, "fetch").mockResolvedValue({
+			ok: false,
+			status: 500,
+			text: async () => "upstream boom",
+		} as unknown as Response);
+		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const { runInstaller } = await import("../scripts/install-oc-codex-multi-auth-core.js");
+
+		await expect(
+			runInstaller(["limits", "--json"], {
+				env: { ...process.env, HOME: tempHome, USERPROFILE: tempHome },
+			}),
+		).resolves.toMatchObject({ action: "limits", exitCode: 1 });
+
+		const output = JSON.parse(String(logSpy.mock.calls.at(-1)?.[0]));
+		expect(output.accounts[0].error).toContain("500");
+	});
 });
 

--- a/test/standalone-cli.test.ts
+++ b/test/standalone-cli.test.ts
@@ -276,6 +276,59 @@ describe("standalone oc-codex-multi-auth CLI commands", () => {
 		expect(printed).toContain("Weekly limit: 58% left");
 	});
 
+	it("limits: --tag only contacts matching accounts", async () => {
+		vi.resetModules();
+		tempHome = await createTempHome();
+		await writeAccounts(tempHome, [
+			freshAccount({ email: "tagged@example.com", accountTags: ["work"] }),
+			freshAccount({
+				email: "untagged@example.com",
+				accountId: "acct_other",
+				refreshToken: "rt-other",
+			}),
+		]);
+		const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue({
+			ok: true,
+			status: 200,
+			json: async () => usagePayload,
+			text: async () => JSON.stringify(usagePayload),
+		} as unknown as Response);
+		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const { runInstaller } = await import("../scripts/install-oc-codex-multi-auth-core.js");
+
+		await runInstaller(["limits", "--tag", "work", "--json"], {
+			env: { ...process.env, HOME: tempHome, USERPROFILE: tempHome },
+		});
+
+		const output = JSON.parse(String(logSpy.mock.calls.at(-1)?.[0]));
+		// The untagged account must not be fetched: that would bill it a usage
+		// request and could persist refreshed credentials for it.
+		expect(output.accounts).toHaveLength(1);
+		expect(output.accounts[0].index).toBe(0);
+		expect(fetchSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it("limits: redacts token material leaked by a failing refresh", async () => {
+		vi.resetModules();
+		tempHome = await createTempHome();
+		await writeAccounts(tempHome, [freshAccount()]);
+		vi.spyOn(globalThis, "fetch").mockResolvedValue({
+			ok: false,
+			status: 401,
+			text: async () =>
+				'{"error":"invalid_grant","refresh_token":"rt-super-secret-value"}',
+		} as unknown as Response);
+		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const { runInstaller } = await import("../scripts/install-oc-codex-multi-auth-core.js");
+
+		await runInstaller(["limits", "--json"], {
+			env: { ...process.env, HOME: tempHome, USERPROFILE: tempHome },
+		});
+
+		const output = JSON.parse(String(logSpy.mock.calls.at(-1)?.[0]));
+		expect(output.accounts[0].error).not.toContain("rt-super-secret-value");
+	});
+
 	it("limits: an account whose usage fetch fails is reported and exits 1 (#209)", async () => {
 		vi.resetModules();
 		tempHome = await createTempHome();


### PR DESCRIPTION
## Summary

- **What changed?** Fixes the two open bug reports.

  **#210 — `warm` fails every account with `HTTP 400`.** Two independent causes:
  - The warm ping was pinned to `gpt-5.4`. That id is no longer in the installer's shipped model catalog (`config/opencode-modern.json` ships `gpt-5.4-mini`/`gpt-5.4-nano` but not `gpt-5.4`) and is listed in `STALE_MANAGED_MODEL_KEYS`, so the installer actively strips it from user config. Accounts without that entitlement got `model_not_supported_with_chatgpt_account`. The entry point moves to `gpt-5.5`, the generally-available anchor every 5.6 preview tier already degrades toward.
  - `warmAccountWindow` only classified `429` and dead-ended every other status, so it could not recover the way live chat traffic does. A `model_not_supported_with_chatgpt_account` 400 now walks the shared `resolveUnsupportedCodexFallbackModel` chain (`gpt-5.5 → gpt-5.4 → gpt-5.4-mini → gpt-5.4-nano`), bounded to 4 model attempts because `warm.ts` fans out across accounts concurrently.

  Two supporting changes: the warm body is built outside the request transformer, so it now applies the same `reasoning.effort: "none"` clamp — a fallback hop to a model that rejects `"none"` would otherwise be a fresh 400 — and failures report the sanitized upstream body instead of a bare status code.

  **#209 — `limits` shows no limits.** `runStandaloneCommand` computed `payload.rateLimits`, but `printStandaloneResult` never rendered it, so the output was identical to `list`. Even rendered it would have been empty: stored `rateLimitResetTimes` stays blank until a live request has already been rate-limited, and it carries reset timestamps, not the weekly/5h usage the command advertises. `limits` now has its own command that fetches `GET /wham/usage` through the compiled `codex-usage` runtime — the same path the in-conversation `codex-limits` tool uses, with the same workspace dedupe, window titles, and summaries.

- **Why is this needed?** Both commands are currently non-functional as documented. Closes #210, closes #209.

Before / after for `limits`:

```
- [0] Personal (role:owner) [id:2vFTKI] enabled=true refresh=true access=true   # before

- [0] Personal (demo....com)                                                    # after
  5h limit: 82% left (resets 14:20)
  Weekly limit: 58% left (resets 09:15 on Aug 04)
  Plan: plus
```

## Testing

- [x] `npm run lint` — 0 errors (3 pre-existing warnings in generated `coverage/`)
- [x] `npm run build`
- [x] `npm test` — 113 files, 2848 passed, 1 skipped
- [ ] Not applicable

10 new regression tests:
- `warm` falls back on an unsupported-model 400; stops at the bounded attempt budget; does **not** retry a non-entitlement 400; surfaces the sanitized detail; redacts bearer tokens leaked in an error body; keeps `effort: "none"` across the whole default chain and clamps it elsewhere.
- `limits` reports live 5h/weekly windows, renders them in text output, handles an empty pool, and reports a per-account fetch failure with exit 1.

Also smoke-tested the real CLI end to end (not just via vitest): empty pool exits 0 with the no-accounts message; a bogus-token account renders `Error: HTTP 403 …` inline with the email masked and exits 1.

## Compliance Confirmation

- [x] This change stays within the repository scope and OpenAI Terms of Service expectations.
- [x] This change uses official authentication flows only and does not add bypass, scraping, or credential-sharing behavior.
- [x] I updated tests and documentation when the change affected users, maintainers, or repository behavior.

## Notes

- Linked issue: #210, #209
- Follow-up work or rollout notes:
  - `limits` now makes a network call and may refresh a token, where it was previously a purely local read. This matches the command's documented purpose and the `codex-limits` tool; the help text is updated to "Show live 5-hour and weekly usage for each account". `rateLimitResetTimes` remains in the JSON payload so existing `--json` consumers do not break.
  - The `"none"`-effort allowlist in `warm-request.ts` duplicates the `supportsNone` rule in `request-transformer.ts`, which is a local (non-exported) const. Worth extracting into a shared predicate if a third caller ever needs it.
  - I could not verify against a live entitled account, so the `gpt-5.5` entry point is chosen from the shipped catalog and the codebase's own fallback topology rather than from an observed 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CZmm4Ye1fS25ovgh26T1TR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated account warming to start with GPT-5.5, apply canonical per-model reasoning settings, and automatically fall back through compatible models.
  - Enhanced the standalone CLI `limits` command with `--tag` to restrict live usage checks to matching accounts.

- **Bug Fixes**
  - Improved warm-up retry logic for unsupported-model cases, including clearer “tried models” messaging and better handling of quota vs active rate limits.
  - Strengthened CLI error handling to redact sensitive token material from output.

- **Chores**
  - Updated CI to run build before tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

this follow-up completes the `warm` and `limits` fixes.
- `warm` now starts with gpt-5.5, applies model-specific request shaping, and follows a bounded unsupported-model fallback chain.
- `limits` now loads the compiled usage runtime, fetches live usage, filters tagged accounts before network or token-refresh work, and masks refresh errors.
- ci now builds `dist` before running vitest suites that load compiled modules.

<h3>Confidence Score: 5/5</h3>

the pr appears safe to merge.

no blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lib/accounts/warm-request.ts | adds bounded model fallback, canonical reasoning configuration, per-model wire shaping, and sanitized upstream failures. |
| scripts/install-oc-codex-multi-auth-core.js | adds live limits retrieval and addresses the prior tag-filtering, duplicate-tag, and token-safety findings. |
| test/accounts-warm-request.test.ts | adds vitest coverage for fallback bounds, request reasoning, error classification, and token redaction. |
| test/standalone-cli.test.ts | adds vitest coverage for live limits output, pre-contact tag filtering, duplicate tags, and refresh-error redaction. |
| .github/workflows/ci.yml | builds generated runtime files before tests import them. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[limits command] --> B[load accounts]
  B --> C[deduplicate workspaces]
  C --> D[filter by tag]
  D --> E[refresh token if needed]
  E --> F[fetch live usage]
  F --> G[mask errors and print result]
```
</details>

<sub>Reviews (3): Last reviewed commit: ["test(cli): cover the refresh-error path ..."](https://github.com/ndycode/oc-codex-multi-auth/commit/5957bebaced96b6f244fa123e3cc737167a76c97) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48636362)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Multi-Account Rotation and Health](https://app.greptile.com/zeian/-/custom-context/knowledge-base/ndycode/oc-codex-multi-auth/-/docs/accounts-rotation.md)
- Knowledge Base — [Request Pipeline](https://app.greptile.com/zeian/-/custom-context/knowledge-base/ndycode/oc-codex-multi-auth/-/docs/request-pipeline.md)
- Knowledge Base — [Installer and Standalone CLI Scripts](https://app.greptile.com/zeian/-/custom-context/knowledge-base/ndycode/oc-codex-multi-auth/-/docs/installer-scripts.md)
</details>

<!-- /greptile_comment -->