### PR TITLE
ci: add a workflow_dispatch trigger to the CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,11 @@ on:
     types: [opened, synchronize, reopened]
   push:
     branches: [main]
+  # Manual trigger. Lets a maintainer run the full gate on any ref from the
+  # Actions tab without pushing a throwaway commit — useful for confirming the
+  # pipeline itself works, and for re-running against a branch after an
+  # infrastructure problem rather than a code change.
+  workflow_dispatch:
 
 # Cancel superseded runs on the same ref to save CI minutes.
 concurrency:


### PR DESCRIPTION
`ci.yml` could only be started by a push to `main` or a `pull_request` event. There was no way to run the gate on demand, which matters when the pipeline itself is what you need to verify — confirming Actions works, or re-running a branch after an infrastructure problem rather than a code change. The only alternative was pushing a throwaway commit.

Adds `workflow_dispatch:` so the workflow can be run from the Actions tab against any ref.

## Why the concurrency block needs no change

`cancel-in-progress: ${{ github.event_name == 'pull_request' }}` evaluates to `false` for a manual run, so a dispatch is never cancelled by a subsequent push. The group key is unchanged.

## Verification

`js-yaml` parse of the edited file confirms the trigger registers as expected:

```json
"on": {
  "pull_request": { "types": ["opened", "synchronize", "reopened"] },
  "push": { "branches": ["main"] },
  "workflow_dispatch": null
}
```

Suite green on this branch (114 files, 2885 passed, 1 skipped) and `npm run lint` clean, though neither is affected by a trigger-only change.

## Note

This does not make CI run. No workflow in this repo has produced a `push` or `pull_request` run — `ci.yml` has zero runs ever, and the same holds across every repo on the account, so Actions is blocked upstream of the workflow definitions. This PR only ensures that once that is resolved, the gate can be started manually instead of by guessing at a commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0172XgMBpMqBKsZrCAAQiZXw

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added the ability to manually trigger the CI workflow from the GitHub Actions interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

adds a manual `workflow_dispatch` trigger so maintainers can run ci against any ref without creating a commit.

- preserves existing push and pull request triggers.
- leaves concurrency behavior unchanged; manual and push runs are not cancelled, while superseded pull request runs remain cancellable.
- no windows filesystem, token safety, or vitest coverage concern is relevant to this trigger-only change.

<h3>Confidence Score: 5/5</h3>

the pr appears safe to merge.

the change only enables manual invocation of the existing workflow, with no accepted functional, security, concurrency, or platform-specific failure.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/ci.yml | the new empty `workflow_dispatch` mapping is valid github actions syntax and does not alter jobs or concurrency configuration. |

</details>

<sub>Reviews (1): Last reviewed commit: ["ci: add a workflow\_dispatch trigger to t..."](https://github.com/ndycode/oc-codex-multi-auth/commit/928e68dfd36810eed0c27e4f323ed448ec720856) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50052458)</sub>

<!-- /greptile_comment -->