### PR TITLE
feat: add strict model account pool routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,10 @@ reordering accounts does not silently change a model's routing.
     "gpt-5.6-terra": [
       "org-another-account-id"
     ]
+  },
+  "modelAccountPoolModes": {
+    "gpt-5.6-sol": "strict",
+    "gpt-5.6-terra": "preferred"
   }
 }
 ```
@@ -323,6 +327,7 @@ codex-pool
 codex-pool action="set" model="gpt-5.6-sol" accounts=[7,8]
 codex-pool action="add" model="gpt-5.6-sol" accounts=[9]
 codex-pool action="remove" model="gpt-5.6-sol" accounts=[7]
+codex-pool action="set-mode" model="gpt-5.6-sol" poolMode="strict"
 codex-pool action="clear" model="gpt-5.6-sol"
 ```
 
@@ -334,11 +339,12 @@ the current project is reported but never automatically deleted.
 
 Routing behavior:
 
-- A mapped model uses only healthy, selectable accounts in its preferred pool.
+- A mapped model defaults to `preferred` mode and uses healthy, selectable accounts in its pool.
 - Existing rotation strategy, quota, cooldown, and token-health rules still apply within the preferred pool.
-- If every preferred account is unavailable, disabled, unknown, cooling down, or rate-limited, routing automatically falls back to the healthy general account pool.
+- In `preferred` mode, an unavailable pool falls back to the healthy general account pool.
+- In `strict` mode, routing never leaves the configured pool and immediately returns `strict_pool_unavailable` when no pooled account is selectable.
 - An unmapped model or an empty account list uses the general account pool directly.
-- `codex-status`, `codex-dashboard`, and routing diagnostics report the account-pool mode as `preferred`, `general`, or `general-fallback`.
+- `codex-status`, `codex-dashboard`, and routing diagnostics also report `strict` and `strict-unavailable` modes.
 
 Account IDs are local account metadata but should still be treated as private
 configuration. Do not publish a populated configuration file.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -97,7 +97,7 @@ ChatGPT-backed Codex endpoint
 | `sticky` | Drain one account until rate-limited/cooling, then move to the lowest-indexed available account |
 | `round-robin` | Advance through accounts in order |
 
-`modelAccountPools` maps effective model IDs to preferred stable account IDs. While a preferred pool has a healthy selectable account, selection stays inside that pool (still applying quota, cooldown, and token-health rules). If the preferred pool is empty or exhausted, routing falls back to the general pool. Manage pools with `codex-pool` or edit `~/.opencode/openai-codex-auth-config.json`.
+`modelAccountPools` maps effective model IDs to stable account IDs. `modelAccountPoolModes` selects `preferred` (the default, with general-pool fallback) or `strict` (never leave the configured pool). Strict exhaustion returns immediately without entering the global account wait loop. All modes still apply quota, cooldown, and token-health rules. Manage pools with `codex-pool` or edit `~/.opencode/openai-codex-auth-config.json`.
 
 ### 5. Tool registry
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -179,6 +179,9 @@ advanced settings go in `~/.opencode/openai-codex-auth-config.json`:
   "modelAccountPools": {
     "gpt-5.6-sol": ["org-example-account-id"]
   },
+  "modelAccountPoolModes": {
+    "gpt-5.6-sol": "strict"
+  },
   "retryProfile": "balanced",
   "retryBudgetOverrides": {
     "network": 2,
@@ -231,6 +234,7 @@ The sample above intentionally sets `"retryAllAccountsMaxRetries": 3` as a bound
 | `fastSessionMaxInputItems` | `30` | max input items kept when fast mode is applied |
 | `rotationStrategy` | `hybrid` | account selection strategy: `hybrid` (stick while healthy, else score-select), `sticky` (drain one account first), or `round-robin` |
 | `modelAccountPools` | `{}` | optional map of effective model IDs to preferred stable account IDs; selection uses the configured pool while it has a healthy account, then falls back to the general account pool |
+| `modelAccountPoolModes` | `{}` | optional per-model `preferred` or `strict` policy; omitted models default to `preferred` |
 | `retryProfile` | `balanced` | retry budget profile for request classes (`conservative`, `balanced`, `aggressive`) |
 | `retryBudgetOverrides` | `{}` | optional per-class budget overrides (`authRefresh`, `network`, `server`, `rateLimitShort`, `rateLimitGlobal`, `emptyResponse`) |
 | `perProjectAccounts` | `true` | each project gets its own account storage |
@@ -258,15 +262,19 @@ The sample above intentionally sets `"retryAllAccountsMaxRetries": 3` as a bound
 
 Use `codex-pool action="set" model="gpt-5.6-sol" accounts=[7,8]` to manage a
 pool with 1-based account numbers while persisting stable IDs. The tool also
-supports `status` (default), `add`, `remove`, `clear`, `dryRun=true`, and JSON
+supports `status` (default), `add`, `remove`, `clear`, `set-mode`, `dryRun=true`, and JSON
 output. Restart OpenCode after an applied mutation. Because this config is
 global while account storage is per-project by default, references unavailable
 in the current project are reported but not automatically pruned.
 
 Model keys are matched case-insensitively after request model normalization.
-Empty lists, unmapped models, and pools with no selectable accounts use the
-general account pool. Routing diagnostics expose the resulting mode as
-`preferred`, `general`, or `general-fallback`.
+Empty lists and unmapped models use the general account pool. A `preferred`
+pool with no selectable account falls back to the general pool. A `strict`
+pool never leaves its configured accounts and immediately returns
+`strict_pool_unavailable` instead of entering the global wait loop. Switch an
+existing pool with `codex-pool action="set-mode" model="gpt-5.6-sol"
+poolMode="strict"`. Routing diagnostics expose `general`, `preferred`,
+`general-fallback`, `strict`, or `strict-unavailable`.
 
 ### Beginner Safe Mode Behavior
 

--- a/docs/development/ARCHITECTURE.md
+++ b/docs/development/ARCHITECTURE.md
@@ -153,7 +153,7 @@ High-level provider fetch flow:
 5. Normalize model aliases and fallback candidates (including GPT-5.6 Sol/Terra/Luna tiers).
 6. For GPT-5.6 models, apply the responses-lite reshape (`lib/request/helpers/responses-lite.ts`): tools move into `input` as `additional_tools`, instructions become a developer message, top-level `tools`/`instructions` are cleared for lite shape, image `detail` is stripped, and `x-openai-internal-codex-responses-lite: true` is set.
 7. Resolve client identity (`lib/request/helpers/client-identity.ts`): GPT-5.6 defaults to `originator: opencode`; other models default to `codex_cli_rs`. Override with `CODEX_AUTH_CLIENT_IDENTITY`.
-8. Resolve preferred accounts from `modelAccountPools` for the effective model; fall back to the general pool when the preferred pool is empty or unavailable.
+8. Resolve accounts and `preferred`/`strict` policy from `modelAccountPools` and `modelAccountPoolModes`; only preferred pools fall back to the general pool when unavailable.
 9. Resolve account/workspace selection with the configured `rotationStrategy` (default `hybrid` health scoring), cooldown, token bucket, and explicit `CODEX_AUTH_ACCOUNT_ID` constraints.
 10. Refresh tokens through the queued refresh path when needed.
 11. Attach OAuth/Codex headers and forward the request.

--- a/docs/development/CONFIG_FIELDS.md
+++ b/docs/development/CONFIG_FIELDS.md
@@ -228,6 +228,7 @@ Defaults come from `lib/config.ts` / `lib/schemas.ts`. Environment overrides win
 | `fastSessionMaxInputItems` | `30` | `CODEX_AUTH_FAST_SESSION_MAX_INPUT_ITEMS` | Max input items kept in fast mode |
 | `rotationStrategy` | `hybrid` | `CODEX_AUTH_ROTATION_STRATEGY` | `hybrid`, `sticky`, or `round-robin` account selection |
 | `modelAccountPools` | `{}` | (file only) | Preferred stable account IDs per effective model |
+| `modelAccountPoolModes` | `{}` | (file only) | Per-model `preferred` or `strict` pool policy |
 | `retryProfile` | `balanced` | `CODEX_AUTH_RETRY_PROFILE` | `conservative` / `balanced` / `aggressive` |
 | `retryBudgetOverrides` | `{}` | (file only) | Per-class budget overrides |
 | `retryAllAccountsRateLimited` | `true` | `CODEX_AUTH_RETRY_ALL_RATE_LIMITED` | Wait/retry when every account is limited |
@@ -262,20 +263,24 @@ The plugin runtime config can map effective model IDs to preferred stable accoun
   "modelAccountPools": {
     "gpt-5.6-sol": ["org-example-account-id"],
     "gpt-5.5": ["org-another-account-id"]
+  },
+  "modelAccountPoolModes": {
+    "gpt-5.6-sol": "strict"
   }
 }
 ```
 
 The request pipeline resolves the pool after model normalization. All rotation
 strategies restrict selection to healthy accounts in the preferred pool while
-one is available. If the configured IDs are unknown or every preferred account
-is disabled, cooling down, rate-limited, or locally depleted, selection falls
-back to the general account pool. Empty lists and unmapped models use the
-general pool directly.
+one is available. `modelAccountPoolModes` defaults each mapping to `preferred`,
+which falls back to the general pool when the mapping is unavailable. A
+`strict` mapping never leaves its configured accounts and fails immediately.
+Empty lists and unmapped models use the general pool directly.
 
 `codex-pool` is the supported mutation surface. It accepts 1-based account
 numbers for `set`, `add`, and `remove`, but resolves and atomically persists
-only stable account IDs. `clear` removes a model mapping, and every mutation
+only stable account IDs. `set-mode` switches between `preferred` and `strict`,
+`clear` removes a model mapping and its mode, and every mutation
 supports a dry-run preview. Writes preserve unrelated raw config fields and
 refuse to replace malformed JSON or an invalid existing pool.
 

--- a/docs/tools-and-cli.md
+++ b/docs/tools-and-cli.md
@@ -37,7 +37,7 @@ Registered from **24 per-file factories** under `lib/tools/` via `createToolRegi
 | `codex-label` | Set a stable display label for an account |
 | `codex-tag` | Set or clear account tags for grouping/filtering |
 | `codex-note` | Attach a private note to an account |
-| `codex-pool` | Manage `modelAccountPools` (preferred accounts per model) |
+| `codex-pool` | Manage model account pools and `preferred`/`strict` routing modes |
 | `codex-remove` | Remove a saved account (confirm required) |
 | `codex-refresh` | Refresh tokens / re-auth guidance for an account |
 
@@ -72,6 +72,7 @@ codex-pool
 codex-pool action="set" model="gpt-5.6-sol" accounts=[7,8]
 codex-pool action="add" model="gpt-5.6-sol" accounts=[9]
 codex-pool action="remove" model="gpt-5.6-sol" accounts=[7]
+codex-pool action="set-mode" model="gpt-5.6-sol" poolMode="strict"
 codex-pool action="clear" model="gpt-5.6-sol"
 codex-label index=2 label="plus-1"
 codex-tag index=2 tags="work,team-a"
@@ -104,7 +105,7 @@ Account indices are **1-based**. Destructive tools require an explicit confirm f
 | `codex-label` | `index?`, `label` (empty string clears) |
 | `codex-tag` | `index?`, `tags` (CSV; empty clears) |
 | `codex-note` | `index?`, `note` (empty clears) |
-| `codex-pool` | `action?` (`status` \| `set` \| `add` \| `remove` \| `clear`), `model?`, `accounts?` (1-based number array), `dryRun?`, `format?`, `includeSensitive?` |
+| `codex-pool` | `action?` (`status` \| `set` \| `add` \| `remove` \| `clear` \| `set-mode`), `model?`, `accounts?` (1-based number array), `poolMode?` (`preferred` \| `strict`), `dryRun?`, `format?`, `includeSensitive?` |
 | `codex-remove` | `index?`, `confirm` (must be `true` to delete) |
 | `codex-refresh` | _(none)_ |
 | `codex-health` | `format?`, `includeSensitive?` |
@@ -199,7 +200,7 @@ npx -y oc-codex-multi-auth@latest warm
 ## Related runtime concepts
 
 - **Rotation:** `rotationStrategy` = `hybrid` (default) | `sticky` | `round-robin` in `~/.opencode/openai-codex-auth-config.json` or `CODEX_AUTH_ROTATION_STRATEGY`.
-- **Model pools:** `modelAccountPools` + `codex-pool` prefer specific accounts per effective model ID, then fall back to the general pool.
+- **Model pools:** `modelAccountPools` + `codex-pool` route effective model IDs through specific accounts. `preferred` mode falls back to the general pool; `strict` mode never leaves its configured pool.
 - **Per-project accounts:** default `true` under `~/.opencode/projects/<project-key>/`.
 - **Stateless Codex contract:** `store: false` and `reasoning.encrypted_content`.
 - **GPT-5.6:** responses-lite path; client identity defaults to host/opencode for 5.6.

--- a/index.ts
+++ b/index.ts
@@ -79,6 +79,7 @@ import {
 	getPidOffsetEnabled,
 	getRotationStrategy,
 	getModelAccountPool,
+	getModelAccountPoolMode,
 	getFetchTimeoutMs,
 	getStreamStallTimeoutMs,
 	getCodexTuiV2,
@@ -488,7 +489,10 @@ export const OpenAIOAuthPlugin: Plugin = async ({ client }: PluginInput) => {
 				ui,
 				"Account pool",
 				formatRoutingValue(routing.accountPoolMode),
-				routing.accountPoolMode === "general-fallback" ? "warning" : "muted",
+				routing.accountPoolMode === "general-fallback" ||
+					routing.accountPoolMode === "strict-unavailable"
+					? "warning"
+					: "muted",
 			),
 		);
 		lines.push(
@@ -2037,6 +2041,9 @@ export const OpenAIOAuthPlugin: Plugin = async ({ client }: PluginInput) => {
 						let restartAccountTraversalWithFallback = false;
 						let restartAccountTraversalAfterWorkspaceDeactivation = false;
 						const preferredAccountIds = getModelAccountPool(pluginConfig, model);
+						const accountPoolMode = getModelAccountPoolMode(pluginConfig, model);
+						const strictAccountPool =
+							preferredAccountIds.length > 0 && accountPoolMode === "strict";
 
 			while (attempted.size < Math.max(1, accountCount)) {
 				const selectionExplainability = accountManager.getSelectionExplainability(
@@ -2058,6 +2065,7 @@ export const OpenAIOAuthPlugin: Plugin = async ({ client }: PluginInput) => {
 					fallbackTo,
 					fallbackReason,
 					configuredAccountPoolSize: preferredAccountIds.length,
+					accountPoolMode: strictAccountPool ? "strict" : undefined,
 				};
 				const account = accountManager.getAccountForStrategy(
 					rotationStrategy,
@@ -2065,6 +2073,8 @@ export const OpenAIOAuthPlugin: Plugin = async ({ client }: PluginInput) => {
 					model,
 					{ pidOffsetEnabled },
 					preferredAccountIds,
+					accountPoolMode,
+					attempted,
 				);
 				if (!account || attempted.has(account.index)) {
 					break;
@@ -2084,7 +2094,9 @@ export const OpenAIOAuthPlugin: Plugin = async ({ client }: PluginInput) => {
 									fallbackTo,
 					fallbackReason,
 					accountPoolMode:
-						preferredAccountIds.length === 0
+						strictAccountPool
+							? "strict"
+							: preferredAccountIds.length === 0
 							? "general"
 							: account.accountId !== undefined &&
 								preferredAccountIds.includes(account.accountId)
@@ -2996,6 +3008,46 @@ export const OpenAIOAuthPlugin: Plugin = async ({ client }: PluginInput) => {
 						}
 						if (restartAccountTraversalAfterWorkspaceDeactivation) {
 							continue;
+						}
+
+						if (strictAccountPool) {
+							const poolWaitMs = accountManager.getMinWaitTimeForFamily(
+								modelFamily,
+								model,
+								preferredAccountIds,
+							);
+							const effectiveModel = model ?? requestedModel ?? "requested model";
+							const waitDetail =
+								poolWaitMs > 0
+									? ` Try again in ${formatWaitTime(poolWaitMs)}.`
+									: " Check the pooled accounts with `codex-health`.";
+							const message =
+								`Strict account pool unavailable for ${effectiveModel}. ` +
+								`None of its ${preferredAccountIds.length} configured account(s) is selectable.` +
+								waitDetail;
+							if (runtimeMetrics.lastSelectionSnapshot) {
+								runtimeMetrics.lastSelectionSnapshot = {
+									...runtimeMetrics.lastSelectionSnapshot,
+									accountPoolMode: "strict-unavailable",
+								};
+							}
+							runtimeMetrics.failedRequests++;
+							runtimeMetrics.lastError = message;
+							runtimeMetrics.lastErrorCategory = "strict-pool-unavailable";
+							return new Response(
+								JSON.stringify({
+									error: {
+										code: "strict_pool_unavailable",
+										message,
+									},
+								}),
+								{
+									status: poolWaitMs > 0 ? 429 : 503,
+									headers: {
+										"content-type": "application/json; charset=utf-8",
+									},
+								},
+							);
 						}
 
 										const waitMs = accountManager.getMinWaitTimeForFamily(modelFamily, model);

--- a/lib/accounts.ts
+++ b/lib/accounts.ts
@@ -244,6 +244,8 @@ export class AccountManager {
 		model?: string | null,
 		options?: HybridSelectionOptions,
 		preferredAccountIds?: readonly string[],
+		poolMode: "preferred" | "strict" = "preferred",
+		excludedIndices?: ReadonlySet<number>,
 	): ManagedAccount | null {
 		switch (strategy) {
 			case "sticky":
@@ -251,12 +253,16 @@ export class AccountManager {
 					family,
 					model,
 					preferredAccountIds,
+					poolMode === "strict",
+					excludedIndices,
 				);
 			case "round-robin":
 				return this.rotation.getCurrentOrNextForFamily(
 					family,
 					model,
 					preferredAccountIds,
+					poolMode === "strict",
+					excludedIndices,
 				);
 			default:
 				return this.rotation.getCurrentOrNextForFamilyHybrid(
@@ -264,6 +270,8 @@ export class AccountManager {
 					model,
 					options,
 					preferredAccountIds,
+					poolMode === "strict",
+					excludedIndices,
 				);
 		}
 	}
@@ -366,8 +374,12 @@ export class AccountManager {
 		return this.rotation.getMinWaitTimeForFamily("codex");
 	}
 
-	getMinWaitTimeForFamily(family: ModelFamily, model?: string | null): number {
-		return this.rotation.getMinWaitTimeForFamily(family, model);
+	getMinWaitTimeForFamily(
+		family: ModelFamily,
+		model?: string | null,
+		accountIds?: readonly string[],
+	): number {
+		return this.rotation.getMinWaitTimeForFamily(family, model, accountIds);
 	}
 
 	// ----- persistence delegations -----

--- a/lib/accounts/rotation.ts
+++ b/lib/accounts/rotation.ts
@@ -57,6 +57,7 @@ export class AccountRotation {
 		accountIds: readonly string[] | undefined,
 		family: ModelFamily,
 		model?: string | null,
+		strictPreferredPool = false,
 	): ReadonlySet<number> | null {
 		if (!accountIds?.length) return null;
 		const preferredIds = new Set(accountIds);
@@ -69,7 +70,11 @@ export class AccountRotation {
 					this.isSelectable(account, family, model),
 			)
 			.map((account) => account.index);
-		return indices.length > 0 ? new Set(indices) : null;
+		return indices.length > 0
+			? new Set(indices)
+			: strictPreferredPool
+				? new Set<number>()
+				: null;
 	}
 
 	private isInSelectionPool(
@@ -83,6 +88,8 @@ export class AccountRotation {
 		family: ModelFamily,
 		model?: string | null,
 		preferredAccountIds?: readonly string[],
+		strictPreferredPool = false,
+		excludedIndices?: ReadonlySet<number>,
 	): ManagedAccount | null {
 		const count = this.state.accounts.length;
 		if (count === 0) return null;
@@ -90,6 +97,7 @@ export class AccountRotation {
 			preferredAccountIds,
 			family,
 			model,
+			strictPreferredPool,
 		);
 
 		const cursor = this.state.cursorByFamily[family];
@@ -98,6 +106,7 @@ export class AccountRotation {
 			const idx = (cursor + i) % count;
 			const account = this.state.accounts[idx];
 			if (!account) continue;
+			if (excludedIndices?.has(account.index)) continue;
 			if (!this.isInSelectionPool(account, preferredIndices)) continue;
 			if (!this.isSelectable(account, family, model)) continue;
 
@@ -135,6 +144,8 @@ export class AccountRotation {
 		model?: string | null,
 		options?: HybridSelectionOptions,
 		preferredAccountIds?: readonly string[],
+		strictPreferredPool = false,
+		excludedIndices?: ReadonlySet<number>,
 	): ManagedAccount | null {
 		const count = this.state.accounts.length;
 		if (count === 0) return null;
@@ -142,13 +153,16 @@ export class AccountRotation {
 			preferredAccountIds,
 			family,
 			model,
+			strictPreferredPool,
 		);
 
 		const currentIndex = this.state.currentAccountIndexByFamily[family];
 		if (currentIndex >= 0 && currentIndex < count) {
 			const currentAccount = this.state.accounts[currentIndex];
 			if (currentAccount) {
-				if (currentAccount.enabled === false) {
+				if (excludedIndices?.has(currentAccount.index)) {
+					// Fall through to hybrid selection.
+				} else if (currentAccount.enabled === false) {
 					// Fall through to hybrid selection.
 				} else if (
 					this.isInSelectionPool(currentAccount, preferredIndices) &&
@@ -168,6 +182,7 @@ export class AccountRotation {
 			.map((account): AccountWithMetrics | null => {
 				if (!account) return null;
 				if (account.enabled === false) return null;
+				if (excludedIndices?.has(account.index)) return null;
 				if (!this.isInSelectionPool(account, preferredIndices)) return null;
 				return {
 					index: account.index,
@@ -216,6 +231,8 @@ export class AccountRotation {
 		family: ModelFamily,
 		model?: string | null,
 		preferredAccountIds?: readonly string[],
+		strictPreferredPool = false,
+		excludedIndices?: ReadonlySet<number>,
 	): ManagedAccount | null {
 		const count = this.state.accounts.length;
 		if (count === 0) return null;
@@ -223,6 +240,7 @@ export class AccountRotation {
 			preferredAccountIds,
 			family,
 			model,
+			strictPreferredPool,
 		);
 
 		// Prefer the account we are already pinned to while it still has quota.
@@ -231,6 +249,7 @@ export class AccountRotation {
 			const currentAccount = this.state.accounts[currentIndex];
 			if (
 				currentAccount &&
+				!excludedIndices?.has(currentAccount.index) &&
 				this.isInSelectionPool(currentAccount, preferredIndices) &&
 				this.isSelectable(currentAccount, family, model)
 			) {
@@ -244,6 +263,7 @@ export class AccountRotation {
 		for (let idx = 0; idx < count; idx++) {
 			const account = this.state.accounts[idx];
 			if (!account) continue;
+			if (excludedIndices?.has(account.index)) continue;
 			if (!this.isInSelectionPool(account, preferredIndices)) continue;
 			if (!this.isSelectable(account, family, model)) continue;
 
@@ -452,10 +472,18 @@ export class AccountRotation {
 		return matches.length;
 	}
 
-	getMinWaitTimeForFamily(family: ModelFamily, model?: string | null): number {
+	getMinWaitTimeForFamily(
+		family: ModelFamily,
+		model?: string | null,
+		accountIds?: readonly string[],
+	): number {
 		const now = nowMs();
+		const accountIdSet = accountIds?.length ? new Set(accountIds) : null;
 		const enabledAccounts = this.state.accounts.filter(
-			(account) => account.enabled !== false,
+			(account) =>
+				account.enabled !== false &&
+				(accountIdSet === null ||
+					(account.accountId !== undefined && accountIdSet.has(account.accountId))),
 		);
 		const available = enabledAccounts.filter((account) =>
 			this.isSelectable(account, family, model),

--- a/lib/accounts/rotation.ts
+++ b/lib/accounts/rotation.ts
@@ -58,16 +58,18 @@ export class AccountRotation {
 		family: ModelFamily,
 		model?: string | null,
 		strictPreferredPool = false,
+		excludedIndices?: ReadonlySet<number>,
 	): ReadonlySet<number> | null {
 		if (!accountIds?.length) return null;
 		const preferredIds = new Set(accountIds);
 		const indices = this.state.accounts
 			.filter(
 				(account) =>
-					account &&
-					account.accountId !== undefined &&
-					preferredIds.has(account.accountId) &&
-					this.isSelectable(account, family, model),
+				account &&
+				account.accountId !== undefined &&
+				preferredIds.has(account.accountId) &&
+				!excludedIndices?.has(account.index) &&
+				this.isSelectable(account, family, model),
 			)
 			.map((account) => account.index);
 		return indices.length > 0
@@ -98,6 +100,7 @@ export class AccountRotation {
 			family,
 			model,
 			strictPreferredPool,
+			excludedIndices,
 		);
 
 		const cursor = this.state.cursorByFamily[family];
@@ -154,6 +157,7 @@ export class AccountRotation {
 			family,
 			model,
 			strictPreferredPool,
+			excludedIndices,
 		);
 
 		const currentIndex = this.state.currentAccountIndexByFamily[family];
@@ -241,6 +245,7 @@ export class AccountRotation {
 			family,
 			model,
 			strictPreferredPool,
+			excludedIndices,
 		);
 
 		// Prefer the account we are already pinned to while it still has quota.

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -29,12 +29,21 @@ const RETRY_PROFILES = new Set(["conservative", "balanced", "aggressive"]);
 
 export type UnsupportedCodexPolicy = "strict" | "fallback";
 
-export type ModelAccountPoolMutation = "set" | "add" | "remove" | "clear";
+export type ModelAccountPoolMode = "preferred" | "strict";
+
+export type ModelAccountPoolMutation =
+	| "set"
+	| "add"
+	| "remove"
+	| "clear"
+	| "set-mode";
 
 export interface ModelAccountPoolMutationResult {
 	model: string;
 	previousAccountIds: string[];
 	accountIds: string[];
+	previousPoolMode: ModelAccountPoolMode;
+	poolMode: ModelAccountPoolMode;
 	changed: boolean;
 	dryRun: boolean;
 }
@@ -164,7 +173,7 @@ export function updateModelAccountPool(
 	model: string,
 	mutation: ModelAccountPoolMutation,
 	accountIds: readonly string[] = [],
-	options: { dryRun?: boolean } = {},
+	options: { dryRun?: boolean; poolMode?: ModelAccountPoolMode } = {},
 ): Promise<ModelAccountPoolMutationResult> {
 	const pending = modelAccountPoolMutationQueue.then(async () => {
 		await fs.mkdir(dirname(CONFIG_PATH), { recursive: true, mode: 0o700 });
@@ -202,7 +211,7 @@ async function performModelAccountPoolMutation(
 	model: string,
 	mutation: ModelAccountPoolMutation,
 	accountIds: readonly string[],
-	options: { dryRun?: boolean },
+	options: { dryRun?: boolean; poolMode?: ModelAccountPoolMode },
 ): Promise<ModelAccountPoolMutationResult> {
 	const normalizedModel = model.trim().toLowerCase();
 	if (!normalizedModel) throw new Error("Model is required.");
@@ -221,6 +230,7 @@ async function performModelAccountPoolMutation(
 
 	const poolResult = PluginConfigSchema.safeParse({
 		modelAccountPools: rawConfig.modelAccountPools,
+		modelAccountPoolModes: rawConfig.modelAccountPoolModes,
 	});
 	if (!poolResult.success) {
 		throw new Error(
@@ -232,19 +242,35 @@ async function performModelAccountPoolMutation(
 	}
 
 	const pools = { ...(poolResult.data.modelAccountPools ?? {}) };
+	const poolModes = { ...(poolResult.data.modelAccountPoolModes ?? {}) };
 	const matchingKeys = Object.keys(pools).filter(
+		(key) => key.trim().toLowerCase() === normalizedModel,
+	);
+	const matchingModeKeys = Object.keys(poolModes).filter(
 		(key) => key.trim().toLowerCase() === normalizedModel,
 	);
 	const previousAccountIds = Array.from(
 		new Set(matchingKeys.flatMap((key) => pools[key] ?? [])),
 	);
 	for (const key of matchingKeys) delete pools[key];
+	const previousPoolMode = matchingModeKeys
+		.map((key) => poolModes[key])
+		.find((mode): mode is ModelAccountPoolMode => mode !== undefined) ?? "preferred";
+	for (const key of matchingModeKeys) delete poolModes[key];
+	if (mutation === "set-mode" && previousAccountIds.length === 0) {
+		throw new Error(`No model account pool configured for ${normalizedModel}.`);
+	}
+	if (mutation === "set-mode" && options.poolMode === undefined) {
+		throw new Error("poolMode is required for set-mode.");
+	}
 
 	const normalizedAccountIds = Array.from(
 		new Set(accountIds.map((id) => id.trim()).filter(Boolean)),
 	);
 	let nextAccountIds: string[];
-	if (mutation === "set") {
+	if (mutation === "set-mode") {
+		nextAccountIds = previousAccountIds;
+	} else if (mutation === "set") {
 		nextAccountIds = normalizedAccountIds;
 	} else if (mutation === "add") {
 		nextAccountIds = Array.from(
@@ -257,18 +283,34 @@ async function performModelAccountPoolMutation(
 		nextAccountIds = [];
 	}
 
-	if (nextAccountIds.length > 0) pools[normalizedModel] = nextAccountIds;
+	const nextPoolMode = mutation === "clear"
+		? "preferred"
+		: options.poolMode ?? previousPoolMode;
+	if (nextAccountIds.length > 0) {
+		pools[normalizedModel] = nextAccountIds;
+		if (nextPoolMode !== "preferred") {
+			poolModes[normalizedModel] = nextPoolMode;
+		}
+	}
 	const changed =
 		matchingKeys.length !== (nextAccountIds.length > 0 ? 1 : 0) ||
 		previousAccountIds.length !== nextAccountIds.length ||
 		previousAccountIds.some((id, index) => id !== nextAccountIds[index]) ||
-		(matchingKeys[0] !== undefined && matchingKeys[0] !== normalizedModel);
+		(matchingKeys[0] !== undefined && matchingKeys[0] !== normalizedModel) ||
+		matchingModeKeys.length !== (nextPoolMode !== "preferred" && nextAccountIds.length > 0 ? 1 : 0) ||
+		previousPoolMode !== nextPoolMode ||
+		(matchingModeKeys[0] !== undefined && matchingModeKeys[0] !== normalizedModel);
 
 	if (changed && options.dryRun !== true) {
 		if (Object.keys(pools).length > 0) {
 			rawConfig.modelAccountPools = pools;
 		} else {
 			delete rawConfig.modelAccountPools;
+		}
+		if (Object.keys(poolModes).length > 0) {
+			rawConfig.modelAccountPoolModes = poolModes;
+		} else {
+			delete rawConfig.modelAccountPoolModes;
 		}
 
 		const tempPath = `${CONFIG_PATH}.${process.pid}.${randomUUID()}.tmp`;
@@ -287,6 +329,8 @@ async function performModelAccountPoolMutation(
 		model: normalizedModel,
 		previousAccountIds,
 		accountIds: nextAccountIds,
+		previousPoolMode,
+		poolMode: nextPoolMode,
 		changed,
 		dryRun: options.dryRun === true,
 	};
@@ -536,6 +580,20 @@ export function getModelAccountPool(
 		}
 	}
 	return [];
+}
+
+export function getModelAccountPoolMode(
+	pluginConfig: PluginConfig,
+	model?: string | null,
+): ModelAccountPoolMode {
+	if (!model) return "preferred";
+	const normalizedModel = model.trim().toLowerCase();
+	for (const [configuredModel, mode] of Object.entries(
+		pluginConfig.modelAccountPoolModes ?? {},
+	)) {
+		if (configuredModel.trim().toLowerCase() === normalizedModel) return mode;
+	}
+	return "preferred";
 }
 
 export function getFastSessionMaxInputItems(pluginConfig: PluginConfig): number {

--- a/lib/runtime.ts
+++ b/lib/runtime.ts
@@ -84,7 +84,12 @@ export type SelectionSnapshot = {
 	fallbackFrom: string | null;
 	fallbackTo: string | null;
 	fallbackReason: string | null;
-	accountPoolMode?: "general" | "preferred" | "general-fallback";
+	accountPoolMode?:
+		| "general"
+		| "preferred"
+		| "general-fallback"
+		| "strict"
+		| "strict-unavailable";
 	configuredAccountPoolSize?: number;
 };
 
@@ -115,7 +120,13 @@ export type RoutingVisibilitySnapshot = {
 	fallbackFrom: string | null;
 	fallbackTo: string | null;
 	fallbackReason: string | null;
-	accountPoolMode: "general" | "preferred" | "general-fallback" | null;
+	accountPoolMode:
+		| "general"
+		| "preferred"
+		| "general-fallback"
+		| "strict"
+		| "strict-unavailable"
+		| null;
 	configuredAccountPoolSize: number;
 	selectionExplainability: SerializedSelectionExplainability[];
 };

--- a/lib/schemas.ts
+++ b/lib/schemas.ts
@@ -26,6 +26,10 @@ export const PluginConfigSchema = z.object({
 		z.string().min(1),
 		z.array(z.string().min(1)),
 	).optional(),
+	modelAccountPoolModes: z.record(
+		z.string().min(1),
+		z.enum(["preferred", "strict"]),
+	).optional(),
 	fastSessionMaxInputItems: z.number().min(8).max(200).optional(),
 	retryProfile: z.enum(["conservative", "balanced", "aggressive"]).optional(),
 	retryBudgetOverrides: z.object({

--- a/lib/tools/codex-pool.ts
+++ b/lib/tools/codex-pool.ts
@@ -2,7 +2,9 @@
 
 import { tool, type ToolDefinition } from "@opencode-ai/plugin/tool";
 import {
+	getModelAccountPoolMode,
 	loadPluginConfig,
+	type ModelAccountPoolMode,
 	updateModelAccountPool,
 	type ModelAccountPoolMutation,
 } from "../config.js";
@@ -17,6 +19,7 @@ type CodexPoolArgs = {
 	model?: string;
 	accounts?: number[];
 	dryRun?: boolean;
+	poolMode?: string;
 	format?: string;
 	includeSensitive?: boolean;
 };
@@ -27,12 +30,22 @@ function normalizePoolAction(action?: string): CodexPoolAction {
 		action === "set" ||
 		action === "add" ||
 		action === "remove" ||
-		action === "clear"
+		action === "clear" ||
+		action === "set-mode"
 	) {
 		return action;
 	}
 	throw new Error(
-		`Invalid action "${action}". Expected "status", "set", "add", "remove", or "clear".`,
+		`Invalid action "${action}". Expected "status", "set", "add", "remove", "clear", or "set-mode".`,
+	);
+}
+
+function normalizePoolMode(mode?: string): ModelAccountPoolMode | undefined {
+	const normalized = mode?.trim().toLowerCase();
+	if (!normalized) return undefined;
+	if (normalized === "preferred" || normalized === "strict") return normalized;
+	throw new Error(
+		`Invalid pool mode "${mode}". Expected "preferred" or "strict".`,
 	);
 }
 
@@ -81,8 +94,10 @@ function buildPoolSnapshot(
 	storage: AccountStorageV3 | null,
 	ctx: ToolContext,
 	includeSensitive: boolean,
+	poolMode: ModelAccountPoolMode,
 ): {
 	model: string;
+	poolMode: ModelAccountPoolMode;
 	configuredCount: number;
 	accounts: Record<string, unknown>[];
 	unresolvedCount: number;
@@ -114,6 +129,7 @@ function buildPoolSnapshot(
 
 	return {
 		model,
+		poolMode,
 		configuredCount: accountIds.length,
 		accounts,
 		unresolvedCount: unresolvedAccountIds.length,
@@ -130,7 +146,7 @@ function renderPoolStatusText(
 	const lines = ["Model account pools"];
 	const maskEmail = ctx.resolveMaskEmail();
 	for (const pool of pools) {
-		lines.push("", pool.model);
+		lines.push("", `${pool.model} [${pool.poolMode}]`);
 		for (const identity of pool.accounts) {
 			const index = identity.zeroBasedIndex;
 			if (typeof index !== "number") continue;
@@ -160,7 +176,7 @@ export function createCodexPoolTool(ctx: ToolContext): ToolDefinition {
 			action: tool.schema
 				.string()
 				.optional()
-				.describe('"status" (default), "set", "add", "remove", or "clear".'),
+				.describe('"status" (default), "set", "add", "remove", "clear", or "set-mode".'),
 			model: tool.schema
 				.string()
 				.optional()
@@ -173,6 +189,10 @@ export function createCodexPoolTool(ctx: ToolContext): ToolDefinition {
 				.boolean()
 				.optional()
 				.describe("Preview a mutation without changing configuration."),
+			poolMode: tool.schema
+				.string()
+				.optional()
+				.describe('Pool routing mode used by "set-mode": "preferred" or "strict".'),
 			format: tool.schema
 				.string()
 				.optional()
@@ -186,11 +206,13 @@ export function createCodexPoolTool(ctx: ToolContext): ToolDefinition {
 			const action = normalizePoolAction(args.action);
 			const format = normalizeToolOutputFormat(args.format);
 			const model = normalizeModel(args.model);
+			const poolMode = normalizePoolMode(args.poolMode);
 			const storage = await loadAccounts();
 			const includeSensitive = args.includeSensitive === true;
 
 			if (action === "status") {
-				const configuredPools = loadPluginConfig().modelAccountPools ?? {};
+				const config = loadPluginConfig();
+				const configuredPools = config.modelAccountPools ?? {};
 				const entries = Object.entries(configuredPools).filter(
 					([configuredModel]) =>
 						model === undefined || configuredModel.trim().toLowerCase() === model,
@@ -202,6 +224,7 @@ export function createCodexPoolTool(ctx: ToolContext): ToolDefinition {
 						storage,
 						ctx,
 						includeSensitive,
+						getModelAccountPoolMode(config, configuredModel),
 					),
 				);
 				if (format === "json") {
@@ -214,12 +237,19 @@ export function createCodexPoolTool(ctx: ToolContext): ToolDefinition {
 			}
 
 			if (!model) throw new Error(`Model is required for action "${action}".`);
+			if (action === "set-mode" && !poolMode) {
+				throw new Error('poolMode is required for action "set-mode".');
+			}
+			if (action !== "set-mode" && poolMode) {
+				throw new Error('poolMode is only valid for action "set-mode".');
+			}
 			const accountIds =
-				action === "clear"
+				action === "clear" || action === "set-mode"
 					? []
 					: resolveAccountIds(storage, args.accounts);
 			const result = await updateModelAccountPool(model, action, accountIds, {
 				dryRun: args.dryRun,
+				poolMode,
 			});
 			const pool = buildPoolSnapshot(
 				result.model,
@@ -227,6 +257,7 @@ export function createCodexPoolTool(ctx: ToolContext): ToolDefinition {
 				storage,
 				ctx,
 				includeSensitive,
+				result.poolMode,
 			);
 			const applied = result.changed && !result.dryRun;
 			const payload = {
@@ -237,6 +268,7 @@ export function createCodexPoolTool(ctx: ToolContext): ToolDefinition {
 				dryRun: result.dryRun,
 				restartRequired: applied,
 				previousConfiguredCount: result.previousAccountIds.length,
+				previousPoolMode: result.previousPoolMode,
 				pool,
 			};
 			if (format === "json") return renderJsonOutput(payload);
@@ -246,6 +278,7 @@ export function createCodexPoolTool(ctx: ToolContext): ToolDefinition {
 				`${verb} model account pool: ${result.model}`,
 				`Previous accounts: ${result.previousAccountIds.length}`,
 				`Current accounts: ${result.accountIds.length}`,
+				`Pool mode: ${result.poolMode}`,
 			];
 			if (applied) lines.push("Restart OpenCode to apply this routing change.");
 			return lines.join("\n");

--- a/test/accounts.test.ts
+++ b/test/accounts.test.ts
@@ -894,6 +894,41 @@ describe("AccountManager", () => {
     expect(selected?.refreshToken).toBe("shared-refresh");
   });
 
+  it("falls back outside a preferred pool when its remaining account was attempted", () => {
+    const now = Date.now();
+    const stored = {
+      version: 3 as const,
+      activeIndex: 0,
+      accounts: [
+        {
+          refreshToken: "preferred-token",
+          accountId: "preferred-account",
+          addedAt: now,
+          lastUsed: now,
+        },
+        {
+          refreshToken: "general-token",
+          accountId: "general-account",
+          addedAt: now,
+          lastUsed: now,
+        },
+      ],
+    };
+
+    const manager = new AccountManager(undefined, stored);
+    const selected = manager.getAccountForStrategy(
+      "round-robin",
+      "codex",
+      undefined,
+      undefined,
+      ["preferred-account"],
+      "preferred",
+      new Set([0]),
+    );
+
+    expect(selected?.accountId).toBe("general-account");
+  });
+
   it("returns null and preserves min-wait behavior when all shared-token variants are blocked", () => {
     const now = Date.now();
     const stored = {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -135,6 +135,7 @@ vi.mock("../lib/config.js", () => ({
 	getPidOffsetEnabled: () => false,
 	getRotationStrategy: () => "hybrid",
 	getModelAccountPool: vi.fn(() => []),
+	getModelAccountPoolMode: vi.fn(() => "preferred"),
 	getFetchTimeoutMs: () => 60000,
 	getStreamStallTimeoutMs: () => 45000,
 	getCodexTuiV2: () => false,
@@ -421,7 +422,21 @@ vi.mock("../lib/accounts.js", () => {
 			return this.accounts[0] ?? null;
 		}
 
-		getAccountForStrategy() {
+		getAccountForStrategy(
+			_strategy?: string,
+			_family?: string,
+			_model?: string,
+			_options?: unknown,
+			preferredAccountIds: readonly string[] = [],
+			poolMode: "preferred" | "strict" = "preferred",
+		) {
+			const preferred = this.accounts.find(
+				(account) =>
+					account.accountId !== undefined &&
+					preferredAccountIds.includes(account.accountId),
+			);
+			if (preferred) return preferred;
+			if (poolMode === "strict" && preferredAccountIds.length > 0) return null;
 			return this.getCurrentOrNextForFamilyHybrid();
 		}
 
@@ -3573,14 +3588,16 @@ describe("OpenAIOAuthPlugin fetch handler", () => {
 	});
 
 	it.each([
-		{ pool: [], mode: "general", size: 0 },
-		{ pool: ["acc-1"], mode: "preferred", size: 1 },
-		{ pool: ["unavailable-account"], mode: "general-fallback", size: 1 },
+		{ pool: [], policy: "preferred", mode: "general", size: 0 },
+		{ pool: ["acc-1"], policy: "preferred", mode: "preferred", size: 1 },
+		{ pool: ["unavailable-account"], policy: "preferred", mode: "general-fallback", size: 1 },
+		{ pool: ["acc-1"], policy: "strict", mode: "strict", size: 1 },
 	] as const)(
 		"reports $mode account pool routing diagnostics",
-		async ({ pool, mode, size }) => {
+		async ({ pool, policy, mode, size }) => {
 			const configModule = await import("../lib/config.js");
 			vi.mocked(configModule.getModelAccountPool).mockReturnValueOnce([...pool]);
+			vi.mocked(configModule.getModelAccountPoolMode).mockReturnValueOnce(policy);
 			globalThis.fetch = vi.fn().mockResolvedValue(
 				new Response(JSON.stringify({ content: "test" }), { status: 200 }),
 			);
@@ -3604,6 +3621,38 @@ describe("OpenAIOAuthPlugin fetch handler", () => {
 			});
 		},
 	);
+
+	it("fails immediately when a strict model pool has no selectable account", async () => {
+		const configModule = await import("../lib/config.js");
+		vi.mocked(configModule.getModelAccountPool).mockReturnValueOnce([
+			"unavailable-account",
+		]);
+		vi.mocked(configModule.getModelAccountPoolMode).mockReturnValueOnce("strict");
+		globalThis.fetch = vi.fn();
+
+		const { plugin, sdk } = await setupPlugin();
+		const response = await sdk.fetch!("https://api.openai.com/v1/chat", {
+			method: "POST",
+			body: JSON.stringify({ model: "gpt-5.1" }),
+		});
+		expect(configModule.getModelAccountPoolMode).toHaveBeenCalled();
+		expect(response).toBeInstanceOf(Response);
+		const body = (await response.json()) as {
+			error: { code: string; message: string };
+		};
+
+		expect(response.status).toBe(503);
+		expect(body.error).toMatchObject({
+			code: "strict_pool_unavailable",
+		});
+		expect(body.error.message).toContain("Strict account pool unavailable");
+		expect(globalThis.fetch).not.toHaveBeenCalled();
+
+		const metrics = parseJsonOutput<{
+			routingVisibility: { accountPoolMode: string | null };
+		}>(await plugin.tool["codex-metrics"].execute({ format: "json" }));
+		expect(metrics.routingVisibility.accountPoolMode).toBe("strict-unavailable");
+	});
 
 	it("records TUI quota cache from successful Codex response headers", async () => {
 		const previousStateDir = process.env.OPENCODE_STATE_DIR;

--- a/test/model-pool-config.test.ts
+++ b/test/model-pool-config.test.ts
@@ -87,8 +87,27 @@ describe("model account pool config mutation", () => {
 			model: ["one", "three"],
 		});
 
+		const modeResult = await updateModelAccountPool("model", "set-mode", [], {
+			poolMode: "strict",
+		});
+		expect(modeResult).toMatchObject({
+			previousPoolMode: "preferred",
+			poolMode: "strict",
+		});
+		expect((await readConfig()).modelAccountPoolModes).toEqual({
+			model: "strict",
+		});
+
 		await updateModelAccountPool("model", "clear");
-		expect(await readConfig()).not.toHaveProperty("modelAccountPools");
+		const cleared = await readConfig();
+		expect(cleared).not.toHaveProperty("modelAccountPools");
+		expect(cleared).not.toHaveProperty("modelAccountPoolModes");
+	});
+
+	it("rejects mode changes for models without a configured pool", async () => {
+		await expect(
+			updateModelAccountPool("missing", "set-mode", [], { poolMode: "strict" }),
+		).rejects.toThrow("No model account pool configured");
 	});
 
 	it("serializes concurrent mutations so updates are not lost", async () => {

--- a/test/rotation-strategy.test.ts
+++ b/test/rotation-strategy.test.ts
@@ -1,7 +1,11 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { AccountManager } from "../lib/accounts.js";
 import { resetTrackers } from "../lib/rotation.js";
-import { getModelAccountPool, getRotationStrategy } from "../lib/config.js";
+import {
+	getModelAccountPool,
+	getModelAccountPoolMode,
+	getRotationStrategy,
+} from "../lib/config.js";
 import type { PluginConfig } from "../lib/types.js";
 import type { AccountStorageV3 } from "../lib/storage.js";
 import type { ModelFamily } from "../lib/prompts/codex.js";
@@ -98,6 +102,14 @@ describe("model account pool config", () => {
 
 	it("returns an empty pool for unmapped models", () => {
 		expect(getModelAccountPool({ modelAccountPools: {} } as PluginConfig, "gpt-5.5")).toEqual([]);
+	});
+
+	it("defaults pool mode to preferred and resolves strict case-insensitively", () => {
+		const config = {
+			modelAccountPoolModes: { "GPT-5.6-SOL": "strict" },
+		} as PluginConfig;
+		expect(getModelAccountPoolMode(config, "gpt-5.6-sol")).toBe("strict");
+		expect(getModelAccountPoolMode(config, "gpt-5.6-terra")).toBe("preferred");
 	});
 });
 
@@ -223,6 +235,50 @@ describe("strategy dispatcher (#183)", () => {
 			);
 			expect(selected).not.toBeNull();
 			expect(selected?.accountId).not.toBe("account-id-2");
+		},
+	);
+
+	it.each(["sticky", "round-robin", "hybrid"] as const)(
+		"%s does not leave an unavailable strict pool",
+		(strategy) => {
+			manager.setAccountEnabled(1, false);
+			const selected = manager.getAccountForStrategy(
+				strategy,
+				FAMILY,
+				"gpt-5.6-sol",
+				undefined,
+				["account-id-2"],
+				"strict",
+			);
+			expect(selected).toBeNull();
+		},
+	);
+
+	it("does not leave a strict pool whose configured IDs are unknown", () => {
+		const selected = manager.getAccountForStrategy(
+			"sticky",
+			FAMILY,
+			"gpt-5.6-sol",
+			undefined,
+			["unknown-account-id"],
+			"strict",
+		);
+		expect(selected).toBeNull();
+	});
+
+	it.each(["sticky", "round-robin", "hybrid"] as const)(
+		"%s tries another strict-pool account after a request-local attempt",
+		(strategy) => {
+			const selected = manager.getAccountForStrategy(
+				strategy,
+				FAMILY,
+				"gpt-5.6-sol",
+				undefined,
+				["account-id-1", "account-id-2"],
+				"strict",
+				new Set([0]),
+			);
+			expect(selected?.accountId).toBe("account-id-2");
 		},
 	);
 

--- a/test/tools-codex-pool.test.ts
+++ b/test/tools-codex-pool.test.ts
@@ -9,6 +9,9 @@ vi.mock("../lib/storage.js", () => ({
 }));
 
 vi.mock("../lib/config.js", () => ({
+	getModelAccountPoolMode: vi.fn((config, model) =>
+		config.modelAccountPoolModes?.[model] ?? "preferred",
+	),
 	loadPluginConfig: vi.fn(),
 	updateModelAccountPool: vi.fn(),
 }));
@@ -64,6 +67,7 @@ describe("codex-pool tool", () => {
 			modelAccountPools: {
 				"gpt-5.6-sol": ["account-one", "missing-account"],
 			},
+			modelAccountPoolModes: { "gpt-5.6-sol": "strict" },
 		});
 	});
 
@@ -75,6 +79,7 @@ describe("codex-pool tool", () => {
 		const parsed = JSON.parse(output as string) as {
 			pools: Array<{
 				configuredCount: number;
+				poolMode: string;
 				accounts: Array<Record<string, unknown>>;
 				unresolvedCount: number;
 				unresolvedAccountIds?: string[];
@@ -83,6 +88,7 @@ describe("codex-pool tool", () => {
 
 		expect(parsed.pools[0]).toMatchObject({
 			configuredCount: 2,
+			poolMode: "strict",
 			unresolvedCount: 1,
 		});
 		expect(parsed.pools[0]?.accounts[0]).toMatchObject({ index: 1 });
@@ -113,6 +119,8 @@ describe("codex-pool tool", () => {
 			model: "gpt-5.6-sol",
 			previousAccountIds: [],
 			accountIds: ["account-two", "account-one"],
+			previousPoolMode: "preferred",
+			poolMode: "preferred",
 			changed: true,
 			dryRun: false,
 		});
@@ -130,7 +138,7 @@ describe("codex-pool tool", () => {
 			"gpt-5.6-sol",
 			"set",
 			["account-two", "account-one"],
-			{ dryRun: undefined },
+			{ dryRun: undefined, poolMode: undefined },
 		);
 		expect(output).toContain("Restart OpenCode");
 	});
@@ -140,6 +148,8 @@ describe("codex-pool tool", () => {
 			model: "gpt-5.6-sol",
 			previousAccountIds: ["account-one"],
 			accountIds: ["account-one", "account-two"],
+			previousPoolMode: "preferred",
+			poolMode: "preferred",
 			changed: true,
 			dryRun: true,
 		});
@@ -158,7 +168,7 @@ describe("codex-pool tool", () => {
 			"gpt-5.6-sol",
 			"add",
 			["account-two"],
-			{ dryRun: true },
+			{ dryRun: true, poolMode: undefined },
 		);
 		expect(output).not.toContain("Restart OpenCode");
 	});
@@ -169,6 +179,8 @@ describe("codex-pool tool", () => {
 			model: "gpt-5.6-sol",
 			previousAccountIds: ["account-one"],
 			accountIds: [],
+			previousPoolMode: "strict",
+			poolMode: "preferred",
 			changed: true,
 			dryRun: false,
 		});
@@ -182,8 +194,37 @@ describe("codex-pool tool", () => {
 			"gpt-5.6-sol",
 			"clear",
 			[],
-			{ dryRun: undefined },
+			{ dryRun: undefined, poolMode: undefined },
 		);
+	});
+
+	it("switches an existing pool between preferred and strict", async () => {
+		vi.mocked(updateModelAccountPool).mockResolvedValue({
+			model: "gpt-5.6-sol",
+			previousAccountIds: ["account-one"],
+			accountIds: ["account-one"],
+			previousPoolMode: "preferred",
+			poolMode: "strict",
+			changed: true,
+			dryRun: false,
+		});
+
+		const output = await createCodexPoolTool(buildCtx()).execute(
+			{
+				action: "set-mode",
+				model: "gpt-5.6-sol",
+				poolMode: "strict",
+			},
+			{} as never,
+		);
+
+		expect(updateModelAccountPool).toHaveBeenCalledWith(
+			"gpt-5.6-sol",
+			"set-mode",
+			[],
+			{ dryRun: undefined, poolMode: "strict" },
+		);
+		expect(output).toContain("Pool mode: strict");
 	});
 
 	it("rejects invalid account numbers before writing", async () => {


### PR DESCRIPTION
## Summary
- add preferred and strict routing modes for model-specific account pools
- keep retries, rotation, and wait calculations scoped to strict pools
- expose pool mode management through `codex-pool` and document the configuration
- fall back to a general account after a preferred account is attempted in preferred mode

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm test` (2,933 tests)

## Compliance Confirmation
- [x] No credentials, personal data, or sensitive diagnostics added
- [x] Runtime account routing behavior is covered by regression tests
- [x] User-facing configuration and CLI documentation are updated

## Notes
No linked issue or rollout dependency. Strict mode is opt-in; existing model pools retain preferred fallback behavior.

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

this pr adds preferred and strict routing policies for model-specific account pools.
- strict routing confines account selection, retries, and wait calculations to configured accounts.
- `codex-pool set-mode` manages the persisted routing policy.
- diagnostics, schemas, documentation, and vitest coverage are updated for the new modes.

<h3>Confidence Score: 5/5</h3>

the pr appears safe to merge because no blocking failure remains in the eligible follow-up scope.

no blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| index.ts | wires strict pool policy into request selection, scoped wait handling, diagnostics, and structured unavailable responses. |
| lib/accounts/rotation.ts | adds strict selection boundaries, request-local exclusions, and account-id-scoped minimum wait calculations. |
| lib/config.ts | adds serialized and atomically persisted model pool mode mutations while retaining windows rename retries. |
| lib/tools/codex-pool.ts | exposes pool mode status and validated set-mode mutations without adding token output. |
| lib/schemas.ts | validates preferred and strict per-model pool policies. |
| test/index.test.ts | covers strict routing success diagnostics and immediate unavailable responses. |
| test/model-pool-config.test.ts | covers mode persistence, clearing, missing-pool rejection, and existing mutation serialization. |
| test/rotation-strategy.test.ts | covers strict confinement and attempted-account exclusion across all rotation strategies. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[normalized model request] --> B{configured account pool?}
  B -->|no| C[general account pool]
  B -->|yes| D{pool mode}
  D -->|preferred| E[select healthy pooled account]
  E -->|none available| C
  D -->|strict| F[select healthy pooled account only]
  F -->|available| G[send request]
  F -->|none available| H[strict_pool_unavailable]
  C --> G
  E -->|available| G
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: fall back after preferred pool acco..."](https://github.com/ndycode/oc-codex-multi-auth/commit/620bdc144806a5635085d0d86a771c28d7565f3f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51084426)</sub>

<details><summary><h4>Context used (4)</h4></summary>

- Knowledge Base — [Plugin Entrypoint: index.ts](https://app.greptile.com/zeian/-/custom-context/knowledge-base/ndycode/oc-codex-multi-auth/-/docs/plugin-entrypoint.md)
- Knowledge Base — [Multi-Account Rotation and Health](https://app.greptile.com/zeian/-/custom-context/knowledge-base/ndycode/oc-codex-multi-auth/-/docs/accounts-rotation.md)
- Knowledge Base — [Config, Schemas, and Shared Primitives](https://app.greptile.com/zeian/-/custom-context/knowledge-base/ndycode/oc-codex-multi-auth/-/docs/config-schemas.md)
- Knowledge Base — [Tools and CLI](https://app.greptile.com/zeian/-/custom-context/knowledge-base/ndycode/oc-codex-multi-auth/-/docs/tools-cli.md)
</details>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-model account pool modes: `preferred` and `strict`.
  * Added `codex-pool set-mode` for changing a model’s pool behavior.
  * Strict pools remain limited to configured accounts and report unavailable-pool diagnostics.
  * Preferred pools fall back to the general healthy pool when needed.
* **Bug Fixes**
  * Unavailable strict pools now return a structured error instead of using unrelated accounts.
* **Documentation**
  * Updated configuration, routing, architecture, and CLI documentation with pool mode behavior and examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->