### PR TITLE
fix(loader): retry after a failed account load instead of caching the rejection

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -3,7 +3,17 @@ import tsparser from "@typescript-eslint/parser";
 
 export default [
   {
-    ignores: ["dist/**", "node_modules/**", "winston/**", "*.cjs", "*.mjs"],
+    // `coverage/` holds vitest's generated HTML report, including vendored JS.
+    // It is gitignored but was still being linted, so `npm run lint` reported
+    // warnings from generated files after any `npm run test:coverage`.
+    ignores: [
+      "dist/**",
+      "coverage/**",
+      "node_modules/**",
+      "winston/**",
+      "*.cjs",
+      "*.mjs",
+    ],
   },
   {
     files: ["index.ts", "tui.ts", "lib/**/*.ts"],

--- a/index.ts
+++ b/index.ts
@@ -1609,7 +1609,21 @@ export const OpenAIOAuthPlugin: Plugin = async ({ client }: PluginInput) => {
 				});
 				try {
 					if (!accountManagerPromise) {
-						accountManagerPromise = AccountManager.loadFromDisk(authFallback);
+						// Evict the cached promise if the load rejects. Without this a
+						// transient read failure — a momentary Windows file lock, a
+						// partially-written save — parks a rejected promise here and
+						// every later request re-awaits it, so the plugin keeps failing
+						// long after the cause is gone and only an opencode restart
+						// clears it. The guard keeps a concurrent reload's newer promise
+						// from being dropped. The current call still rejects; only the
+						// next one gets a fresh attempt.
+						const pending = AccountManager.loadFromDisk(authFallback);
+						accountManagerPromise = pending;
+						void pending.catch(() => {
+							if (accountManagerPromise === pending) {
+								accountManagerPromise = null;
+							}
+						});
 					}
 					let accountManager = await accountManagerPromise;
 					cachedAccountManager = accountManager;

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -715,6 +715,44 @@ describe("OpenAIOAuthPlugin", () => {
 	});
 
 	describe("auth loader", () => {
+		// The loader caches `accountManagerPromise` before awaiting it. A rejected
+		// load therefore parks a rejected promise in that cache, and nothing
+		// clears it on failure — so a transient read error (a momentary Windows
+		// file lock, a partially-written save) keeps failing every later request
+		// until opencode is restarted, long after the cause is gone.
+		it("recovers on the next call when a load fails transiently", async () => {
+			const accountsModule = await import("../lib/accounts.js");
+			const healthyManager = {
+				getAccountCount: () => 1,
+				getSelectionExplainability: () => null,
+				getCurrentOrNextForFamilyHybrid: () => null,
+				getAccountForStrategy: () => null,
+				getMinWaitTimeForFamily: () => 0,
+				hasRefreshToken: () => true,
+				saveToDisk: async () => {},
+			} as unknown as InstanceType<typeof accountsModule.AccountManager>;
+
+			const spy = vi
+				.spyOn(accountsModule.AccountManager, "loadFromDisk")
+				.mockRejectedValueOnce(new Error("EBUSY: storage temporarily locked"))
+				.mockResolvedValue(healthyManager);
+
+			const getAuth = async () => ({
+				type: "oauth" as const,
+				access: "access-token",
+				refresh: "refresh-token",
+				expires: Date.now() + 60_000,
+				multiAccount: true,
+			});
+
+			await expect(plugin.auth.loader(getAuth, {})).rejects.toThrow();
+
+			// The transient cause is gone; the next load must be attempted again.
+			const result = await plugin.auth.loader(getAuth, {});
+			expect(result.fetch).toBeDefined();
+			expect(spy).toHaveBeenCalledTimes(2);
+		});
+
 		it("returns SDK config for non-oauth auth when stored accounts exist", async () => {
 			const getAuth = async () => ({ type: "apikey" as const, key: "test" });
 			const result = await plugin.auth.loader(getAuth, {});


### PR DESCRIPTION
Two findings from deep-testing `main` after the #213 work (#214, #215).

## 1. A failed account load poisons the plugin until restart

`loader()` assigns `accountManagerPromise` **before** awaiting it, and nothing clears that cache when the load rejects — `invalidateAccountManagerCache()` only runs on explicit account mutations. A rejected promise stays parked in the cache, and every later request re-awaits the same rejection.

The failure outlives its own cause. One momentary Windows file lock, or a partially-written save during a concurrent write, rejects a single load — and from then on every request fails with that stale error until opencode is restarted. This repo already treats Windows lock contention as expected (`lib/storage.ts` retries renames for exactly that reason), so the trigger is realistic rather than hypothetical.

**Fix:** evict the cached promise on rejection, guarded by identity so a concurrent reload's newer promise is not dropped. The failing call still rejects; only the next one gets a fresh attempt.

**Proof:** the regression test mocks `loadFromDisk` to reject once and then succeed, and asserts the second `loader()` call succeeds. Against the previous commit it fails, re-throwing the first error with only **one** `loadFromDisk` call recorded — the second call never happened.

## 2. eslint linted generated coverage output

`eslint.config.js` ignored `dist/` but not `coverage/`. After any `npm run test:coverage`, `npm run lint` reported 3 warnings from vitest's generated HTML report (vendored `prettify.js`, `sorter.js`, `block-navigation.js`), and `eslint . --max-warnings=0` — what the pre-commit hook runs — failed on generated files. `coverage/` is gitignored, so this was purely a lint-config gap. Now ignored alongside `dist/`.

## Verification

- `eslint . --ext .ts --max-warnings=0` now exits 0; it did not before
- Full suite: 114 files, 2885 passed, 1 skipped
- `tsc --noEmit` and `npm run build` clean

Also probed with no defects found: rotation never selects a disabled or rate-limited account, removal keeps indices contiguous and remaps rate-limit backoff to the right account, `migrateV1ToV3` preserves all accounts and credentials, malformed/corrupt storage degrades to `null` rather than throwing, `decodeJWT` never throws on hostile input, and a 5000-account pool loads fine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lv8ZRVdmaQyCxz1tdsoEBF

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

this pr evicts a failed account-manager load so a transient windows filesystem error does not poison later requests, and excludes generated vitest coverage output from eslint.

- preserves a concurrently installed account-manager promise through an identity guard, protecting fresh token state
- adds sequential reject-then-retry vitest coverage, but not the guard's concurrent replacement branch
- ignores coverage/** during linting

<h3>Confidence Score: 4/5</h3>

the pr appears safe to merge, with one non-blocking gap in concurrency-focused vitest coverage.

the rejection cache is cleared before serialized loader waiters proceed, and the identity check protects newer account and token state; only the concurrent replacement branch remains untested.

**Files Needing Attention:** test/index.test.ts

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| index.ts | retries after transient account-load rejection while an identity guard preserves concurrent cache replacements. |
| test/index.test.ts | verifies sequential recovery, but lacks vitest coverage for the concurrency-specific identity-guard branch. |
| eslint.config.js | excludes generated coverage reports from eslint without changing source lint coverage. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant L as loader
  participant D as disk load
  participant R as concurrent reload
  L->>D: cache pending load
  R->>L: install newer manager promise
  D-->>L: reject
  L->>L: compare cache with pending
  L->>L: preserve newer promise
```
</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Foc-codex-multi-auth%22%20on%20the%20existing%20branch%20%22fix%2Floader-cached-rejection%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Floader-cached-rejection%22.%0A%0A%23%23%23%20Issue%201%0Atest%2Findex.test.ts%3A750-751%0A**cover%20concurrent%20cache%20replacement**%0A%0Athis%20test%20covers%20sequential%20retry%20but%20not%20the%20identity%20guard%E2%80%99s%20concurrency-specific%20branch.%20add%20a%20vitest%20case%20where%20a%20reload%20installs%20a%20newer%20%60accountManagerPromise%60%20before%20the%20original%20load%20rejects%2C%20so%20regressions%20cannot%20discard%20fresh%20account%20or%20oauth%20token%20state%20while%20this%20test%20still%20passes.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=ndycode%2Foc-codex-multi-auth&pr=216&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
test/index.test.ts:750-751
**cover concurrent cache replacement**

this test covers sequential retry but not the identity guard’s concurrency-specific branch. add a vitest case where a reload installs a newer `accountManagerPromise` before the original load rejects, so regressions cannot discard fresh account or oauth token state while this test still passes.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(loader): retry after a failed accoun..."](https://github.com/ndycode/oc-codex-multi-auth/commit/9e364a68faf01a036fd6461dd90c113ae4a42bca) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49448275)</sub>

**Context used:**

- Context used - speak in lowercase, concise sentences. act like th... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))
- Knowledge Base — [Plugin Entrypoint: index.ts](https://app.greptile.com/zeian/-/custom-context/knowledge-base/ndycode/oc-codex-multi-auth/-/docs/plugin-entrypoint.md)

<!-- /greptile_comment -->