### PR TITLE
fix(rotation): stop retrying accounts whose weekly quota is spent (#218)

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -112,6 +112,7 @@ import { handleContextOverflow } from "./lib/context-overflow.js";
 import {
 	AccountManager,
 	type AccountSelectionExplainability,
+	type ManagedAccount,
         extractAccountEmail,
         extractAccountId,
         formatAccountLabel,
@@ -233,6 +234,7 @@ import {
 	parseCodexUsagePayload,
 	type CodexUsageSummary,
 } from "./lib/codex-usage.js";
+import { getQuotaExhaustedResetAtMs } from "./lib/quota-windows.js";
 import {
 	clearTuiQuotaSnapshot,
 	parseTuiQuotaSnapshotFromHeaders,
@@ -667,6 +669,40 @@ export const OpenAIOAuthPlugin: Plugin = async ({ client }: PluginInput) => {
 			} catch (error) {
 				logDebug(
 					`[${PLUGIN_NAME}] Failed to record TUI quota headers: ${error instanceof Error ? error.message : String(error)}`,
+				);
+			}
+		};
+
+		/**
+		 * Take an account out of rotation whenever the backend reports one of its
+		 * quota windows as fully spent (issue #218).
+		 *
+		 * Every Codex response — success or 429 — carries `x-codex-*-used-percent`
+		 * and the matching reset time, so the moment an account hits 0% left we
+		 * can record it instead of rediscovering it with a failed request on every
+		 * subsequent prompt. The block lands on the persisted `rateLimitResetTimes`
+		 * map, so it is remembered across restarts and shared with other processes,
+		 * and it clears itself once the window rolls over.
+		 */
+		const applyQuotaExhaustion = (
+			manager: AccountManager,
+			headers: Headers,
+			account: ManagedAccount,
+			family: ModelFamily,
+			model: string | null | undefined,
+		): void => {
+			try {
+				const resetAtMs = getQuotaExhaustedResetAtMs(headers);
+				if (resetAtMs === undefined) return;
+				if (!manager.markQuotaExhausted(account, resetAtMs, family, model)) return;
+				account.lastSwitchReason = "rate-limit";
+				manager.saveToDiskDebounced();
+				logWarn(
+					`Account ${account.index + 1} (${account.email ?? "unknown"}) has no ${family} quota left; skipping it for ${formatWaitTime(resetAtMs - Date.now())}.`,
+				);
+			} catch (error) {
+				logDebug(
+					`[${PLUGIN_NAME}] Failed to apply quota exhaustion: ${error instanceof Error ? error.message : String(error)}`,
 				);
 			}
 		};
@@ -2380,6 +2416,13 @@ export const OpenAIOAuthPlugin: Plugin = async ({ client }: PluginInput) => {
 								headers: Object.fromEntries(response.headers.entries()),
 							});
 							void recordPromptQuotaHeaders(response, account, accountCount);
+							applyQuotaExhaustion(
+								accountManager,
+								response.headers,
+								account,
+								modelFamily,
+								model,
+							);
 
 								if (!response.ok) {
 									const contextOverflowResult = await handleContextOverflow(response, model);

--- a/lib/accounts.ts
+++ b/lib/accounts.ts
@@ -327,6 +327,21 @@ export class AccountManager {
 		this.rotation.markRateLimitedWithReason(account, retryAfterMs, family, reason, model);
 	}
 
+	/**
+	 * Block an account until a fully-spent quota window resets. See
+	 * {@link AccountRotation.markQuotaExhausted}.
+	 *
+	 * @returns true when a new (or longer) block was written.
+	 */
+	markQuotaExhausted(
+		account: ManagedAccount,
+		resetAtMs: number,
+		family: ModelFamily,
+		model?: string | null,
+	): boolean {
+		return this.rotation.markQuotaExhausted(account, resetAtMs, family, model);
+	}
+
 	markAccountCoolingDown(
 		account: ManagedAccount,
 		cooldownMs: number,

--- a/lib/accounts/persistence.ts
+++ b/lib/accounts/persistence.ts
@@ -16,6 +16,7 @@ import {
 	type AccountStorageV3,
 } from "../storage.js";
 import { getWorkspaceIdentityKey } from "../storage/identity.js";
+import { nowMs } from "../utils.js";
 import { clampNonNegativeInt } from "./rate-limits.js";
 import type { AccountState } from "./state.js";
 
@@ -62,9 +63,12 @@ export class AccountPersistence {
 				addedAt: account.addedAt,
 				lastUsed: account.lastUsed,
 				lastSwitchReason: account.lastSwitchReason,
+				// Copied, not referenced: adoptLongerDiskRateLimits merges the
+				// on-disk blocks into this payload, and it must not reach back
+				// through a shared reference into live rotation state.
 				rateLimitResetTimes:
 					Object.keys(account.rateLimitResetTimes).length > 0
-						? account.rateLimitResetTimes
+						? { ...account.rateLimitResetTimes }
 						: undefined,
 				coolingDownUntil: account.coolingDownUntil,
 				cooldownReason: account.cooldownReason,
@@ -82,10 +86,69 @@ export class AccountPersistence {
 		// persisting.
 		await withAccountStorageTransaction(async (current, persist) => {
 			if (current) {
+				// Before adoptNewerDiskCredentials: for records without workspace
+				// ids the refresh token participates in the identity key, and
+				// adopting a rotated token would change which disk record this
+				// account matches.
+				this.adoptLongerDiskRateLimits(storage, current);
 				this.adoptNewerDiskCredentials(storage, current);
 			}
 			await persist(storage);
 		});
+	}
+
+	/**
+	 * Merges still-active rate-limit blocks from `disk` into `outgoing`, keeping
+	 * whichever block runs longer per quota key.
+	 *
+	 * Rate-limit state is otherwise last-writer-wins, which is fine for a 5h
+	 * window that both processes rediscover within minutes. It is not fine for a
+	 * quota block: a second opencode process holding a stale snapshot would save
+	 * over the weekly block another process had just recorded, and the exhausted
+	 * account would be back in rotation after the next reload (issue #218).
+	 *
+	 * Only blocks still in the future are adopted, so an expired entry another
+	 * process has not pruned yet cannot be resurrected, and a block this process
+	 * deliberately cleared stays cleared once it has elapsed. `codex-doctor --fix`
+	 * is unaffected: it persists through its own storage transaction rather than
+	 * this method.
+	 *
+	 * Live in-memory state is intentionally left alone — unlike a consumed
+	 * refresh token, a missing block is self-correcting, since the very next
+	 * response re-applies it from the quota headers.
+	 */
+	private adoptLongerDiskRateLimits(
+		outgoing: AccountStorageV3,
+		disk: AccountStorageV3,
+	): void {
+		const now = nowMs();
+		const diskByIdentity = new Map<string, AccountMetadataV3>();
+		for (const record of disk.accounts) {
+			diskByIdentity.set(getWorkspaceIdentityKey(record), record);
+		}
+
+		for (const mine of outgoing.accounts) {
+			if (!mine) continue;
+			const theirs = diskByIdentity.get(getWorkspaceIdentityKey(mine));
+			const theirResets = theirs?.rateLimitResetTimes;
+			if (!theirResets) continue;
+
+			for (const [key, theirReset] of Object.entries(theirResets)) {
+				if (
+					typeof theirReset !== "number" ||
+					!Number.isFinite(theirReset) ||
+					theirReset <= now
+				) {
+					continue;
+				}
+				const myReset = mine.rateLimitResetTimes?.[key];
+				if (typeof myReset === "number" && myReset >= theirReset) continue;
+				mine.rateLimitResetTimes = {
+					...(mine.rateLimitResetTimes ?? {}),
+					[key]: theirReset,
+				};
+			}
+		}
 	}
 
 	/**

--- a/lib/accounts/rotation.ts
+++ b/lib/accounts/rotation.ts
@@ -316,6 +316,48 @@ export class AccountRotation {
 		this.markRateLimitedWithReason(account, retryAfterMs, family, "unknown", model);
 	}
 
+	/**
+	 * The quota keys a (family, model) block covers: the family-wide key, plus
+	 * the model-scoped one when a model is named.
+	 */
+	private getBlockedQuotaKeys(
+		family: ModelFamily,
+		model?: string | null,
+	): string[] {
+		const keys: string[] = [getQuotaKey(family)];
+		if (model) keys.push(getQuotaKey(family, model));
+		return keys;
+	}
+
+	/**
+	 * Write a rate-limit reset for `key`, keeping whichever block runs longer.
+	 *
+	 * Every writer goes through here so a later, shorter block can never shorten
+	 * an existing one: a concurrent in-flight request that lands a plain 429 with
+	 * a 30s retry-after must not pull a week-long weekly-quota block forward
+	 * (issue #218). A stale past value can never win, because any reset written
+	 * here is at or after `nowMs()`, and expired entries are dropped by
+	 * `clearExpiredRateLimits` on the next selection pass anyway.
+	 *
+	 * @returns true when the stored reset moved later.
+	 */
+	private extendRateLimitReset(
+		account: ManagedAccount,
+		key: string,
+		resetAt: number,
+	): boolean {
+		const existing = account.rateLimitResetTimes[key];
+		if (
+			typeof existing === "number" &&
+			Number.isFinite(existing) &&
+			existing >= resetAt
+		) {
+			return false;
+		}
+		account.rateLimitResetTimes[key] = resetAt;
+		return true;
+	}
+
 	markRateLimitedWithReason(
 		account: ManagedAccount,
 		retryAfterMs: number,
@@ -324,16 +366,26 @@ export class AccountRotation {
 		model?: string | null,
 	): void {
 		const retryMs = Math.max(0, Math.floor(retryAfterMs));
-		const resetAt = nowMs() + retryMs;
+		const keys = this.getBlockedQuotaKeys(family, model);
 
-		const baseKey = getQuotaKey(family);
-		account.rateLimitResetTimes[baseKey] = resetAt;
-
-		if (model) {
-			const modelKey = getQuotaKey(family, model);
-			account.rateLimitResetTimes[modelKey] = resetAt;
+		if (retryMs === 0) {
+			// A zero-length rate limit is not a block, it is the caller saying the
+			// window has elapsed. Clearing keeps the long-standing behavior: the
+			// old code wrote `nowMs()`, which clearExpiredRateLimits dropped on the
+			// next pass. It has to be explicit now, because the monotonic write
+			// below would otherwise preserve the very block the caller just
+			// declared expired. Nothing in the request path passes 0 — every
+			// server-derived delay is at least 1ms.
+			for (const key of keys) delete account.rateLimitResetTimes[key];
+		} else {
+			const resetAt = nowMs() + retryMs;
+			for (const key of keys) {
+				this.extendRateLimitReset(account, key, resetAt);
+			}
 		}
 
+		// Set unconditionally even when the existing block already ran longer:
+		// this records the reason for the most recent 429, not for the block.
 		account.lastRateLimitReason = reason;
 	}
 
@@ -341,13 +393,11 @@ export class AccountRotation {
 	 * Block an account until a quota window the backend reported as fully spent
 	 * resets (issue #218).
 	 *
-	 * Differs from {@link markRateLimitedWithReason} in two ways that matter:
-	 *
-	 * - It takes an ABSOLUTE reset stamp, so a week-long weekly-quota block is
-	 *   never rebuilt from a capped or backed-off retry delay.
-	 * - It never shortens an existing block. A concurrent in-flight request that
-	 *   lands a plain 429 with a 30s retry-after must not pull a weekly block
-	 *   forward; the account genuinely cannot serve until the window rolls over.
+	 * Differs from {@link markRateLimitedWithReason} in taking an ABSOLUTE reset
+	 * stamp, so a week-long weekly-quota block is never rebuilt from a capped or
+	 * backed-off retry delay. Like every writer it goes through
+	 * {@link extendRateLimitReset}, so it neither shortens an existing block nor
+	 * can be shortened by a later one.
 	 *
 	 * The block rides on the same persisted `rateLimitResetTimes` map as server
 	 * 429s, so it survives restarts and is shared with other processes through
@@ -365,15 +415,9 @@ export class AccountRotation {
 		const resetAt = Math.floor(resetAtMs);
 		if (resetAt <= nowMs()) return false;
 
-		const keys: string[] = [getQuotaKey(family)];
-		if (model) keys.push(getQuotaKey(family, model));
-
 		let changed = false;
-		for (const key of keys) {
-			const existing = account.rateLimitResetTimes[key];
-			if (typeof existing === "number" && existing >= resetAt) continue;
-			account.rateLimitResetTimes[key] = resetAt;
-			changed = true;
+		for (const key of this.getBlockedQuotaKeys(family, model)) {
+			if (this.extendRateLimitReset(account, key, resetAt)) changed = true;
 		}
 
 		if (changed) account.lastRateLimitReason = "quota";

--- a/lib/accounts/rotation.ts
+++ b/lib/accounts/rotation.ts
@@ -337,6 +337,49 @@ export class AccountRotation {
 		account.lastRateLimitReason = reason;
 	}
 
+	/**
+	 * Block an account until a quota window the backend reported as fully spent
+	 * resets (issue #218).
+	 *
+	 * Differs from {@link markRateLimitedWithReason} in two ways that matter:
+	 *
+	 * - It takes an ABSOLUTE reset stamp, so a week-long weekly-quota block is
+	 *   never rebuilt from a capped or backed-off retry delay.
+	 * - It never shortens an existing block. A concurrent in-flight request that
+	 *   lands a plain 429 with a 30s retry-after must not pull a weekly block
+	 *   forward; the account genuinely cannot serve until the window rolls over.
+	 *
+	 * The block rides on the same persisted `rateLimitResetTimes` map as server
+	 * 429s, so it survives restarts and is shared with other processes through
+	 * the accounts file, and it expires on its own via `clearExpiredRateLimits`.
+	 *
+	 * @returns true when a new (or longer) block was written.
+	 */
+	markQuotaExhausted(
+		account: ManagedAccount,
+		resetAtMs: number,
+		family: ModelFamily,
+		model?: string | null,
+	): boolean {
+		if (!Number.isFinite(resetAtMs)) return false;
+		const resetAt = Math.floor(resetAtMs);
+		if (resetAt <= nowMs()) return false;
+
+		const keys: string[] = [getQuotaKey(family)];
+		if (model) keys.push(getQuotaKey(family, model));
+
+		let changed = false;
+		for (const key of keys) {
+			const existing = account.rateLimitResetTimes[key];
+			if (typeof existing === "number" && existing >= resetAt) continue;
+			account.rateLimitResetTimes[key] = resetAt;
+			changed = true;
+		}
+
+		if (changed) account.lastRateLimitReason = "quota";
+		return changed;
+	}
+
 	markAccountCoolingDown(
 		account: ManagedAccount,
 		cooldownMs: number,

--- a/lib/quota-windows.ts
+++ b/lib/quota-windows.ts
@@ -1,0 +1,183 @@
+/**
+ * Shared parser for the per-window quota headers the Codex backend puts on
+ * every response (`x-codex-primary-*` = the rolling ~5h window,
+ * `x-codex-secondary-*` = the weekly window).
+ *
+ * These headers were previously only read for the TUI status line
+ * (`lib/tui-quota-cache.ts`), so the rotation layer had no idea an account had
+ * spent its weekly quota until the backend 429'd — and even then it could not
+ * tell *which* window was spent. Issue #218: an account at 0% weekly was picked
+ * again on every prompt, failed, and rotated away, forever.
+ *
+ * This module is deliberately a leaf (no imports): both the request path and
+ * the TUI cache depend on it, and it must not drag either into the other.
+ */
+
+export type CodexQuotaWindowKind = "primary" | "secondary";
+
+export interface CodexQuotaWindow {
+	kind: CodexQuotaWindowKind;
+	/** 0-100. Values >= 100 mean the window is spent. */
+	usedPercent?: number;
+	/** Window length in minutes. An explicit `0` means "disabled for this plan". */
+	windowMinutes?: number;
+	/** Absolute reset time in ms since epoch. */
+	resetAtMs?: number;
+}
+
+export const CODEX_QUOTA_WINDOW_KINDS: readonly CodexQuotaWindowKind[] = [
+	"primary",
+	"secondary",
+];
+
+export const CODEX_QUOTA_HEADER_PREFIXES: Record<CodexQuotaWindowKind, string> = {
+	primary: "x-codex-primary",
+	secondary: "x-codex-secondary",
+};
+
+const QUOTA_HEADER_SUFFIXES = [
+	"-used-percent",
+	"-window-minutes",
+	"-reset-at",
+	"-reset-after-seconds",
+] as const;
+
+/** Epoch values below this are seconds, above are milliseconds. */
+const EPOCH_SECONDS_CEILING = 10_000_000_000;
+
+function parseFiniteNumberHeader(
+	headers: Headers,
+	name: string,
+): number | undefined {
+	const raw = headers.get(name);
+	if (!raw) return undefined;
+	const parsed = Number(raw);
+	return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function parseFiniteIntHeader(headers: Headers, name: string): number | undefined {
+	const raw = headers.get(name);
+	if (!raw) return undefined;
+	const parsed = Number.parseInt(raw, 10);
+	return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+/**
+ * Resolve a window's absolute reset time.
+ *
+ * `-reset-after-seconds` is preferred over `-reset-at` because it is immune to
+ * clock skew between this host and the backend. `-reset-at` is accepted both as
+ * an epoch stamp (seconds or milliseconds) and as an ISO-8601 date string.
+ */
+export function parseQuotaResetAtMs(
+	headers: Headers,
+	prefix: string,
+	now: number = Date.now(),
+): number | undefined {
+	const resetAfterSeconds = parseFiniteIntHeader(
+		headers,
+		`${prefix}-reset-after-seconds`,
+	);
+	if (typeof resetAfterSeconds === "number" && resetAfterSeconds > 0) {
+		return now + resetAfterSeconds * 1000;
+	}
+
+	const resetAtRaw = headers.get(`${prefix}-reset-at`);
+	if (!resetAtRaw) return undefined;
+	const trimmed = resetAtRaw.trim();
+	if (/^\d+$/.test(trimmed)) {
+		const parsed = Number.parseInt(trimmed, 10);
+		if (Number.isFinite(parsed) && parsed > 0) {
+			return parsed < EPOCH_SECONDS_CEILING ? parsed * 1000 : parsed;
+		}
+		return undefined;
+	}
+
+	const parsedDate = Date.parse(trimmed);
+	return Number.isFinite(parsedDate) ? parsedDate : undefined;
+}
+
+export function hasCodexQuotaHeaders(headers: Headers): boolean {
+	return CODEX_QUOTA_WINDOW_KINDS.some((kind) =>
+		QUOTA_HEADER_SUFFIXES.some(
+			(suffix) =>
+				headers.get(`${CODEX_QUOTA_HEADER_PREFIXES[kind]}${suffix}`) !== null,
+		),
+	);
+}
+
+export function parseCodexQuotaWindow(
+	headers: Headers,
+	kind: CodexQuotaWindowKind,
+	now: number = Date.now(),
+): CodexQuotaWindow {
+	const prefix = CODEX_QUOTA_HEADER_PREFIXES[kind];
+	return {
+		kind,
+		usedPercent: parseFiniteNumberHeader(headers, `${prefix}-used-percent`),
+		windowMinutes: parseFiniteIntHeader(headers, `${prefix}-window-minutes`),
+		resetAtMs: parseQuotaResetAtMs(headers, prefix, now),
+	};
+}
+
+/**
+ * Parse every quota window the response describes. Windows with no headers at
+ * all are omitted, so an empty array means the backend reported no quota state.
+ */
+export function parseCodexQuotaWindows(
+	headers: Headers,
+	now: number = Date.now(),
+): CodexQuotaWindow[] {
+	return CODEX_QUOTA_WINDOW_KINDS.map((kind) =>
+		parseCodexQuotaWindow(headers, kind, now),
+	).filter(hasQuotaWindowData);
+}
+
+function hasQuotaWindowData(window: CodexQuotaWindow): boolean {
+	return (
+		typeof window.usedPercent === "number" ||
+		typeof window.windowMinutes === "number" ||
+		typeof window.resetAtMs === "number"
+	);
+}
+
+/**
+ * A window reported with `window-minutes: 0` is switched off for the plan, not
+ * a window of unknown length. It still reports a used-percent, so it has to be
+ * rejected on the explicit zero rather than on missing data.
+ */
+export function isQuotaWindowDisabled(
+	window: Pick<CodexQuotaWindow, "windowMinutes">,
+): boolean {
+	return window.windowMinutes === 0;
+}
+
+export function isQuotaWindowExhausted(
+	window: Pick<CodexQuotaWindow, "windowMinutes" | "usedPercent">,
+): boolean {
+	if (isQuotaWindowDisabled(window)) return false;
+	return typeof window.usedPercent === "number" && window.usedPercent >= 100;
+}
+
+/**
+ * The instant at which every spent window has reset, or `undefined` when no
+ * window is spent (or the backend gave no usable reset time).
+ *
+ * The *latest* reset wins, not the soonest: an account whose weekly window is
+ * gone stays unusable even after its 5h window rolls over, so collapsing the
+ * two with `Math.min` is what let issue #218's account back into rotation every
+ * five hours.
+ */
+export function getQuotaExhaustedResetAtMs(
+	headers: Headers,
+	now: number = Date.now(),
+): number | undefined {
+	let latest: number | undefined;
+	for (const window of parseCodexQuotaWindows(headers, now)) {
+		if (!isQuotaWindowExhausted(window)) continue;
+		const resetAtMs = window.resetAtMs;
+		if (typeof resetAtMs !== "number" || resetAtMs <= now) continue;
+		if (latest === undefined || resetAtMs > latest) latest = resetAtMs;
+	}
+	return latest;
+}

--- a/lib/request/fetch-helpers.ts
+++ b/lib/request/fetch-helpers.ts
@@ -37,7 +37,11 @@ import {
 	DEACTIVATED_WORKSPACE_ERROR_CODE,
 	isInvalidatedAuthTokenMessage,
 } from "../error-sentinels.js";
-import { getQuotaExhaustedResetAtMs } from "../quota-windows.js";
+import {
+	getQuotaExhaustedResetAtMs,
+	isQuotaWindowDisabled,
+	parseCodexQuotaWindows,
+} from "../quota-windows.js";
 import { isRecord } from "../utils.js";
 import {
         CODEX_BASE_URL,
@@ -1289,13 +1293,23 @@ function parseRetryAfterMs(
 
         // No window claimed exhaustion, so this is an ordinary throttle rather
         // than a spent quota: the soonest reset is the right one to wait for.
-        const resetAtHeaders = [
-                "x-codex-primary-reset-at",
-                "x-codex-secondary-reset-at",
-                "x-ratelimit-reset",
-        ];
         const now = Date.now();
         const resetCandidates: number[] = [];
+
+        // Read the Codex windows through the shared parser rather than the
+        // reset-at header alone, so a 429 carrying only `-reset-after-seconds`
+        // or an ISO `-reset-at` produces a candidate instead of falling back to
+        // the 60s default. Windows the plan has switched off are skipped: their
+        // reset says nothing about when this request can go through.
+        for (const window of parseCodexQuotaWindows(response.headers, now)) {
+                if (isQuotaWindowDisabled(window)) continue;
+                const resetAtMs = window.resetAtMs;
+                if (typeof resetAtMs !== "number" || !Number.isFinite(resetAtMs)) continue;
+                const delta = resetAtMs - now;
+                if (delta > 0) resetCandidates.push(delta);
+        }
+
+        const resetAtHeaders = ["x-ratelimit-reset"];
         for (const header of resetAtHeaders) {
                 const value = response.headers.get(header);
                 if (!value) continue;

--- a/lib/request/fetch-helpers.ts
+++ b/lib/request/fetch-helpers.ts
@@ -37,6 +37,7 @@ import {
 	DEACTIVATED_WORKSPACE_ERROR_CODE,
 	isInvalidatedAuthTokenMessage,
 } from "../error-sentinels.js";
+import { getQuotaExhaustedResetAtMs } from "../quota-windows.js";
 import { isRecord } from "../utils.js";
 import {
         CODEX_BASE_URL,
@@ -1244,6 +1245,17 @@ function parseRetryAfterMs(
         response: Response,
         parsedBody?: { resetsAt?: number; retryAfterMs?: number },
 ): number | null {
+        // A window the backend reports as fully spent (`used-percent >= 100`)
+        // outranks every other signal, and is deliberately uncapped. Its reset
+        // is the earliest moment the account can serve again; a `retry-after`
+        // of 30s or the sooner 5h reset would just put the account back into
+        // rotation to fail again (issue #218).
+        const exhaustedResetAtMs = getQuotaExhaustedResetAtMs(response.headers);
+        if (exhaustedResetAtMs !== undefined) {
+                const delta = exhaustedResetAtMs - Date.now();
+                if (delta > 0) return delta;
+        }
+
         if (parsedBody?.retryAfterMs !== undefined) {
                 // Already normalized to milliseconds in parseRateLimitBody (ms field
                 // used verbatim, seconds field converted via *1000). Do NOT pass
@@ -1275,6 +1287,8 @@ function parseRetryAfterMs(
                 }
         }
 
+        // No window claimed exhaustion, so this is an ordinary throttle rather
+        // than a spent quota: the soonest reset is the right one to wait for.
         const resetAtHeaders = [
                 "x-codex-primary-reset-at",
                 "x-codex-secondary-reset-at",

--- a/lib/tui-quota-cache.ts
+++ b/lib/tui-quota-cache.ts
@@ -2,6 +2,13 @@ import { promises as fs } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 
+import {
+	CODEX_QUOTA_WINDOW_KINDS,
+	hasCodexQuotaHeaders,
+	isQuotaWindowDisabled,
+	parseCodexQuotaWindow,
+	type CodexQuotaWindowKind,
+} from "./quota-windows.js";
 import { renameWithWindowsRetry } from "./storage/atomic-write.js";
 import type { CompactQuotaLimit } from "./tui-status.js";
 
@@ -59,16 +66,6 @@ export function getTuiQuotaCachePath(stateDir?: string): string {
 	return join(stateDir?.trim() || envStateDir || getDefaultOpenCodeStateDir(), TUI_QUOTA_CACHE_FILE);
 }
 
-function parseFiniteNumberHeader(
-	headers: Headers,
-	name: string,
-): number | undefined {
-	const raw = headers.get(name);
-	if (!raw) return undefined;
-	const parsed = Number(raw);
-	return Number.isFinite(parsed) ? parsed : undefined;
-}
-
 function parseFiniteIntHeader(
 	headers: Headers,
 	name: string,
@@ -77,35 +74,6 @@ function parseFiniteIntHeader(
 	if (!raw) return undefined;
 	const parsed = Number.parseInt(raw, 10);
 	return Number.isFinite(parsed) ? parsed : undefined;
-}
-
-function parseResetAtMs(headers: Headers, prefix: string): number | undefined {
-	const resetAfterSeconds = parseFiniteIntHeader(
-		headers,
-		`${prefix}-reset-after-seconds`,
-	);
-	if (
-		typeof resetAfterSeconds === "number" &&
-		Number.isFinite(resetAfterSeconds) &&
-		resetAfterSeconds > 0
-	) {
-		return Date.now() + resetAfterSeconds * 1000;
-	}
-
-	const resetAtRaw = headers.get(`${prefix}-reset-at`);
-	if (!resetAtRaw) return undefined;
-	const trimmed = resetAtRaw.trim();
-	if (/^\d+$/.test(trimmed)) {
-		const parsedNumber = Number.parseInt(trimmed, 10);
-		if (Number.isFinite(parsedNumber) && parsedNumber > 0) {
-			return parsedNumber < 10_000_000_000
-				? parsedNumber * 1000
-				: parsedNumber;
-		}
-	}
-
-	const parsedDate = Date.parse(trimmed);
-	return Number.isFinite(parsedDate) ? parsedDate : undefined;
 }
 
 function formatWindowLabel(windowMinutes: number | undefined): string {
@@ -127,27 +95,14 @@ function getLeftPercent(usedPercent: number | undefined): number | null {
 		: null;
 }
 
-function hasCodexQuotaHeaders(headers: Headers): boolean {
-	const keys = [
-		"x-codex-primary-used-percent",
-		"x-codex-primary-window-minutes",
-		"x-codex-primary-reset-at",
-		"x-codex-primary-reset-after-seconds",
-		"x-codex-secondary-used-percent",
-		"x-codex-secondary-window-minutes",
-		"x-codex-secondary-reset-at",
-		"x-codex-secondary-reset-after-seconds",
-	];
-	return keys.some((key) => headers.get(key) !== null);
-}
-
-function parseLimit(headers: Headers, prefix: string): TuiQuotaLimit {
-	const usedPercent = parseFiniteNumberHeader(headers, `${prefix}-used-percent`);
-	const windowMinutes = parseFiniteIntHeader(
+function parseLimit(
+	headers: Headers,
+	kind: CodexQuotaWindowKind,
+): TuiQuotaLimit {
+	const { usedPercent, windowMinutes, resetAtMs } = parseCodexQuotaWindow(
 		headers,
-		`${prefix}-window-minutes`,
+		kind,
 	);
-	const resetAtMs = parseResetAtMs(headers, prefix);
 	return {
 		label: formatWindowLabel(windowMinutes),
 		leftPercent: getLeftPercent(usedPercent),
@@ -166,7 +121,7 @@ function parseLimit(headers: Headers, prefix: string): TuiQuotaLimit {
  * window, and it is still shown under the generic `quota` label.
  */
 export function isDisabledQuotaLimit(limit: TuiQuotaLimit): boolean {
-	return limit.windowMinutes === 0;
+	return isQuotaWindowDisabled(limit);
 }
 
 function hasUsefulLimit(limit: TuiQuotaLimit): boolean {
@@ -213,10 +168,9 @@ export function parseTuiQuotaSnapshotFromHeaders(
 	input: Omit<TuiQuotaSnapshotInput, "source" | "limits">,
 ): TuiQuotaSnapshot | undefined {
 	if (!hasCodexQuotaHeaders(headers)) return undefined;
-	const limits = [
-		parseLimit(headers, "x-codex-primary"),
-		parseLimit(headers, "x-codex-secondary"),
-	].filter(hasUsefulLimit);
+	const limits = CODEX_QUOTA_WINDOW_KINDS.map((kind) =>
+		parseLimit(headers, kind),
+	).filter(hasUsefulLimit);
 	if (limits.length === 0) return undefined;
 
 	const planTypeRaw = headers.get("x-codex-plan-type");

--- a/test/credential-clobber.test.ts
+++ b/test/credential-clobber.test.ts
@@ -91,6 +91,120 @@ function persistedStorage(): AccountStorageV3 | undefined {
 	return saveAccountsMock.mock.calls[0]?.[0] as AccountStorageV3 | undefined;
 }
 
+// Issue #218: a weekly quota block is worth days, so unlike a 5h window it
+// cannot be left to last-writer-wins. A second process holding a stale snapshot
+// would save over it and put the exhausted account straight back in rotation.
+describe("AccountPersistence rate-limit merge (multi-process clobber guard)", () => {
+	const WEEKLY_RESET = Date.now() + 7 * 24 * 60 * 60 * 1000;
+
+	it("keeps a longer on-disk quota block instead of clobbering it", async () => {
+		const state = makeState([makeStoredAccount()]);
+		const persistence = new AccountPersistence(state);
+
+		// Another process recorded the weekly block after this one loaded.
+		diskStateRef.current = {
+			version: 3,
+			accounts: [
+				makeStoredAccount({ rateLimitResetTimes: { codex: WEEKLY_RESET } }),
+			],
+			activeIndex: 0,
+		} satisfies AccountStorageV3;
+
+		await persistence.saveToDisk();
+
+		expect(persistedStorage()?.accounts[0]?.rateLimitResetTimes?.codex).toBe(
+			WEEKLY_RESET,
+		);
+	});
+
+	it("keeps its own block when it is the longer one", async () => {
+		const state = makeState([
+			makeStoredAccount({ rateLimitResetTimes: { codex: WEEKLY_RESET } }),
+		]);
+		const persistence = new AccountPersistence(state);
+
+		diskStateRef.current = {
+			version: 3,
+			accounts: [
+				makeStoredAccount({
+					rateLimitResetTimes: { codex: Date.now() + 30_000 },
+				}),
+			],
+			activeIndex: 0,
+		} satisfies AccountStorageV3;
+
+		await persistence.saveToDisk();
+
+		expect(persistedStorage()?.accounts[0]?.rateLimitResetTimes?.codex).toBe(
+			WEEKLY_RESET,
+		);
+	});
+
+	it("merges per quota key rather than wholesale", async () => {
+		const state = makeState([
+			makeStoredAccount({ rateLimitResetTimes: { codex: WEEKLY_RESET } }),
+		]);
+		const persistence = new AccountPersistence(state);
+
+		const modelReset = Date.now() + 60_000;
+		diskStateRef.current = {
+			version: 3,
+			accounts: [
+				makeStoredAccount({
+					rateLimitResetTimes: { "codex:gpt-5-codex": modelReset },
+				}),
+			],
+			activeIndex: 0,
+		} satisfies AccountStorageV3;
+
+		await persistence.saveToDisk();
+
+		expect(persistedStorage()?.accounts[0]?.rateLimitResetTimes).toEqual({
+			codex: WEEKLY_RESET,
+			"codex:gpt-5-codex": modelReset,
+		});
+	});
+
+	it("does not resurrect an expired on-disk block", async () => {
+		const state = makeState([makeStoredAccount()]);
+		const persistence = new AccountPersistence(state);
+
+		diskStateRef.current = {
+			version: 3,
+			accounts: [
+				makeStoredAccount({
+					rateLimitResetTimes: { codex: Date.now() - 60_000 },
+				}),
+			],
+			activeIndex: 0,
+		} satisfies AccountStorageV3;
+
+		await persistence.saveToDisk();
+
+		expect(
+			persistedStorage()?.accounts[0]?.rateLimitResetTimes?.codex,
+		).toBeUndefined();
+	});
+
+	it("leaves live rotation state untouched", async () => {
+		const state = makeState([makeStoredAccount()]);
+		const persistence = new AccountPersistence(state);
+
+		diskStateRef.current = {
+			version: 3,
+			accounts: [
+				makeStoredAccount({ rateLimitResetTimes: { codex: WEEKLY_RESET } }),
+			],
+			activeIndex: 0,
+		} satisfies AccountStorageV3;
+
+		await persistence.saveToDisk();
+
+		// The persisted payload must not share a reference with live state.
+		expect(state.accounts[0]?.rateLimitResetTimes).toEqual({});
+	});
+});
+
 describe("AccountPersistence credential merge (multi-process clobber guard)", () => {
 	it("adopts a newer rotated refresh token from disk instead of clobbering it", async () => {
 		const state = makeState([

--- a/test/credential-clobber.test.ts
+++ b/test/credential-clobber.test.ts
@@ -186,6 +186,50 @@ describe("AccountPersistence rate-limit merge (multi-process clobber guard)", ()
 		).toBeUndefined();
 	});
 
+	// Documents a known limitation rather than desired behavior. A record with
+	// neither organizationId nor accountId is identified by its refresh token
+	// (lib/storage/identity.ts), so once another process rotates that token
+	// there is nothing left to match the two records on and the merge cannot
+	// run. It degrades to the pre-merge behavior — the block is dropped, never
+	// mis-assigned to a different account — which is why a positional fallback
+	// would be worse than this. Fixing it needs a rotation-invariant account id
+	// in storage, which also fixes the more serious credential miss asserted
+	// below. Flip both expectations when that lands.
+	it("cannot merge a token-only record whose token rotated (known limitation)", async () => {
+		const state = makeState([
+			makeStoredAccount({
+				accountId: undefined,
+				organizationId: undefined,
+				refreshToken: "rt-old",
+				tokenRotatedAt: 1_000,
+			}),
+		]);
+		const persistence = new AccountPersistence(state);
+
+		diskStateRef.current = {
+			version: 3,
+			accounts: [
+				makeStoredAccount({
+					accountId: undefined,
+					organizationId: undefined,
+					refreshToken: "rt-new",
+					tokenRotatedAt: 2_000,
+					rateLimitResetTimes: { codex: WEEKLY_RESET },
+				}),
+			],
+			activeIndex: 0,
+		} satisfies AccountStorageV3;
+
+		await persistence.saveToDisk();
+
+		const persisted = persistedStorage();
+		// Dropped, not mis-assigned: no record matched, so nothing was merged.
+		expect(persisted?.accounts[0]?.rateLimitResetTimes).toBeUndefined();
+		// Pre-existing and more serious: the same identity miss makes
+		// adoptNewerDiskCredentials overwrite the rotated single-use token.
+		expect(persisted?.accounts[0]?.refreshToken).toBe("rt-old");
+	});
+
 	it("leaves live rotation state untouched", async () => {
 		const state = makeState([makeStoredAccount()]);
 		const persistence = new AccountPersistence(state);

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -273,6 +273,13 @@ const mockStorage = {
 	activeIndexByFamily: {} as Record<string, number>,
 };
 
+/** Records every quota-exhaustion block the request path applies (issue #218). */
+const mockQuotaExhaustionCalls: Array<{
+	resetAtMs: number;
+	family: string;
+	model?: string | null;
+}> = [];
+
 const cloneAccount = (account: (typeof mockStorage.accounts)[number]) => structuredClone(account);
 
 const cloneMockStorage = () => ({
@@ -459,6 +466,15 @@ vi.mock("../lib/accounts.js", () => {
 		markAccountsWithRefreshTokenCoolingDown() { return 1; }
 		markRateLimited() {}
 		markRateLimitedWithReason() {}
+		markQuotaExhausted(
+			_account: unknown,
+			resetAtMs: number,
+			family: string,
+			model?: string | null,
+		) {
+			mockQuotaExhaustionCalls.push({ resetAtMs, family, model });
+			return true;
+		}
 		consumeToken() { return true; }
 		refundToken() {}
 		markSwitched() {}
@@ -3656,6 +3672,77 @@ describe("OpenAIOAuthPlugin fetch handler", () => {
 			}
 			await rm(stateDir, { recursive: true, force: true });
 		}
+	});
+
+	// Issue #218: an account whose weekly window is spent was picked again on
+	// every prompt because nothing consumed the used-percent headers, and the
+	// 429 path collapsed the weekly and 5h resets with Math.min.
+	describe("issue #218: weekly quota exhaustion", () => {
+		const nowSeconds = () => Math.floor(Date.now() / 1000);
+
+		const respondWith = (headers: Record<string, string>, status = 200) => {
+			globalThis.fetch = vi.fn().mockResolvedValue(
+				new Response(JSON.stringify({ content: "test" }), { status, headers }),
+			);
+		};
+
+		const sendPrompt = async () => {
+			const { sdk } = await setupPlugin();
+			return sdk.fetch!("https://api.openai.com/v1/chat", {
+				method: "POST",
+				body: JSON.stringify({ model: "gpt-5.1" }),
+			});
+		};
+
+		beforeEach(() => {
+			mockQuotaExhaustionCalls.length = 0;
+		});
+
+		it("blocks the account until the weekly reset when it reports 0% left", async () => {
+			const weeklyResetAtSeconds = nowSeconds() + 7 * 24 * 60 * 60;
+			respondWith({
+				"x-codex-primary-used-percent": "40",
+				"x-codex-primary-window-minutes": "300",
+				"x-codex-primary-reset-at": String(nowSeconds() + 5 * 60 * 60),
+				"x-codex-secondary-used-percent": "100",
+				"x-codex-secondary-window-minutes": "10080",
+				"x-codex-secondary-reset-at": String(weeklyResetAtSeconds),
+			});
+
+			expect((await sendPrompt()).status).toBe(200);
+
+			// The weekly reset wins over the sooner 5h reset: an account whose
+			// weekly quota is gone stays unusable after the 5h window rolls over.
+			expect(mockQuotaExhaustionCalls).toEqual([
+				expect.objectContaining({ resetAtMs: weeklyResetAtSeconds * 1000 }),
+			]);
+		});
+
+		it("leaves an account with quota left in rotation", async () => {
+			respondWith({
+				"x-codex-primary-used-percent": "40",
+				"x-codex-primary-window-minutes": "300",
+				"x-codex-secondary-used-percent": "99",
+				"x-codex-secondary-window-minutes": "10080",
+				"x-codex-secondary-reset-at": String(nowSeconds() + 7 * 24 * 60 * 60),
+			});
+
+			expect((await sendPrompt()).status).toBe(200);
+			expect(mockQuotaExhaustionCalls).toEqual([]);
+		});
+
+		it("ignores a window the plan has switched off", async () => {
+			respondWith({
+				"x-codex-primary-used-percent": "100",
+				"x-codex-primary-window-minutes": "0",
+				"x-codex-primary-reset-at": String(nowSeconds() + 5 * 60 * 60),
+				"x-codex-secondary-used-percent": "12",
+				"x-codex-secondary-window-minutes": "10080",
+			});
+
+			expect((await sendPrompt()).status).toBe(200);
+			expect(mockQuotaExhaustionCalls).toEqual([]);
+		});
 	});
 
 	it("persists the selected account before writing TUI quota snapshots", async () => {

--- a/test/quota-windows.test.ts
+++ b/test/quota-windows.test.ts
@@ -192,6 +192,67 @@ describe("handleErrorResponse weekly quota reset (issue #218)", () => {
 		expect(rateLimit?.retryAfterMs).toBeGreaterThan(FIVE_HOURS_MS - 60_000);
 	});
 
+	it("uses a relative reset header on an ordinary throttle", async () => {
+		const response = new Response(
+			JSON.stringify({ error: { code: "rate_limit_exceeded" } }),
+			{
+				status: 429,
+				headers: new Headers({
+					"x-codex-primary-used-percent": "80",
+					"x-codex-primary-window-minutes": "300",
+					"x-codex-primary-reset-after-seconds": "900",
+				}),
+			},
+		);
+
+		const { rateLimit } = await handleErrorResponse(response);
+
+		// Not the 60s default: the backend told us when the window rolls over.
+		expect(rateLimit?.retryAfterMs).toBeGreaterThan(890_000);
+		expect(rateLimit?.retryAfterMs).toBeLessThanOrEqual(900_000);
+	});
+
+	it("uses an ISO reset header on an ordinary throttle", async () => {
+		const response = new Response(
+			JSON.stringify({ error: { code: "rate_limit_exceeded" } }),
+			{
+				status: 429,
+				headers: new Headers({
+					"x-codex-primary-used-percent": "80",
+					"x-codex-primary-reset-at": new Date(
+						Date.now() + 15 * 60 * 1000,
+					).toISOString(),
+				}),
+			},
+		);
+
+		const { rateLimit } = await handleErrorResponse(response);
+
+		expect(rateLimit?.retryAfterMs).toBeGreaterThan(890_000);
+		expect(rateLimit?.retryAfterMs).toBeLessThanOrEqual(900_000);
+	});
+
+	it("ignores a plan-disabled window when picking an ordinary throttle reset", async () => {
+		const response = new Response(
+			JSON.stringify({ error: { code: "rate_limit_exceeded" } }),
+			{
+				status: 429,
+				headers: new Headers({
+					"x-codex-primary-used-percent": "0",
+					"x-codex-primary-window-minutes": "0",
+					"x-codex-primary-reset-after-seconds": "60",
+					"x-codex-secondary-used-percent": "80",
+					"x-codex-secondary-window-minutes": "10080",
+					"x-codex-secondary-reset-after-seconds": "900",
+				}),
+			},
+		);
+
+		const { rateLimit } = await handleErrorResponse(response);
+
+		expect(rateLimit?.retryAfterMs).toBeGreaterThan(890_000);
+	});
+
 	it("keeps the short retry-after when the 429 is not a quota exhaustion", async () => {
 		const response = new Response(
 			JSON.stringify({ error: { code: "rate_limit_exceeded", retry_after_ms: 1750 } }),
@@ -248,6 +309,49 @@ describe("AccountManager.markQuotaExhausted (issue #218)", () => {
 		expect(manager.markQuotaExhausted(account, weeklyReset, "codex")).toBe(true);
 		expect(manager.markQuotaExhausted(account, Date.now() + 60_000, "codex")).toBe(false);
 		expect(account.rateLimitResetTimes.codex).toBe(weeklyReset);
+	});
+
+	it("is not shortened by a later ordinary rate limit", () => {
+		const manager = buildManager();
+		const account = manager.getCurrentOrNext()!;
+		const weeklyReset = Date.now() + SEVEN_DAYS_MS;
+
+		manager.markQuotaExhausted(account, weeklyReset, "codex", "gpt-5-codex");
+		// A concurrent in-flight request lands a plain 429 with a 30s
+		// retry-after; it must not pull the weekly block forward.
+		manager.markRateLimitedWithReason(
+			account,
+			30_000,
+			"codex",
+			"tokens",
+			"gpt-5-codex",
+		);
+
+		expect(account.rateLimitResetTimes.codex).toBe(weeklyReset);
+		expect(account.rateLimitResetTimes["codex:gpt-5-codex"]).toBe(weeklyReset);
+		expect(manager.getCurrentOrNext()?.refreshToken).toBe("token-2");
+	});
+
+	it("still lets a zero-length rate limit clear a block", () => {
+		const manager = buildManager();
+		const account = manager.getCurrentOrNext()!;
+
+		manager.markRateLimited(account, 60_000, "codex");
+		expect(account.rateLimitResetTimes.codex).toBeDefined();
+
+		manager.markRateLimited(account, 0, "codex");
+		expect(account.rateLimitResetTimes.codex).toBeUndefined();
+	});
+
+	it("still lets an ordinary rate limit extend a shorter block", () => {
+		const manager = buildManager();
+		const account = manager.getCurrentOrNext()!;
+
+		manager.markRateLimitedWithReason(account, 30_000, "codex", "tokens");
+		const shortReset = account.rateLimitResetTimes.codex!;
+		manager.markRateLimitedWithReason(account, 10 * 60_000, "codex", "quota");
+
+		expect(account.rateLimitResetTimes.codex).toBeGreaterThan(shortReset);
 	});
 
 	it("ignores a reset that is already in the past", () => {

--- a/test/quota-windows.test.ts
+++ b/test/quota-windows.test.ts
@@ -1,0 +1,271 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { AccountManager } from "../lib/accounts.js";
+import {
+	getQuotaExhaustedResetAtMs,
+	isQuotaWindowDisabled,
+	isQuotaWindowExhausted,
+	parseCodexQuotaWindows,
+} from "../lib/quota-windows.js";
+import { handleErrorResponse } from "../lib/request/fetch-helpers.js";
+
+vi.mock("../lib/storage.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../lib/storage.js")>();
+	const saveAccounts = vi.fn().mockResolvedValue(undefined);
+	return {
+		...actual,
+		saveAccounts,
+		loadAccounts: vi.fn().mockResolvedValue(null),
+		withAccountStorageTransaction: vi.fn(
+			async (
+				handler: (
+					current: null,
+					persist: (storage: unknown) => Promise<void>,
+				) => Promise<unknown>,
+			) => handler(null, saveAccounts as (storage: unknown) => Promise<void>),
+		),
+	};
+});
+
+const FIVE_HOURS_MS = 5 * 60 * 60 * 1000;
+const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
+
+function epochSeconds(offsetMs: number): string {
+	return String(Math.floor((Date.now() + offsetMs) / 1000));
+}
+
+/** Headers as returned for an account whose weekly window is fully spent. */
+function weeklyExhaustedHeaders(extra: Record<string, string> = {}): Headers {
+	return new Headers({
+		"x-codex-primary-used-percent": "40",
+		"x-codex-primary-window-minutes": "300",
+		"x-codex-primary-reset-at": epochSeconds(FIVE_HOURS_MS),
+		"x-codex-secondary-used-percent": "100",
+		"x-codex-secondary-window-minutes": "10080",
+		"x-codex-secondary-reset-at": epochSeconds(SEVEN_DAYS_MS),
+		...extra,
+	});
+}
+
+describe("parseCodexQuotaWindows", () => {
+	it("reads both windows from the Codex quota headers", () => {
+		const windows = parseCodexQuotaWindows(weeklyExhaustedHeaders());
+
+		expect(windows).toHaveLength(2);
+		expect(windows[0]).toMatchObject({
+			kind: "primary",
+			usedPercent: 40,
+			windowMinutes: 300,
+		});
+		expect(windows[1]).toMatchObject({
+			kind: "secondary",
+			usedPercent: 100,
+			windowMinutes: 10080,
+		});
+		expect(windows[1]?.resetAtMs).toBeGreaterThan(Date.now() + SEVEN_DAYS_MS - 60_000);
+	});
+
+	it("accepts a relative reset-after-seconds header", () => {
+		const windows = parseCodexQuotaWindows(
+			new Headers({
+				"x-codex-secondary-used-percent": "100",
+				"x-codex-secondary-window-minutes": "10080",
+				"x-codex-secondary-reset-after-seconds": "3600",
+			}),
+		);
+
+		const secondary = windows.find((window) => window.kind === "secondary");
+		expect(secondary?.resetAtMs).toBeGreaterThan(Date.now() + 3_500_000);
+	});
+
+	it("accepts an ISO-8601 reset-at header", () => {
+		const resetAt = new Date(Date.now() + SEVEN_DAYS_MS).toISOString();
+		const windows = parseCodexQuotaWindows(
+			new Headers({
+				"x-codex-secondary-used-percent": "100",
+				"x-codex-secondary-reset-at": resetAt,
+			}),
+		);
+
+		expect(windows.find((window) => window.kind === "secondary")?.resetAtMs).toBe(
+			Date.parse(resetAt),
+		);
+	});
+
+	it("returns an empty list when no quota headers are present", () => {
+		expect(parseCodexQuotaWindows(new Headers({ "retry-after": "30" }))).toEqual([]);
+	});
+});
+
+describe("isQuotaWindowExhausted", () => {
+	it("treats a window at or above 100% used as exhausted", () => {
+		expect(isQuotaWindowExhausted({ kind: "secondary", usedPercent: 100 })).toBe(true);
+		expect(isQuotaWindowExhausted({ kind: "secondary", usedPercent: 100.4 })).toBe(true);
+		expect(isQuotaWindowExhausted({ kind: "primary", usedPercent: 99 })).toBe(false);
+		expect(isQuotaWindowExhausted({ kind: "primary" })).toBe(false);
+	});
+
+	it("never treats a plan-disabled window as exhausted", () => {
+		const disabled = { kind: "primary" as const, usedPercent: 100, windowMinutes: 0 };
+		expect(isQuotaWindowDisabled(disabled)).toBe(true);
+		expect(isQuotaWindowExhausted(disabled)).toBe(false);
+	});
+});
+
+describe("getQuotaExhaustedResetAtMs", () => {
+	it("returns the weekly reset when only the weekly window is spent", () => {
+		const resetAtMs = getQuotaExhaustedResetAtMs(weeklyExhaustedHeaders());
+
+		expect(resetAtMs).toBeDefined();
+		expect(resetAtMs! - Date.now()).toBeGreaterThan(SEVEN_DAYS_MS - 60_000);
+	});
+
+	it("returns the latest reset when both windows are spent", () => {
+		const resetAtMs = getQuotaExhaustedResetAtMs(
+			weeklyExhaustedHeaders({ "x-codex-primary-used-percent": "100" }),
+		);
+
+		expect(resetAtMs! - Date.now()).toBeGreaterThan(SEVEN_DAYS_MS - 60_000);
+	});
+
+	it("returns undefined when nothing is exhausted", () => {
+		expect(
+			getQuotaExhaustedResetAtMs(
+				weeklyExhaustedHeaders({ "x-codex-secondary-used-percent": "60" }),
+			),
+		).toBeUndefined();
+	});
+
+	it("returns undefined when the exhausted window has no future reset", () => {
+		expect(
+			getQuotaExhaustedResetAtMs(
+				new Headers({
+					"x-codex-secondary-used-percent": "100",
+					"x-codex-secondary-reset-at": epochSeconds(-60_000),
+				}),
+			),
+		).toBeUndefined();
+	});
+});
+
+describe("handleErrorResponse weekly quota reset (issue #218)", () => {
+	it("blocks until the weekly reset instead of the sooner 5h reset", async () => {
+		const response = new Response(
+			JSON.stringify({ error: { code: "usage_limit_reached" } }),
+			{ status: 429, headers: weeklyExhaustedHeaders() },
+		);
+
+		const { rateLimit } = await handleErrorResponse(response);
+
+		expect(rateLimit?.retryAfterMs).toBeGreaterThan(SEVEN_DAYS_MS - 60_000);
+	});
+
+	it("is not truncated by a short retry-after when the weekly window is spent", async () => {
+		const response = new Response(
+			JSON.stringify({ error: { code: "usage_limit_reached", retry_after: 30 } }),
+			{
+				status: 429,
+				headers: weeklyExhaustedHeaders({ "retry-after": "30" }),
+			},
+		);
+
+		const { rateLimit } = await handleErrorResponse(response);
+
+		expect(rateLimit?.retryAfterMs).toBeGreaterThan(SEVEN_DAYS_MS - 60_000);
+	});
+
+	it("still prefers the soonest reset when no window reports exhaustion", async () => {
+		const response = new Response(
+			JSON.stringify({ error: { code: "rate_limit_exceeded" } }),
+			{
+				status: 429,
+				headers: new Headers({
+					"x-codex-primary-reset-at": epochSeconds(FIVE_HOURS_MS),
+					"x-codex-secondary-reset-at": epochSeconds(SEVEN_DAYS_MS),
+				}),
+			},
+		);
+
+		const { rateLimit } = await handleErrorResponse(response);
+
+		expect(rateLimit?.retryAfterMs).toBeLessThan(FIVE_HOURS_MS + 60_000);
+		expect(rateLimit?.retryAfterMs).toBeGreaterThan(FIVE_HOURS_MS - 60_000);
+	});
+
+	it("keeps the short retry-after when the 429 is not a quota exhaustion", async () => {
+		const response = new Response(
+			JSON.stringify({ error: { code: "rate_limit_exceeded", retry_after_ms: 1750 } }),
+			{ status: 429 },
+		);
+
+		const { rateLimit } = await handleErrorResponse(response);
+
+		expect(rateLimit?.retryAfterMs).toBe(1750);
+	});
+});
+
+describe("AccountManager.markQuotaExhausted (issue #218)", () => {
+	function buildManager() {
+		const now = Date.now();
+		return new AccountManager(undefined, {
+			version: 3 as const,
+			activeIndex: 0,
+			accounts: [
+				{ refreshToken: "token-1", addedAt: now, lastUsed: now },
+				{ refreshToken: "token-2", addedAt: now, lastUsed: now },
+			],
+		});
+	}
+
+	it("keeps a weekly-exhausted account out of rotation", () => {
+		const manager = buildManager();
+		const first = manager.getCurrentOrNext();
+		expect(first?.refreshToken).toBe("token-1");
+
+		const changed = manager.markQuotaExhausted(
+			first!,
+			Date.now() + SEVEN_DAYS_MS,
+			"codex",
+		);
+		expect(changed).toBe(true);
+
+		expect(manager.getCurrentOrNext()?.refreshToken).toBe("token-2");
+		expect(manager.getCurrentOrNext()?.refreshToken).toBe("token-2");
+	});
+
+	it("records the block as a quota rate limit", () => {
+		const manager = buildManager();
+		const account = manager.getCurrentOrNext()!;
+		manager.markQuotaExhausted(account, Date.now() + SEVEN_DAYS_MS, "codex");
+		expect(account.lastRateLimitReason).toBe("quota");
+	});
+
+	it("never shortens an existing longer block", () => {
+		const manager = buildManager();
+		const account = manager.getCurrentOrNext()!;
+		const weeklyReset = Date.now() + SEVEN_DAYS_MS;
+
+		expect(manager.markQuotaExhausted(account, weeklyReset, "codex")).toBe(true);
+		expect(manager.markQuotaExhausted(account, Date.now() + 60_000, "codex")).toBe(false);
+		expect(account.rateLimitResetTimes.codex).toBe(weeklyReset);
+	});
+
+	it("ignores a reset that is already in the past", () => {
+		const manager = buildManager();
+		const account = manager.getCurrentOrNext()!;
+
+		expect(manager.markQuotaExhausted(account, Date.now() - 1000, "codex")).toBe(false);
+		expect(account.rateLimitResetTimes.codex).toBeUndefined();
+	});
+
+	it("blocks the model-scoped quota key too", () => {
+		const manager = buildManager();
+		const account = manager.getCurrentOrNext()!;
+		const weeklyReset = Date.now() + SEVEN_DAYS_MS;
+
+		manager.markQuotaExhausted(account, weeklyReset, "codex", "gpt-5-codex");
+
+		expect(account.rateLimitResetTimes.codex).toBe(weeklyReset);
+		expect(account.rateLimitResetTimes["codex:gpt-5-codex"]).toBe(weeklyReset);
+	});
+});


### PR DESCRIPTION
Fixes #218.

## The bug

An account whose weekly quota is fully used gets picked again on every prompt. The request fails, the plugin rotates away, and the same thing happens on the next prompt. The reporter's ask — *"account shall not be used and remember that it has 0% quota left"* — was not met on either count.

Two independent defects, both on the same path:

**1. The quota signal was parsed and thrown away.** The backend puts `x-codex-{primary,secondary}-used-percent` and the matching reset time on *every* response. `lib/tui-quota-cache.ts` parsed them for the TUI status line; the rotation layer never saw them. So even right after the server said "weekly: 100% used, resets in 5 days", the account stayed selectable, and the only way to rediscover the exhaustion was to fail another request.

**2. When a 429 did arrive, the wrong reset was persisted.** `parseRetryAfterMs` collapsed the primary (5h) and secondary (weekly) reset-at headers with `Math.min`. The 5h reset is always the sooner one, so the block expired with the wrong window and the spent account walked straight back into rotation. A body-supplied `retry-after` was worse — that path is capped at 5 minutes, so the account came back roughly every five minutes.

## The fix

- **`lib/quota-windows.ts` (new)** — one parser for the `x-codex-{primary,secondary}-*` headers. Both the request path and the TUI cache now use it, so the two cannot drift on what "exhausted" means. It also handles the `-reset-after-seconds` and ISO-8601 `-reset-at` forms that the request path previously ignored.
- **`parseRetryAfterMs`** — a window reporting `used-percent >= 100` now wins, uncapped, over every other signal; when several are spent the *latest* reset wins, since an account whose weekly quota is gone is still unusable after its 5h window rolls over. With nothing exhausted it takes the soonest reset exactly as before.
- **`markQuotaExhausted`** — takes an absolute reset stamp rather than a delay, and never shortens an existing block, so a concurrent 429 carrying a 30s retry-after cannot pull a week-long block forward. It writes to the existing persisted `rateLimitResetTimes` map, so the block survives a restart, is shared with other processes through the accounts file, and expires on its own via `clearExpiredRateLimits` — no new storage field, no schema migration.
- **Applied on every response, success or failure**, so an account that reports 0% left leaves rotation *before* the next prompt instead of after another failed request.

Plan-disabled windows (`window-minutes: 0`, which still report a used percent) are excluded, so they cannot block an account that actually has quota.

## Risk

The proactive gate is the behaviour change worth scrutinising: an account is now taken out of rotation on `used-percent >= 100` without waiting for a 429. If that signal were ever wrong, the cost is bounded — the account is skipped only until the reset time the same response reported, and other accounts serve meanwhile. Against that, the current cost is a failed request on every single prompt.

Not addressed here: `codex-doctor --fix` still clears all `rateLimitResetTimes`, including a weekly block, because the reason is not persisted (`lastRateLimitReason` is in-memory only). The consequence is now just one wasted request after an explicit `--fix` — the next response re-applies the block from the headers — but making the doctor reason-aware would need a new persisted field and belongs in its own change.

## Verification

- `npx vitest run` — 115 files, 2907 passed, 1 skipped
- `npm run lint` and `npx tsc --noEmit` clean
- `npm run build` clean

New coverage in `test/quota-windows.test.ts` (19 cases) and `test/index.test.ts`:
- weekly reset wins over the sooner 5h reset, and over a short `retry-after`
- the soonest reset is still used when no window reports exhaustion
- a short non-quota `retry-after` is left alone
- a weekly-exhausted account drops out of rotation, and the block is never shortened
- an account at 99% stays in rotation; a plan-disabled window never blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0172XgMBpMqBKsZrCAAQiZXw

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic detection of exhausted Codex quota windows.
  * Accounts are temporarily unavailable until quota resets, including model-specific limits.
  * Retry delays now honor quota reset times without the standard retry cap.
  * Supports multiple quota windows and reset-time formats.

* **Bug Fixes**
  * Disabled or expired quota windows are ignored.
  * Longer existing account blocks are preserved across rate-limit updates and concurrent processes.

* **Tests**
  * Added coverage for quota parsing, account blocking, reset handling, retry behavior, and concurrent rate-limit persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

the pr centralizes codex quota-window parsing and makes exhausted-window resets monotonic across request handling and persistence.
- applies quota exhaustion from every response before the next account selection.
- preserves longer in-memory and on-disk reset timestamps against shorter 429 updates and stale concurrent saves.
- reuses the parser for tui quota snapshots and adds vitest coverage for reset formats, disabled windows, rotation, and concurrent persistence.

<h3>Confidence Score: 4/5</h3>

the pr is not yet safe to merge because concurrent refresh-token rotation can still let a stale token-only account save erase both the weekly block and the valid single-use token.

the reply states that the cross-process clobber was fixed, but the new credential-clobber test is a concrete counterexample: when no organization or account id exists, refresh-token rotation changes the identity key, both merges miss the disk record, and the stale process persists an unblocked account with a consumed token.

**Files Needing Attention:** lib/accounts/persistence.ts, test/credential-clobber.test.ts

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| index.ts | applies exhausted quota headers before success or error response handling. |
| lib/quota-windows.ts | adds shared parsing for quota usage, disabled windows, and absolute or relative reset timestamps. |
| lib/accounts/rotation.ts | makes active rate-limit blocks monotonic and adds absolute quota-exhaustion marking. |
| lib/accounts/persistence.ts | merges longer persisted resets transactionally, but token-only identities still fail across concurrent refresh-token rotation. |
| lib/request/fetch-helpers.ts | prioritizes the latest exhausted-window reset while retaining ordinary throttle behavior. |
| lib/tui-quota-cache.ts | adopts the shared quota parser without changing the cache schema. |
| test/credential-clobber.test.ts | covers cross-process reset merging and explicitly demonstrates the remaining token-only identity failure. |
| test/index.test.ts | covers proactive quota blocking from successful responses, including disabled and non-exhausted windows. |
| test/quota-windows.test.ts | covers quota parsing, retry reset selection, rotation blocking, and monotonic updates. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant API as codex api
  participant Fetch as request path
  participant Rotation as account rotation
  participant Store as accounts storage
  API-->>Fetch: response with quota headers
  Fetch->>Fetch: parse quota windows
  Fetch->>Rotation: mark exhausted until latest reset
  Rotation->>Rotation: retain longer existing reset
  Fetch->>Store: debounced transactional save
  Store->>Store: merge longer disk resets
```
</details>

<sub>Reviews (4): Last reviewed commit: ["test(persistence): pin the token-only id..."](https://github.com/ndycode/oc-codex-multi-auth/commit/79512dcc8497a1c9a39bb30db6d52fc5235a6df2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50021761)</sub>

<details><summary><h4>Context used (5)</h4></summary>

- Knowledge Base — [Plugin Entrypoint: index.ts](https://app.greptile.com/zeian/-/custom-context/knowledge-base/ndycode/oc-codex-multi-auth/-/docs/plugin-entrypoint.md)
- Knowledge Base — [Multi-Account Rotation and Health](https://app.greptile.com/zeian/-/custom-context/knowledge-base/ndycode/oc-codex-multi-auth/-/docs/accounts-rotation.md)
- Knowledge Base — [Request Pipeline](https://app.greptile.com/zeian/-/custom-context/knowledge-base/ndycode/oc-codex-multi-auth/-/docs/request-pipeline.md)
- Knowledge Base — [Account Storage Layer](https://app.greptile.com/zeian/-/custom-context/knowledge-base/ndycode/oc-codex-multi-auth/-/docs/storage.md)
- Knowledge Base — [TUI quota status flow](https://app.greptile.com/zeian/-/custom-context/knowledge-base/ndycode/oc-codex-multi-auth/-/docs/tui-quota.md)
</details>

<!-- /greptile_comment -->