### PR TITLE
fix(accounts): replace the stale re-auth note instead of appending a second

### DIFF
--- a/lib/accounts/state.ts
+++ b/lib/accounts/state.ts
@@ -74,11 +74,20 @@ function initFamilyState(defaultValue: number): Record<ModelFamily, number> {
 	) as Record<ModelFamily, number>;
 }
 
+/**
+ * Replaces any re-auth note already on the record with one describing the
+ * currently missing scopes, keeping operator-authored text intact.
+ *
+ * Replace, not append: the previous exact-match guard only recognized an
+ * identical sentence, so a record whose missing set had changed since it was
+ * written — the whole 6.11.2 population, once a real scope became known —
+ * ended up carrying both sentences, the stale one first and contradicting the
+ * accurate one.
+ */
 function appendReauthNote(accountNote: string | undefined, missingScopes: string[]): string {
 	const suffix = `Re-auth required for missing OAuth scope(s): ${missingScopes.join(", ")}.`;
-	if (!accountNote) return suffix;
-	if (accountNote.includes(suffix)) return accountNote;
-	return `${accountNote} ${suffix}`;
+	const preserved = stripReauthNote(accountNote);
+	return preserved ? `${preserved} ${suffix}` : suffix;
 }
 
 const MISSING_SCOPE_NOTE_MARKER = "Re-auth required for missing OAuth scope(s):";

--- a/test/accounts.test.ts
+++ b/test/accounts.test.ts
@@ -589,6 +589,61 @@ describe("AccountManager", () => {
 		expect(saveAccounts).not.toHaveBeenCalled();
 	});
 
+	// The stale sentence contradicted the accurate one: a 6.11.2 record says all
+	// four scopes are missing, but once a real partial scope is known only two
+	// are. The exact-match guard did not recognize the differing sentence.
+	it("replaces a stale re-auth note instead of appending a second one", () => {
+		const now = Date.now();
+		const stored = {
+			version: 3 as const,
+			activeIndex: 0,
+			accounts: [
+				{
+					refreshToken: "refresh-token",
+					oauthScope: "openid profile",
+					enabled: false,
+					accountNote:
+						"Re-auth required for missing OAuth scope(s): openid, profile, email, offline_access.",
+					addedAt: now,
+					lastUsed: now,
+				},
+			],
+		};
+
+		const manager = new AccountManager(undefined, stored);
+		const note = manager.getAccountsSnapshot()[0]?.accountNote;
+
+		expect(note).toBe(
+			"Re-auth required for missing OAuth scope(s): email, offline_access.",
+		);
+		expect(note?.match(/Re-auth required/g)).toHaveLength(1);
+	});
+
+	it("keeps operator text when replacing a stale re-auth note", () => {
+		const now = Date.now();
+		const stored = {
+			version: 3 as const,
+			activeIndex: 0,
+			accounts: [
+				{
+					refreshToken: "refresh-token",
+					oauthScope: "openid profile",
+					enabled: false,
+					accountNote:
+						"work laptop Re-auth required for missing OAuth scope(s): openid, profile, email, offline_access.",
+					addedAt: now,
+					lastUsed: now,
+				},
+			],
+		};
+
+		const manager = new AccountManager(undefined, stored);
+
+		expect(manager.getAccountsSnapshot()[0]?.accountNote).toBe(
+			"work laptop Re-auth required for missing OAuth scope(s): email, offline_access.",
+		);
+	});
+
 	it("rotates when the active account is rate-limited", () => {
     const now = Date.now();
     const stored = {


### PR DESCRIPTION
Found while deep-testing the #213 merge (#214).

## The bug

`appendReauthNote` guarded against duplication with `accountNote.includes(suffix)`, which only recognizes an *identical* sentence. A record whose missing-scope set changed since the note was written therefore accumulates both:

```
Re-auth required for missing OAuth scope(s): openid, profile, email, offline_access. Re-auth required for missing OAuth scope(s): email, offline_access.
```

The stale sentence comes first and contradicts the accurate one, so the surface that shows it tells the user to re-auth for scopes that are not actually missing.

This is reachable for the entire 6.11.2 population, not a corner case: those records claim all four scopes are missing, so the moment a real — but partial — scope becomes known, the sets differ and both sentences stick.

## The fix

`appendReauthNote` strips any existing re-auth note before appending, reusing the `stripReauthNote` helper added in #214. Operator-authored text ahead of the marker survives; exactly one re-auth sentence is ever present.

## Verification

Two regression tests, plus a probe against the built `dist/`:

- notes no longer duplicate when the missing set changes
- `load -> save -> load` is idempotent across three reloads, no drift
- a multi-account pool (healed / genuinely-partial / scope-less) repairs correctly in one pass
- operator text ahead of the marker survives the heal
- a genuinely partial scope still disables, with an accurate note

Full suite: 114 files, 2884 passed, 1 skipped. `tsc --noEmit`, `eslint`, `npm run build`, and `npm audit --omit=dev` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lv8ZRVdmaQyCxz1tdsoEBF

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

this pr replaces stale oauth re-auth notes during account hydration while preserving ordinary operator text.
- routes missing-scope note updates through the existing stripping helper
- adds vitest coverage for stale-note replacement and operator text preceding the generated marker
- does not change windows filesystem handling, token persistence, or concurrency behavior

<h3>Confidence Score: 4/5</h3>

the pr appears safe to merge, with one non-blocking operator-note preservation edge case worth addressing.

the stale-note replacement works for generated notes and ordinary operator prefixes, but exact marker text entered through codex-note is truncated during missing-scope hydration.

**Files Needing Attention:** lib/accounts/state.ts, test/accounts.test.ts

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lib/accounts/state.ts | replaces stale generated re-auth text correctly, but the delimiter can collide with operator-authored note content. |
| test/accounts.test.ts | covers replacement and ordinary prefix preservation, but misses the reachable marker-collision case. |

</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Foc-codex-multi-auth%22%20on%20the%20existing%20branch%20%22fix%2Freauth-note-duplication%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Freauth-note-duplication%22.%0A%0A%23%23%23%20Issue%201%0Alib%2Faccounts%2Fstate.ts%3A89%0A**preserve%20marker%20text%20in%20operator%20notes**%0A%0Awhen%20an%20operator%20note%20contains%20the%20literal%20re-auth%20marker%2C%20%60stripReauthNote%60%20treats%20that%20text%20as%20generated%20content%20and%20truncates%20everything%20from%20the%20marker%20onward%20during%20missing-scope%20hydration.%20the%20new%20vitest%20coverage%20only%20exercises%20operator%20text%20preceding%20the%20marker%2C%20so%20this%20note-loss%20case%20remains%20uncovered.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=ndycode%2Foc-codex-multi-auth&pr=215&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
lib/accounts/state.ts:89
**preserve marker text in operator notes**

when an operator note contains the literal re-auth marker, `stripReauthNote` treats that text as generated content and truncates everything from the marker onward during missing-scope hydration. the new vitest coverage only exercises operator text preceding the marker, so this note-loss case remains uncovered.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(accounts): replace the stale re-auth..."](https://github.com/ndycode/oc-codex-multi-auth/commit/79a08c761f47bd9b6640f39fa36a8bc42e0b9388) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49447588)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Context used - speak in lowercase, concise sentences. act like th... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))
- Knowledge Base — [Multi-Account Rotation and Health](https://app.greptile.com/zeian/-/custom-context/knowledge-base/ndycode/oc-codex-multi-auth/-/docs/accounts-rotation.md)
- Knowledge Base — [OAuth login and token refresh](https://app.greptile.com/zeian/-/custom-context/knowledge-base/ndycode/oc-codex-multi-auth/-/docs/auth-oauth.md)
</details>

<!-- /greptile_comment -->