### PR TITLE
fix(auth): stop disabling accounts whose OAuth scope is merely unknown (#213)

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -104,7 +104,7 @@ There is **no** registered “Manual API Key” login path for this plugin. The 
 
 The browser-based OAuth flow uses the same local callback port as Codex CLI. The authorize redirect is `http://localhost:1455/auth/callback`, while the local callback server binds `http://127.0.0.1:1455/auth/callback` and `[::1]:1455` for dual-stack localhost redirects. Authorization and token exchange go to `auth.openai.com`.
 
-If you authenticated before the connector scopes were added, re-run `opencode auth login`. Current account records persist the granted OAuth scope and accounts missing `api.connectors.read` / `api.connectors.invoke` are marked for re-auth instead of being silently reused.
+Account records persist the granted OAuth scope. The required scopes are `openid`, `profile`, `email`, and `offline_access`; an account whose recorded scope is explicitly missing one of them is marked for re-auth instead of being silently reused. An account whose scope is simply unrecorded is left enabled — absent metadata is not treated as a failed grant — and an account previously marked for re-auth is restored automatically once a complete scope is known.
 
 ### Remote or Headless Login
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -164,7 +164,7 @@ Failed to access Codex API
    opencode auth login
    ```
 
-   Re-auth is required for accounts created before `api.connectors.read` and `api.connectors.invoke` were requested; stale account records are marked inactive until they are refreshed through login.
+   Re-auth is required for accounts whose recorded OAuth scope is explicitly missing one of `openid`, `profile`, `email`, or `offline_access`; those records are marked inactive until they are refreshed through login. Accounts with no recorded scope stay active, and any account marked inactive by this check is restored automatically once a complete scope is known.
 
 2. **Check auth file exists:**
    ```bash

--- a/index.ts
+++ b/index.ts
@@ -693,6 +693,7 @@ export const OpenAIOAuthPlugin: Plugin = async ({ client }: PluginInput) => {
 			access?: unknown;
 			refresh?: unknown;
 			expires?: unknown;
+			scope?: unknown;
 		};
 		type HostAuthStore = Record<string, HostAuthEntry>;
 
@@ -757,6 +758,10 @@ export const OpenAIOAuthPlugin: Plugin = async ({ client }: PluginInput) => {
 			access: candidate.accessToken,
 			refresh: candidate.refreshToken,
 			expires: candidate.expiresAt,
+			// Carry the pool's scope across so the restored host credential is not
+			// scope-less on the next load; a scope-less fallback used to be read as
+			// "no scopes granted" (issue #213).
+			...(candidate.oauthScope ? { scope: candidate.oauthScope } : {}),
 		};
 
 		try {

--- a/lib/accounts.ts
+++ b/lib/accounts.ts
@@ -30,6 +30,7 @@ import {
 } from "./accounts/state.js";
 import { formatWaitTime, type RateLimitReason } from "./accounts/rate-limits.js";
 import { nowMs } from "./utils.js";
+import { logWarn } from "./logger.js";
 import { resolveDisplayEmail } from "./account-display.js";
 
 export type { AccountSelectionExplainability, ManagedAccount } from "./accounts/state.js";
@@ -93,6 +94,23 @@ export class AccountManager {
 		const stored = await loadAccounts();
 		const manager = new AccountManager(authFallback, stored);
 		await manager.recovery.hydrateFromCodexCli();
+		// `initializeFromStorage` repairs accounts an earlier build wrongly
+		// disabled for missing scopes, but only in memory. Flush it once so the
+		// TUI, the CLI, and any other direct storage reader stop reporting the
+		// stale disabled state and re-auth note (issue #213). A failed write is
+		// not fatal: the in-memory repair still holds for this process, and the
+		// next load repeats it.
+		if (manager.state.consumeScopeRepairs()) {
+			try {
+				await manager.persistence.saveToDisk();
+			} catch (error) {
+				logWarn(
+					`Failed to persist OAuth scope repair: ${
+						(error as Error)?.message ?? String(error)
+					}`,
+				);
+			}
+		}
 		return manager;
 	}
 

--- a/lib/accounts/persistence.ts
+++ b/lib/accounts/persistence.ts
@@ -121,7 +121,10 @@ export class AccountPersistence {
 			mine.refreshToken = theirs.refreshToken;
 			mine.accessToken = theirs.accessToken;
 			mine.expiresAt = theirs.expiresAt;
-			mine.oauthScope = theirs.oauthScope ?? mine.oauthScope;
+			// Truthy, not `??`: a legacy record can hold an empty-string scope, and
+			// `??` would let it overwrite a good in-memory value. Matches the live
+			// mirror below (issue #213).
+			mine.oauthScope = theirs.oauthScope || mine.oauthScope;
 			mine.tokenRotatedAt = theirs.tokenRotatedAt;
 
 			// Mirror into live state so this process stops refreshing with the

--- a/lib/accounts/state.ts
+++ b/lib/accounts/state.ts
@@ -91,6 +91,31 @@ function hasMissingScopeReauthNote(accountNote: string | undefined): boolean {
 	return typeof accountNote === "string" && accountNote.includes(MISSING_SCOPE_NOTE_MARKER);
 }
 
+/**
+ * Removes a re-auth note this class previously appended, preserving any
+ * operator-authored text that came before it. `appendReauthNote` always appends
+ * its sentence last, so everything from the marker onward is ours to drop.
+ */
+function stripReauthNote(accountNote: string | undefined): string | undefined {
+	if (!accountNote) return undefined;
+	const markerIndex = accountNote.indexOf(MISSING_SCOPE_NOTE_MARKER);
+	if (markerIndex < 0) return accountNote;
+	const preserved = accountNote.slice(0, markerIndex).trim();
+	return preserved.length > 0 ? preserved : undefined;
+}
+
+/**
+ * Required-scope check that only fires when the granted scope is actually
+ * known. Absent scope metadata means "unknown", NOT "nothing was granted":
+ * `refreshAccessToken` deliberately omits `scope` when the token response does,
+ * and host credentials restored by the OpenAI backfill carry no scope either.
+ * Treating that absence as a total scope failure disabled freshly-authenticated
+ * accounts with "missing: openid, profile, email, offline_access" (issue #213).
+ */
+function getEnforceableMissingOAuthScopes(scope: string | undefined): string[] {
+	return hasExplicitOAuthScope(scope) ? getMissingRequiredOAuthScopes(scope) : [];
+}
+
 function getAuthScope(auth: OAuthAuthDetails | undefined): string | undefined {
 	const scope = auth?.scope;
 	return typeof scope === "string" && scope.trim() ? scope : undefined;
@@ -118,7 +143,7 @@ export class AccountState {
 		const fallbackAccountId = extractAccountId(authFallback?.access);
 		const fallbackAccountEmail = sanitizeEmail(extractAccountEmail(authFallback?.access));
 		const fallbackOAuthScope = getAuthScope(authFallback);
-		const fallbackMissingOAuthScopes = getMissingRequiredOAuthScopes(fallbackOAuthScope);
+		const fallbackMissingOAuthScopes = getEnforceableMissingOAuthScopes(fallbackOAuthScope);
 
 		if (stored && stored.accounts.length > 0) {
 			const baseNow = nowMs();
@@ -141,9 +166,15 @@ export class AccountState {
 						matchesFallback && authFallback ? authFallback.refresh : account.refreshToken;
 					const oauthScope =
 						matchesFallback && fallbackOAuthScope ? fallbackOAuthScope : accountOAuthScope;
-					const hasExplicitScope = hasExplicitOAuthScope(accountOAuthScope);
-					const shouldEnforceScope = hasExplicitScope || hasMissingScopeReauthNote(account.accountNote);
-					const missingOAuthScopes = shouldEnforceScope ? getMissingRequiredOAuthScopes(oauthScope) : [];
+					const missingOAuthScopes = getEnforceableMissingOAuthScopes(oauthScope);
+					// An account this class disabled carries the re-auth note. Once the
+					// scope check stops firing, undo our own damage instead of leaving
+					// it disabled forever — 6.11.2 disabled accounts whose scope was
+					// merely unknown, and re-login alone could not clear that (#213).
+					// A note-less `enabled: false` stays disabled: that one is the
+					// operator's own choice.
+					const disabledByScopeCheck =
+						account.enabled === false && hasMissingScopeReauthNote(account.accountNote);
 
 					return {
 						index,
@@ -156,14 +187,16 @@ export class AccountState {
 						accountTags: account.accountTags,
 						accountNote: missingOAuthScopes.length > 0
 							? appendReauthNote(account.accountNote, missingOAuthScopes)
-							: account.accountNote,
+							: disabledByScopeCheck
+								? stripReauthNote(account.accountNote)
+								: account.accountNote,
 						email: matchesFallback
 							? fallbackAccountEmail ?? sanitizeEmail(account.email)
 							: sanitizeEmail(account.email),
 						refreshToken,
 						enabled:
-							account.enabled !== false &&
-							(!shouldEnforceScope || missingOAuthScopes.length === 0),
+							missingOAuthScopes.length === 0 &&
+							(disabledByScopeCheck || account.enabled !== false),
 						access:
 							matchesFallback && authFallback ? authFallback.access : account.accessToken,
 						expires:

--- a/lib/accounts/state.ts
+++ b/lib/accounts/state.ts
@@ -24,7 +24,7 @@ import {
 	sanitizeEmail,
 	shouldUpdateAccountIdFromToken,
 } from "../auth/token-utils.js";
-import { getMissingRequiredOAuthScopes } from "../auth/scopes.js";
+import { getMissingRequiredOAuthScopes, normalizeScope } from "../auth/scopes.js";
 import { getHealthTracker, getTokenTracker } from "../rotation.js";
 import { remapRateLimitBackoffAfterRemoval } from "../request/rate-limit-backoff.js";
 import { logWarn } from "../logger.js";
@@ -139,8 +139,7 @@ function getEnforceableMissingOAuthScopesAcross(
 }
 
 function getAuthScope(auth: OAuthAuthDetails | undefined): string | undefined {
-	const scope = auth?.scope;
-	return typeof scope === "string" && scope.trim() ? scope : undefined;
+	return normalizeScope(auth?.scope);
 }
 
 export class AccountState {
@@ -189,7 +188,9 @@ export class AccountState {
 						return null;
 					}
 
-					const accountOAuthScope = account.oauthScope;
+					// Canonicalize at the load boundary so a legacy blank on disk is
+					// carried as absent rather than as an explicit empty grant.
+					const accountOAuthScope = normalizeScope(account.oauthScope);
 
 					const matchesFallback =
 						!!authFallback &&

--- a/lib/accounts/state.ts
+++ b/lib/accounts/state.ts
@@ -116,6 +116,28 @@ function getEnforceableMissingOAuthScopes(scope: string | undefined): string[] {
 	return hasExplicitOAuthScope(scope) ? getMissingRequiredOAuthScopes(scope) : [];
 }
 
+/**
+ * Same check across several records of the *same* grant — typically the pool's
+ * stored scope and the host credential's scope. If any known source shows the
+ * required scopes, the account is fine; disabling on the weaker of two sources
+ * would strand an account the other already vouches for. When none satisfies,
+ * the smallest missing set wins so the note reports the best evidence held.
+ */
+function getEnforceableMissingOAuthScopesAcross(
+	scopes: (string | undefined)[],
+): string[] {
+	let fewestMissing: string[] | undefined;
+	for (const scope of scopes) {
+		if (!hasExplicitOAuthScope(scope)) continue;
+		const missing = getMissingRequiredOAuthScopes(scope);
+		if (missing.length === 0) return [];
+		if (!fewestMissing || missing.length < fewestMissing.length) {
+			fewestMissing = missing;
+		}
+	}
+	return fewestMissing ?? [];
+}
+
 function getAuthScope(auth: OAuthAuthDetails | undefined): string | undefined {
 	const scope = auth?.scope;
 	return typeof scope === "string" && scope.trim() ? scope : undefined;
@@ -135,6 +157,20 @@ export class AccountState {
 	 * the lost-update fix for shared-refresh-token accounts.
 	 */
 	incrementAuthFailuresChain: Map<string, Promise<number>> = new Map();
+	/**
+	 * Set when `initializeFromStorage` re-enabled an account that an earlier
+	 * build had wrongly disabled for missing scopes. The repair happens in
+	 * memory, so it must be flushed to disk or every surface that reads storage
+	 * directly keeps showing the stale disabled state and re-auth note.
+	 * `consumeScopeRepairs()` clears it, so the extra write happens once.
+	 */
+	private scopeRepairsPending = false;
+
+	consumeScopeRepairs(): boolean {
+		const pending = this.scopeRepairsPending;
+		this.scopeRepairsPending = false;
+		return pending;
+	}
 
 	initializeFromStorage(
 		authFallback: OAuthAuthDetails | undefined,
@@ -166,7 +202,13 @@ export class AccountState {
 						matchesFallback && authFallback ? authFallback.refresh : account.refreshToken;
 					const oauthScope =
 						matchesFallback && fallbackOAuthScope ? fallbackOAuthScope : accountOAuthScope;
-					const missingOAuthScopes = getEnforceableMissingOAuthScopes(oauthScope);
+					// The stored record and the matching host credential describe the
+					// same grant, so weigh both before disabling anything.
+					const missingOAuthScopes = getEnforceableMissingOAuthScopesAcross(
+						matchesFallback
+							? [accountOAuthScope, fallbackOAuthScope]
+							: [accountOAuthScope],
+					);
 					// An account this class disabled carries the re-auth note. Once the
 					// scope check stops firing, undo our own damage instead of leaving
 					// it disabled forever — 6.11.2 disabled accounts whose scope was
@@ -175,6 +217,9 @@ export class AccountState {
 					// operator's own choice.
 					const disabledByScopeCheck =
 						account.enabled === false && hasMissingScopeReauthNote(account.accountNote);
+					if (disabledByScopeCheck && missingOAuthScopes.length === 0) {
+						this.scopeRepairsPending = true;
+					}
 
 					return {
 						index,

--- a/lib/auth/auth.ts
+++ b/lib/auth/auth.ts
@@ -115,7 +115,11 @@ export async function exchangeAuthorizationCode(
 		refresh: json.refresh_token ?? "",
 		expires: Date.now() + json.expires_in * 1000,
 		idToken: json.id_token,
-		scope: json.scope ?? SCOPE,
+		// A blank `scope` must fall back to what we actually requested, not be
+		// stored verbatim: `??` lets an empty string through, and that empty
+		// string then overwrites known-good scope metadata downstream
+		// (`result.scope ?? existing.oauthScope`). See issue #213.
+		scope: json.scope?.trim() ? json.scope : SCOPE,
 		multiAccount: true,
 	};
 }

--- a/lib/auth/auth.ts
+++ b/lib/auth/auth.ts
@@ -13,7 +13,7 @@ export {
 	getMissingRequiredOAuthScopes,
 	hasRequiredOAuthScopes,
 } from "./scopes.js";
-import { SCOPE } from "./scopes.js";
+import { normalizeScope, SCOPE } from "./scopes.js";
 
 // OAuth constants (from openai/codex)
 export const CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann";
@@ -119,7 +119,7 @@ export async function exchangeAuthorizationCode(
 		// stored verbatim: `??` lets an empty string through, and that empty
 		// string then overwrites known-good scope metadata downstream
 		// (`result.scope ?? existing.oauthScope`). See issue #213.
-		scope: json.scope?.trim() ? json.scope : SCOPE,
+		scope: normalizeScope(json.scope) ?? SCOPE,
 		multiAccount: true,
 	};
 }

--- a/lib/auth/login-runner.ts
+++ b/lib/auth/login-runner.ts
@@ -6,6 +6,7 @@ import {
 	selectBestAccountCandidate,
 } from "../accounts.js";
 import { logInfo } from "../logger.js";
+import { normalizeScope } from "./scopes.js";
 import { MODEL_FAMILIES, type ModelFamily } from "../prompts/codex.js";
 import { withAccountStorageTransaction } from "../storage.js";
 import type { AccountIdSource, TokenResult } from "../types.js";
@@ -625,6 +626,12 @@ export async function persistAccountPool(
 					: undefined;
 			const accountLabel = result.accountLabel;
 			const accountEmail = sanitizeEmail(extractAccountEmail(result.access, result.idToken));
+			// A blank scope must never reach storage: it is indistinguishable from
+			// "granted nothing" at load time, and `?? existing.oauthScope` below
+			// would let it overwrite a good stored value instead of deferring to
+			// it. Absent stays absent — we do not invent a scope we were not told
+			// about (issue #213).
+			const normalizedScope = normalizeScope(result.scope);
 
 			const existingIndex = (() => {
 				if (organizationId) {
@@ -687,7 +694,7 @@ export async function persistAccountPool(
 					refreshToken: result.refresh,
 					accessToken: result.access,
 					expiresAt: result.expires,
-					oauthScope: result.scope,
+					oauthScope: normalizedScope,
 					addedAt: now,
 					lastUsed: now,
 				});
@@ -725,7 +732,7 @@ export async function persistAccountPool(
 				refreshToken: result.refresh,
 				accessToken: result.access,
 				expiresAt: result.expires,
-				oauthScope: result.scope ?? existing.oauthScope,
+				oauthScope: normalizedScope ?? existing.oauthScope,
 				lastUsed: now,
 			};
 			identityIndexes = buildIdentityIndexes();

--- a/lib/auth/scopes.ts
+++ b/lib/auth/scopes.ts
@@ -16,6 +16,18 @@ function parseOAuthScope(scope: string | undefined): Set<string> {
 	);
 }
 
+/**
+ * Canonicalizes a raw scope string: trims, collapses whitespace, drops
+ * duplicates, and returns `undefined` when nothing is left. Blank and absent
+ * scope must be indistinguishable, because an empty string that survives into
+ * storage overwrites known-good metadata through `scope ?? existing` chains
+ * (issue #213).
+ */
+export function normalizeScope(scope: string | undefined): string | undefined {
+	const entries = [...parseOAuthScope(scope)];
+	return entries.length > 0 ? entries.join(" ") : undefined;
+}
+
 export function getMissingRequiredOAuthScopes(scope: string | undefined): string[] {
 	const granted = parseOAuthScope(scope);
 	return REQUIRED_OAUTH_SCOPES.filter((required) => !granted.has(required));

--- a/test/accounts.test.ts
+++ b/test/accounts.test.ts
@@ -294,6 +294,96 @@ describe("AccountManager", () => {
 		expect(account?.accountNote).toBeUndefined();
 	});
 
+	// Issue #213: the host credential legitimately carries no `scope` — the
+	// plugin's own host backfill and `refreshAccessToken` both omit it when the
+	// token response does. Absent metadata is "unknown", not "nothing granted",
+	// so it must not disable the account the way an explicit partial grant does.
+	it("keeps the fallback account enabled when OAuth scope metadata is missing", () => {
+		const auth: OAuthAuthDetails = {
+			type: "oauth",
+			access: "access-token",
+			refresh: "refresh-token",
+			expires: Date.now() + 60_000,
+		};
+
+		const manager = new AccountManager(auth, null);
+		const account = manager.getCurrentAccount();
+
+		expect(account?.enabled).toBe(true);
+		expect(account?.accountNote).toBeUndefined();
+	});
+
+	it("keeps an unmatched fallback account enabled when OAuth scope metadata is missing", () => {
+		const now = Date.now();
+		const stored = {
+			version: 3 as const,
+			activeIndex: 0,
+			accounts: [
+				{
+					refreshToken: "stored-token",
+					oauthScope: SCOPE,
+					addedAt: now,
+					lastUsed: now,
+				},
+			],
+		};
+
+		const auth: OAuthAuthDetails = {
+			type: "oauth",
+			access: "access-token",
+			refresh: "unmatched-token",
+			expires: now + 60_000,
+		};
+
+		const manager = new AccountManager(auth, stored);
+		const accounts = manager.getAccountsSnapshot();
+
+		expect(accounts).toHaveLength(2);
+		expect(accounts[1]?.enabled).toBe(true);
+		expect(accounts[1]?.accountNote).toBeUndefined();
+	});
+
+	it("still disables a fallback account that explicitly lacks a required scope", () => {
+		const auth: OAuthAuthDetails = {
+			type: "oauth",
+			access: "access-token",
+			refresh: "refresh-token",
+			expires: Date.now() + 60_000,
+			scope: "openid profile",
+		};
+
+		const manager = new AccountManager(auth, null);
+		const account = manager.getCurrentAccount();
+
+		expect(account?.enabled).toBe(false);
+		expect(account?.accountNote).toContain("email, offline_access");
+	});
+
+	it("self-heals an account disabled by the scope check once a full scope is known", () => {
+		const now = Date.now();
+		const stored = {
+			version: 3 as const,
+			activeIndex: 0,
+			accounts: [
+				{
+					refreshToken: "refresh-token",
+					oauthScope: SCOPE,
+					enabled: false,
+					accountNote:
+						"Re-auth required for missing OAuth scope(s): openid, profile, email, offline_access.",
+					addedAt: now,
+					lastUsed: now,
+				},
+			],
+		};
+
+		const manager = new AccountManager(undefined, stored);
+		const account = manager.getCurrentAccount();
+
+		expect(account?.enabled).toBe(true);
+		expect(account?.accountNote).toBeUndefined();
+	});
+
 	it("rotates when the active account is rate-limited", () => {
     const now = Date.now();
     const stored = {

--- a/test/accounts.test.ts
+++ b/test/accounts.test.ts
@@ -20,6 +20,7 @@ vi.mock("../lib/storage.js", async (importOriginal) => {
   return {
     ...actual,
     saveAccounts,
+    loadAccounts: vi.fn().mockResolvedValue(null),
     // Persistence saves through the transaction; route its persist callback
     // to the saveAccounts mock (current=null: no on-disk state to merge).
     withAccountStorageTransaction: vi.fn(
@@ -382,6 +383,210 @@ describe("AccountManager", () => {
 
 		expect(account?.enabled).toBe(true);
 		expect(account?.accountNote).toBeUndefined();
+	});
+
+	// The pool record and the matching host credential describe one grant. A
+	// partial scope on either side alone must not strand the account.
+	it("keeps the account enabled when the stored scope is complete but the fallback is partial", () => {
+		const now = Date.now();
+		const stored = {
+			version: 3 as const,
+			activeIndex: 0,
+			accounts: [
+				{
+					refreshToken: "refresh-token",
+					oauthScope: SCOPE,
+					addedAt: now,
+					lastUsed: now,
+				},
+			],
+		};
+
+		const auth: OAuthAuthDetails = {
+			type: "oauth",
+			access: "access-token",
+			refresh: "refresh-token",
+			expires: now + 60_000,
+			scope: "openid profile",
+		};
+
+		const manager = new AccountManager(auth, stored);
+		const account = manager.getCurrentAccount();
+
+		expect(account?.enabled).toBe(true);
+		expect(account?.accountNote).toBeUndefined();
+	});
+
+	it("keeps the account enabled when the fallback scope is complete but the stored one is partial", () => {
+		const now = Date.now();
+		const stored = {
+			version: 3 as const,
+			activeIndex: 0,
+			accounts: [
+				{
+					refreshToken: "refresh-token",
+					oauthScope: "openid profile",
+					addedAt: now,
+					lastUsed: now,
+				},
+			],
+		};
+
+		const auth: OAuthAuthDetails = {
+			type: "oauth",
+			access: "access-token",
+			refresh: "refresh-token",
+			expires: now + 60_000,
+			scope: SCOPE,
+		};
+
+		const manager = new AccountManager(auth, stored);
+		const account = manager.getCurrentAccount();
+
+		expect(account?.enabled).toBe(true);
+		expect(account?.accountNote).toBeUndefined();
+	});
+
+	it("disables the account when both scope sources are partial", () => {
+		const now = Date.now();
+		const stored = {
+			version: 3 as const,
+			activeIndex: 0,
+			accounts: [
+				{
+					refreshToken: "refresh-token",
+					oauthScope: "openid",
+					addedAt: now,
+					lastUsed: now,
+				},
+			],
+		};
+
+		const auth: OAuthAuthDetails = {
+			type: "oauth",
+			access: "access-token",
+			refresh: "refresh-token",
+			expires: now + 60_000,
+			scope: "openid profile",
+		};
+
+		const manager = new AccountManager(auth, stored);
+		const account = manager.getCurrentAccount();
+
+		expect(account?.enabled).toBe(false);
+		// Reports the best evidence held — the smaller missing set.
+		expect(account?.accountNote).toBe(
+			"Re-auth required for missing OAuth scope(s): email, offline_access.",
+		);
+	});
+
+	it("preserves operator-authored note text when stripping a re-auth note", () => {
+		const now = Date.now();
+		const stored = {
+			version: 3 as const,
+			activeIndex: 0,
+			accounts: [
+				{
+					refreshToken: "refresh-token",
+					oauthScope: SCOPE,
+					enabled: false,
+					accountNote:
+						"work laptop Re-auth required for missing OAuth scope(s): openid, profile, email, offline_access.",
+					addedAt: now,
+					lastUsed: now,
+				},
+			],
+		};
+
+		const manager = new AccountManager(undefined, stored);
+		const account = manager.getCurrentAccount();
+
+		expect(account?.enabled).toBe(true);
+		expect(account?.accountNote).toBe("work laptop");
+	});
+
+	it("leaves an operator-disabled account without a re-auth note disabled", () => {
+		const now = Date.now();
+		const stored = {
+			version: 3 as const,
+			activeIndex: 0,
+			accounts: [
+				{
+					refreshToken: "refresh-token",
+					oauthScope: SCOPE,
+					enabled: false,
+					accountNote: "paused by hand",
+					addedAt: now,
+					lastUsed: now,
+				},
+			],
+		};
+
+		const manager = new AccountManager(undefined, stored);
+		const account = manager.getCurrentAccount();
+
+		expect(account?.enabled).toBe(false);
+		expect(account?.accountNote).toBe("paused by hand");
+	});
+
+	// The repair is applied in memory by initializeFromStorage; without a flush
+	// the TUI and CLI keep reading the stale disabled state and re-auth note.
+	it("persists the scope repair so storage stops reporting the account disabled", async () => {
+		const storage = await import("../lib/storage.js");
+		const loadAccounts = vi.mocked(storage.loadAccounts);
+		const saveAccounts = vi.mocked(storage.saveAccounts);
+		const now = Date.now();
+
+		loadAccounts.mockResolvedValueOnce({
+			version: 3 as const,
+			activeIndex: 0,
+			accounts: [
+				{
+					refreshToken: "refresh-token",
+					oauthScope: SCOPE,
+					enabled: false,
+					accountNote:
+						"Re-auth required for missing OAuth scope(s): openid, profile, email, offline_access.",
+					addedAt: now,
+					lastUsed: now,
+				},
+			],
+		});
+		saveAccounts.mockClear();
+
+		await AccountManager.loadFromDisk();
+
+		expect(saveAccounts).toHaveBeenCalledTimes(1);
+		const persisted = saveAccounts.mock.calls[0]?.[0] as {
+			accounts: { enabled?: boolean; accountNote?: string }[];
+		};
+		expect(persisted.accounts[0]?.enabled).toBeUndefined();
+		expect(persisted.accounts[0]?.accountNote).toBeUndefined();
+	});
+
+	it("does not write on load when there is no scope repair to persist", async () => {
+		const storage = await import("../lib/storage.js");
+		const loadAccounts = vi.mocked(storage.loadAccounts);
+		const saveAccounts = vi.mocked(storage.saveAccounts);
+		const now = Date.now();
+
+		loadAccounts.mockResolvedValueOnce({
+			version: 3 as const,
+			activeIndex: 0,
+			accounts: [
+				{
+					refreshToken: "refresh-token",
+					oauthScope: SCOPE,
+					addedAt: now,
+					lastUsed: now,
+				},
+			],
+		});
+		saveAccounts.mockClear();
+
+		await AccountManager.loadFromDisk();
+
+		expect(saveAccounts).not.toHaveBeenCalled();
 	});
 
 	it("rotates when the active account is rate-limited", () => {

--- a/test/auth.test.ts
+++ b/test/auth.test.ts
@@ -284,6 +284,32 @@ describe('Auth Module', () => {
 			}
 		});
 
+		// Issue #213: `??` let a blank scope through, and that blank value then
+		// overwrote known-good scope metadata via `result.scope ?? existing`.
+		it('falls back to the requested scope when the response scope is blank', async () => {
+			vi.spyOn(Date, 'now').mockReturnValue(1_000);
+			const originalFetch = globalThis.fetch;
+			globalThis.fetch = vi.fn(async () =>
+				new Response(JSON.stringify({
+					access_token: 'access-123',
+					refresh_token: 'refresh-123',
+					expires_in: 3600,
+					scope: '   ',
+				}), { status: 200 }),
+			) as never;
+
+			try {
+				const result = await exchangeAuthorizationCode('auth-code', 'verifier-123');
+				expect(result.type).toBe('success');
+				if (result.type === 'success') {
+					expect(result.scope).toBe(SCOPE);
+				}
+			} finally {
+				globalThis.fetch = originalFetch;
+				vi.restoreAllMocks();
+			}
+		});
+
 		it('returns failed for HTTP error response', async () => {
 			const originalFetch = globalThis.fetch;
 			globalThis.fetch = vi.fn(async () =>

--- a/test/login-runner.test.ts
+++ b/test/login-runner.test.ts
@@ -91,6 +91,76 @@ describe("login-runner persistAccountPool", () => {
 		expect(second?.accounts[0]?.refreshToken).toBe("refresh-new");
 	});
 
+	// Issue #213: a blank scope reaching storage is indistinguishable from
+	// "granted nothing" at load time, and would disable the account.
+	it("never persists a blank oauthScope for a fresh login", async () => {
+		await persistAccountPool(
+			[
+				{
+					type: "success",
+					access: jwtWithEmail("user@example.com"),
+					refresh: "refresh-blank-scope",
+					expires: Date.now() + 60_000,
+					scope: "   ",
+				},
+			],
+			false,
+		);
+
+		const loaded = await loadAccounts();
+		expect(loaded?.accounts).toHaveLength(1);
+		expect(loaded?.accounts[0]?.oauthScope).toBeUndefined();
+	});
+
+	it("does not let a blank scope overwrite a stored one on re-login", async () => {
+		await persistAccountPool(
+			[
+				{
+					type: "success",
+					access: jwtWithEmail("user@example.com"),
+					refresh: "refresh-scoped",
+					expires: Date.now() + 60_000,
+					scope: "openid profile email offline_access",
+				},
+			],
+			false,
+		);
+		await persistAccountPool(
+			[
+				{
+					type: "success",
+					access: jwtWithEmail("user@example.com"),
+					refresh: "refresh-scoped-2",
+					expires: Date.now() + 60_000,
+					scope: "",
+				},
+			],
+			false,
+		);
+
+		const loaded = await loadAccounts();
+		expect(loaded?.accounts).toHaveLength(1);
+		expect(loaded?.accounts[0]?.oauthScope).toBe("openid profile email offline_access");
+	});
+
+	it("normalizes a padded scope before persisting it", async () => {
+		await persistAccountPool(
+			[
+				{
+					type: "success",
+					access: jwtWithEmail("user@example.com"),
+					refresh: "refresh-padded",
+					expires: Date.now() + 60_000,
+					scope: "  openid   profile\temail offline_access  ",
+				},
+			],
+			false,
+		);
+
+		const loaded = await loadAccounts();
+		expect(loaded?.accounts[0]?.oauthScope).toBe("openid profile email offline_access");
+	});
+
 	it("keeps two genuinely distinct emails as separate accounts (control)", async () => {
 		await persistAccountPool(
 			[{ type: "success", access: jwtWithEmail("user@example.com"), refresh: "r-a", expires: Date.now() + 60_000 }],

--- a/test/scope-enforcement.integration.test.ts
+++ b/test/scope-enforcement.integration.test.ts
@@ -1,0 +1,225 @@
+/**
+ * End-to-end coverage for issue #213, exercised against REAL storage rather
+ * than the module mocks used in `test/accounts.test.ts`.
+ *
+ * The reported symptom was a fresh `opencode auth login` landing an account in
+ * the pool already disabled with
+ * "Re-auth required for missing OAuth scope(s): openid, profile, email,
+ * offline_access." — all four required scopes at once, which is what an absent
+ * scope looks like rather than a denied one. These tests drive the real
+ * login-persist -> load path and assert on what actually reaches disk.
+ */
+
+import { promises as fs } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { AccountManager } from "../lib/accounts.js";
+import { persistAccountPool } from "../lib/auth/login-runner.js";
+import { SCOPE } from "../lib/auth/auth.js";
+import { loadAccounts, saveAccounts, setStoragePathDirect } from "../lib/storage.js";
+import type { OAuthAuthDetails } from "../lib/types.js";
+
+const REAUTH_NOTE =
+	"Re-auth required for missing OAuth scope(s): openid, profile, email, offline_access.";
+
+describe("OAuth scope enforcement (issue #213, real storage)", () => {
+	let testDir: string;
+
+	beforeEach(async () => {
+		testDir = join(
+			tmpdir(),
+			`scope-enforcement-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+		);
+		await fs.mkdir(testDir, { recursive: true });
+		setStoragePathDirect(join(testDir, "accounts.json"));
+	});
+
+	afterEach(async () => {
+		setStoragePathDirect(null);
+		await fs.rm(testDir, { recursive: true, force: true });
+	});
+
+	// The exact reported flow: log in, then have the plugin load with a host
+	// credential that carries no scope (which is what `refreshAccessToken` and
+	// the host backfill both produce).
+	it("leaves a freshly logged-in account enabled when the host credential has no scope", async () => {
+		await persistAccountPool(
+			[
+				{
+					type: "success",
+					access: "access-token",
+					refresh: "refresh-token",
+					expires: Date.now() + 60_000,
+					scope: SCOPE,
+				},
+			],
+			false,
+		);
+
+		const hostCredential: OAuthAuthDetails = {
+			type: "oauth",
+			access: "access-token",
+			refresh: "refresh-token",
+			expires: Date.now() + 60_000,
+			// No `scope` — exactly what the host auth.json holds after a refresh.
+		};
+
+		const manager = await AccountManager.loadFromDisk(hostCredential);
+		const account = manager.getCurrentAccount();
+
+		expect(manager.getAccountCount()).toBe(1);
+		expect(account?.enabled).toBe(true);
+		expect(account?.accountNote).toBeUndefined();
+	});
+
+	it("leaves the account enabled when neither the pool nor the host records a scope", async () => {
+		await persistAccountPool(
+			[
+				{
+					type: "success",
+					access: "access-token",
+					refresh: "refresh-token",
+					expires: Date.now() + 60_000,
+				},
+			],
+			false,
+		);
+
+		const manager = await AccountManager.loadFromDisk({
+			type: "oauth",
+			access: "access-token",
+			refresh: "refresh-token",
+			expires: Date.now() + 60_000,
+		});
+
+		expect(manager.getCurrentAccount()?.enabled).toBe(true);
+		expect(manager.getCurrentAccount()?.accountNote).toBeUndefined();
+	});
+
+	// Recovery for anyone already stranded by 6.11.2: the repair must reach the
+	// file, not just the in-memory registry.
+	it("repairs a 6.11.2-disabled account and writes the repair to disk", async () => {
+		const now = Date.now();
+		await saveAccounts({
+			version: 3,
+			activeIndex: 0,
+			accounts: [
+				{
+					refreshToken: "refresh-token",
+					oauthScope: SCOPE,
+					enabled: false,
+					accountNote: REAUTH_NOTE,
+					addedAt: now,
+					lastUsed: now,
+				},
+			],
+			activeIndexByFamily: {},
+		});
+
+		const manager = await AccountManager.loadFromDisk();
+		expect(manager.getCurrentAccount()?.enabled).toBe(true);
+
+		// The point of the flush: a separate reader must see the repair too.
+		const onDisk = await loadAccounts();
+		expect(onDisk?.accounts[0]?.enabled).not.toBe(false);
+		expect(onDisk?.accounts[0]?.accountNote).toBeUndefined();
+	});
+
+	it("repairs a 6.11.2-disabled account whose scope was never recorded", async () => {
+		const now = Date.now();
+		await saveAccounts({
+			version: 3,
+			activeIndex: 0,
+			accounts: [
+				{
+					refreshToken: "refresh-token",
+					enabled: false,
+					accountNote: REAUTH_NOTE,
+					addedAt: now,
+					lastUsed: now,
+				},
+			],
+			activeIndexByFamily: {},
+		});
+
+		const manager = await AccountManager.loadFromDisk();
+		expect(manager.getCurrentAccount()?.enabled).toBe(true);
+
+		const onDisk = await loadAccounts();
+		expect(onDisk?.accounts[0]?.enabled).not.toBe(false);
+		expect(onDisk?.accounts[0]?.accountNote).toBeUndefined();
+	});
+
+	// The enforcement that must survive all of the above.
+	it("still disables an account whose recorded scope is genuinely incomplete", async () => {
+		const now = Date.now();
+		await saveAccounts({
+			version: 3,
+			activeIndex: 0,
+			accounts: [
+				{
+					refreshToken: "refresh-token",
+					oauthScope: "openid profile",
+					addedAt: now,
+					lastUsed: now,
+				},
+			],
+			activeIndexByFamily: {},
+		});
+
+		const manager = await AccountManager.loadFromDisk();
+		const account = manager.getAccountsSnapshot()[0];
+
+		expect(account?.enabled).toBe(false);
+		expect(account?.accountNote).toBe(
+			"Re-auth required for missing OAuth scope(s): email, offline_access.",
+		);
+	});
+
+	it("does not resurrect an account the operator disabled by hand", async () => {
+		const now = Date.now();
+		await saveAccounts({
+			version: 3,
+			activeIndex: 0,
+			accounts: [
+				{
+					refreshToken: "refresh-token",
+					oauthScope: SCOPE,
+					enabled: false,
+					addedAt: now,
+					lastUsed: now,
+				},
+			],
+			activeIndexByFamily: {},
+		});
+
+		const manager = await AccountManager.loadFromDisk();
+		expect(manager.getAccountsSnapshot()[0]?.enabled).toBe(false);
+	});
+
+	// A blank scope on disk is legacy junk, not an explicit empty grant.
+	it("treats a blank stored scope as absent rather than as a failed grant", async () => {
+		const now = Date.now();
+		await saveAccounts({
+			version: 3,
+			activeIndex: 0,
+			accounts: [
+				{
+					refreshToken: "refresh-token",
+					oauthScope: "   ",
+					addedAt: now,
+					lastUsed: now,
+				},
+			],
+			activeIndexByFamily: {},
+		});
+
+		const manager = await AccountManager.loadFromDisk();
+		const account = manager.getCurrentAccount();
+
+		expect(account?.enabled).toBe(true);
+		expect(account?.accountNote).toBeUndefined();
+		expect(account?.oauthScope).toBeUndefined();
+	});
+});

--- a/test/scope-enforcement.integration.test.ts
+++ b/test/scope-enforcement.integration.test.ts
@@ -40,10 +40,57 @@ describe("OAuth scope enforcement (issue #213, real storage)", () => {
 		await fs.rm(testDir, { recursive: true, force: true });
 	});
 
-	// The exact reported flow: log in, then have the plugin load with a host
-	// credential that carries no scope (which is what `refreshAccessToken` and
-	// the host backfill both produce).
-	it("leaves a freshly logged-in account enabled when the host credential has no scope", async () => {
+	// The reported symptom — "account is added but disabled". The account is
+	// *added* by the host-fallback branch, which only runs when the credential
+	// matches nothing in the pool (empty pool, or a pool written under a
+	// different storage path). A scope-less credential there was read as "no
+	// scopes granted" and pushed disabled.
+	it("adds a scope-less host credential as an enabled account when the pool is empty", async () => {
+		const hostCredential: OAuthAuthDetails = {
+			type: "oauth",
+			access: "access-token",
+			refresh: "refresh-token",
+			expires: Date.now() + 60_000,
+			// No `scope` — what the host auth.json holds after a refresh, and what
+			// the plugin's own host backfill used to write.
+		};
+
+		const manager = await AccountManager.loadFromDisk(hostCredential);
+		const account = manager.getCurrentAccount();
+
+		expect(manager.getAccountCount()).toBe(1);
+		expect(account?.enabled).toBe(true);
+		expect(account?.accountNote).toBeUndefined();
+	});
+
+	it("adds a scope-less host credential as enabled when it matches nothing in the pool", async () => {
+		await persistAccountPool(
+			[
+				{
+					type: "success",
+					access: "other-access",
+					refresh: "other-refresh",
+					expires: Date.now() + 60_000,
+					scope: SCOPE,
+				},
+			],
+			false,
+		);
+
+		const manager = await AccountManager.loadFromDisk({
+			type: "oauth",
+			access: "access-token",
+			refresh: "unmatched-refresh",
+			expires: Date.now() + 60_000,
+		});
+		const accounts = manager.getAccountsSnapshot();
+
+		expect(accounts).toHaveLength(2);
+		expect(accounts[1]?.enabled).toBe(true);
+		expect(accounts[1]?.accountNote).toBeUndefined();
+	});
+
+	it("keeps a matched account enabled when the pool has a scope but the host does not", async () => {
 		await persistAccountPool(
 			[
 				{
@@ -57,20 +104,62 @@ describe("OAuth scope enforcement (issue #213, real storage)", () => {
 			false,
 		);
 
-		const hostCredential: OAuthAuthDetails = {
+		const manager = await AccountManager.loadFromDisk({
 			type: "oauth",
 			access: "access-token",
 			refresh: "refresh-token",
 			expires: Date.now() + 60_000,
-			// No `scope` — exactly what the host auth.json holds after a refresh.
-		};
-
-		const manager = await AccountManager.loadFromDisk(hostCredential);
+		});
 		const account = manager.getCurrentAccount();
 
 		expect(manager.getAccountCount()).toBe(1);
 		expect(account?.enabled).toBe(true);
 		expect(account?.accountNote).toBeUndefined();
+	});
+
+	// A partial scope on the host credential must not override a complete pool
+	// scope for the same account.
+	it("keeps a matched account enabled when the host scope is partial but the pool is complete", async () => {
+		await persistAccountPool(
+			[
+				{
+					type: "success",
+					access: "access-token",
+					refresh: "refresh-token",
+					expires: Date.now() + 60_000,
+					scope: SCOPE,
+				},
+			],
+			false,
+		);
+
+		const manager = await AccountManager.loadFromDisk({
+			type: "oauth",
+			access: "access-token",
+			refresh: "refresh-token",
+			expires: Date.now() + 60_000,
+			scope: "openid profile",
+		});
+		const account = manager.getCurrentAccount();
+
+		expect(account?.enabled).toBe(true);
+		expect(account?.accountNote).toBeUndefined();
+	});
+
+	it("disables a host credential whose scope is explicitly incomplete", async () => {
+		const manager = await AccountManager.loadFromDisk({
+			type: "oauth",
+			access: "access-token",
+			refresh: "refresh-token",
+			expires: Date.now() + 60_000,
+			scope: "openid profile",
+		});
+		const account = manager.getAccountsSnapshot()[0];
+
+		expect(account?.enabled).toBe(false);
+		expect(account?.accountNote).toBe(
+			"Re-auth required for missing OAuth scope(s): email, offline_access.",
+		);
 	});
 
 	it("leaves the account enabled when neither the pool nor the host records a scope", async () => {


### PR DESCRIPTION
Fixes #213.

## Symptom

A fresh `opencode auth login` adds the account, then immediately disables it:

> Re-auth required for missing OAuth scope(s): openid, profile, email, offline_access.

All four required scopes at once. That is not what a partial grant looks like — it is the signature of scope metadata being **absent** rather than denied.

## Root cause

`AccountState.initializeFromStorage()` enforced required scopes asymmetrically.

The stored-account path guarded on `hasExplicitOAuthScope`, so an account with no recorded scope was deliberately left alone. The two `authFallback` paths had no such guard — they ran `getMissingRequiredOAuthScopes(undefined)`, which returns all four required scopes, and pushed the account with `enabled: false` plus the re-auth note.

A scope-less credential is normal in this codebase, not suspicious:

- `refreshAccessToken` intentionally omits `scope` when the token response does, because callers resolve it with `result.scope ?? existing.oauthScope`.
- `backfillHostOpenAIAuthFromPool` wrote the restored host entry with only `type/access/refresh/expires`.

Either one is enough to reach a fallback path with no scope and lose the account. That also fits the reporter's observation that a second account worked and that a concurrently running opencode session seemed involved — whichever session last wrote the host credential decided whether scope metadata survived.

## Changes

- **`lib/accounts/state.ts`** — every enforcement site now routes through `getEnforceableMissingOAuthScopes`, which only fires when the granted scope is actually known. An explicit partial grant (`"openid profile"`) still disables exactly as before.
- **Self-heal.** `enabled: false` together with the machine-written re-auth note means *we* disabled the account, so it is re-enabled and the note stripped once the check stops firing. 6.11.2 persisted that disabled state, and re-login alone could not clear it. A note-less `enabled: false` is the operator's own choice and stays disabled.
- **`lib/auth/auth.ts`** — `json.scope ?? SCOPE` let an empty string through, which then overwrote known-good metadata downstream via `result.scope ?? existing.oauthScope`. Blank now falls back to the scope we actually requested.
- **`index.ts`** — the host backfill carries `oauthScope` across, so a restored credential is not scope-less on the next load.

## Tests

Five regression tests, all failing before this change:

- fallback-only login with no scope metadata stays enabled
- unmatched fallback with no scope metadata stays enabled
- explicit partial scope still disables (guards against over-correcting)
- an account disabled by this check self-heals once a full scope is known
- a blank response scope falls back to the requested scope

Full suite: 113 files, 2861 passed, 1 skipped. `tsc --noEmit` and `eslint` clean.

## Risk

The self-heal re-enables any account carrying the note and `enabled: false`. The note is only ever machine-written alongside an automatic disable, so this is the intended population; the narrow edge case is an operator who manually disabled an account that already carried the note. That trade buys automatic recovery for everyone stranded by 6.11.2, who otherwise have no path back short of editing the pool JSON by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lv8ZRVdmaQyCxz1tdsoEBF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OAuth scope handling when scope information is missing, blank, or incomplete.
  * Prevented accounts from being disabled when scope metadata is unavailable.
  * Automatically re-enabled previously affected accounts when complete scope information becomes available.
  * Preserved existing account notes and prevented duplicate re-authentication messages.
  * Preserved OAuth scope details when restoring host credentials.
  * Normalized stored OAuth scopes and retained existing values when new scope data is blank.
  * Persisted account repairs safely without interrupting account loading.

* **Documentation**
  * Clarified OAuth scope validation and re-authentication behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

the pr distinguishes unknown oauth scope metadata from explicit partial grants, repairs accounts previously disabled by the scope check, normalizes scope values, and preserves scope during host credential backfill.
- routes scope enforcement through normalized, known-scope checks.
- persists self-healed account state and retains newer token credentials during transactional saves.
- adds vitest coverage for missing, blank, partial, and restored scope states.
- no new windows filesystem handling risk is introduced; existing atomic rename retries remain unchanged.
- token safety is improved by preventing blank scope metadata from replacing known scope information.

<h3>Confidence Score: 5/5</h3>

the pr appears safe to merge because no eligible blocking failure or outstanding prior finding remains.

no blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lib/accounts/state.ts | centralizes known-scope enforcement, normalizes stored scope metadata, and repairs generated disabled state. |
| lib/accounts.ts | flushes load-time scope repairs through the existing persistence layer. |
| lib/accounts/persistence.ts | prevents blank on-disk scope values from replacing usable in-memory scope metadata. |
| lib/auth/auth.ts | falls back to the requested scope when the authorization response contains a blank scope. |
| lib/auth/login-runner.ts | normalizes scope before creating or updating persisted accounts. |
| lib/auth/scopes.ts | adds canonical scope normalization for whitespace, duplicates, and blank values. |
| index.ts | carries pool scope metadata into restored host credentials. |
| test/scope-enforcement.integration.test.ts | adds real-storage vitest coverage for unknown, partial, repaired, and operator-disabled scope states. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[load pool and host credential] --> B[normalize recorded scopes]
  B --> C{explicit scope known?}
  C -->|no| D[leave account enabled]
  C -->|yes, complete| E[enable or repair generated disable]
  C -->|yes, partial| F[disable and append re-auth note]
  E --> G[persist repaired state transactionally]
  D --> H[use account]
  G --> H
```
</details>

<sub>Reviews (3): Last reviewed commit: ["test(auth): make the #213 integration te..."](https://github.com/ndycode/oc-codex-multi-auth/commit/d0e2d664918abf0d98808a26264f146cfd1143f4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49442465)</sub>

<details><summary><h4>Context used (4)</h4></summary>

- Knowledge Base — [OAuth login and token refresh](https://app.greptile.com/zeian/-/custom-context/knowledge-base/ndycode/oc-codex-multi-auth/-/docs/auth-oauth.md)
- Knowledge Base — [Multi-Account Rotation and Health](https://app.greptile.com/zeian/-/custom-context/knowledge-base/ndycode/oc-codex-multi-auth/-/docs/accounts-rotation.md)
- Knowledge Base — [Account Storage Layer](https://app.greptile.com/zeian/-/custom-context/knowledge-base/ndycode/oc-codex-multi-auth/-/docs/storage.md)
- Knowledge Base — [Plugin Entrypoint: index.ts](https://app.greptile.com/zeian/-/custom-context/knowledge-base/ndycode/oc-codex-multi-auth/-/docs/plugin-entrypoint.md)
</details>

<!-- /greptile_comment -->